### PR TITLE
docs: add scenarios describing project vision

### DIFF
--- a/scenarios/embeddable.md
+++ b/scenarios/embeddable.md
@@ -1,0 +1,6 @@
+# embeddable
+
+- `ah` itself is a portable executable archive
+- to configure and extend it(self), `ah` modifies files in its archive
+- `ah` generally does not rely on external files (except maybe for authentication), though it can of course explore its environment and execute/modify things in the environment
+- being embeddable is part of what makes `ah` portable: making a copy of the `ah` file carries with it everything needed to run `ah`

--- a/scenarios/identity.md
+++ b/scenarios/identity.md
@@ -1,0 +1,6 @@
+# identity
+
+- `ah` is an **a**gent **h**arness
+- most importantly, it is improvable: because it can be improved and extended, it can become good at many other things
+- it is built with `whilp/cosmic`, which is a lua distribution that in turn builds on (a fork of) `jart/cosmopolitan`
+- because it is `cosmic`, `ah` has everything it needs to build tools to do more (sqlite, http, json, crypto, etc)


### PR DESCRIPTION
## Summary

- Add `scenarios/` directory with project vision documents
- `identity.md`: defines ah as an improvable agent harness built on cosmic
- `embeddable.md`: describes ah as a self-contained portable executable archive