### PR TITLE
ah: local conversation tree per working directory

### DIFF
--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -1,22 +1,11 @@
--- ah/db.lua: SQLite storage for sessions and messages
+-- ah/db.lua: SQLite storage for conversation tree
 local fs = require("cosmic.fs")
 local sqlite = require("cosmic.sqlite")
 local ulid = require("ulid")
 
 local SCHEMA = [[
-create table if not exists sessions (
-  id text primary key,
-  name text unique,
-  created_at integer not null,
-  updated_at integer not null,
-  cwd text,
-  system_prompt text,
-  model text
-);
-
 create table if not exists messages (
   id text primary key,
-  session_id text not null references sessions(id),
   parent_id text references messages(id),
   role text not null,
   seq integer not null,
@@ -41,7 +30,6 @@ create table if not exists context (
   value text not null
 );
 
-create index if not exists idx_messages_session on messages(session_id);
 create index if not exists idx_messages_parent on messages(parent_id);
 create index if not exists idx_content_blocks_message on content_blocks(message_id);
 ]]
@@ -64,20 +52,8 @@ local record DB
   _db: Database
 end
 
-local record Session
-  id: string
-  name: string
-  created_at: integer
-  updated_at: integer
-  cwd: string
-  system_prompt: string
-  model: string
-  message_count: integer
-end
-
 local record Message
   id: string
-  session_id: string
   parent_id: string
   role: string
   seq: integer
@@ -113,14 +89,20 @@ local record UpdateOpts
 end
 
 local function get_db_path(): string
-  local home = os.getenv("HOME") or ""
-  local ah_dir = fs.join(home, ".ah")
+  local ah_dir = ".ah"
   fs.makedirs(ah_dir)
   return fs.join(ah_dir, "ah.db")
 end
 
 local function open(db_path?: string): DB, string
   db_path = db_path or get_db_path()
+
+  -- Ensure parent directory exists for custom paths
+  local parent = fs.dirname(db_path)
+  if parent and parent ~= "" and parent ~= "." then
+    fs.makedirs(parent)
+  end
+
   local db, err = sqlite.open(db_path) as (Database, string)
   if not db then
     return nil, "failed to open database: " .. db_path .. ": " .. (err or "")
@@ -153,96 +135,6 @@ local function set_context(self: DB, key: string, value: string)
   self._db:exec("insert or replace into context (key, value) values (?, ?)", key, value)
 end
 
--- Session operations
-local function create_session(self: DB, name?: string, cwd?: string, system_prompt?: string, model?: string): Session
-  local id = ulid.generate()
-  local now = os.time()
-
-  -- Use explicit non-nil values to avoid Lua vararg nil-dropping issue
-  local stmt = self._db:prepare([[
-    insert into sessions (id, name, created_at, updated_at, cwd, system_prompt, model)
-    values (?, ?, ?, ?, ?, ?, ?)
-  ]])
-  if stmt then
-    stmt:bind(id, name or "", now, now, cwd or "", system_prompt or "", model or "")
-    stmt:exec()
-    stmt:close()
-  end
-
-  set_context(self, "current_session", id)
-
-  return {
-    id = id,
-    name = name,
-    created_at = now,
-    updated_at = now,
-    cwd = cwd,
-    system_prompt = system_prompt,
-    model = model,
-  }
-end
-
-local function get_session(self: DB, id: string): Session
-  for row in self._db:query("select * from sessions where id = ?", id) do
-    return row as Session
-  end
-  return nil
-end
-
-local function get_session_by_name(self: DB, name: string): Session
-  -- First try exact name match
-  for row in self._db:query("select * from sessions where name = ?", name) do
-    return row as Session
-  end
-
-  -- Then try ID prefix match
-  for row in self._db:query("select * from sessions where id like ? || '%'", name) do
-    return row as Session
-  end
-  return nil
-end
-
-local function list_sessions(self: DB): {Session}
-  local sessions: {Session} = {}
-  local sql = [[
-    select s.*,
-      (select count(*) from messages m where m.session_id = s.id) as message_count
-    from sessions s
-    order by s.updated_at desc
-  ]]
-  for row in self._db:query(sql) do
-    table.insert(sessions, row as Session)
-  end
-  return sessions
-end
-
-local function delete_session(self: DB, id: string)
-  self._db:exec([[
-    delete from content_blocks where message_id in
-    (select id from messages where session_id = ?)
-  ]], id)
-
-  self._db:exec("delete from messages where session_id = ?", id)
-  self._db:exec("delete from sessions where id = ?", id)
-
-  local current = get_context(self, "current_session")
-  if current == id then
-    self._db:exec("delete from context where key = 'current_session'")
-  end
-end
-
-local function get_current_session(self: DB): Session
-  local id = get_context(self, "current_session")
-  if id then
-    return get_session(self, id)
-  end
-  return nil
-end
-
-local function set_current_session(self: DB, id: string)
-  set_context(self, "current_session", id)
-end
-
 -- Message operations
 local function get_message(self: DB, id: string): Message
   for row in self._db:query("select * from messages where id = ?", id) do
@@ -251,7 +143,7 @@ local function get_message(self: DB, id: string): Message
   return nil
 end
 
-local function create_message(self: DB, session_id: string, role: string, parent_id?: string): Message
+local function create_message(self: DB, role: string, parent_id?: string): Message
   local id = ulid.generate()
   local now = os.time()
 
@@ -263,17 +155,14 @@ local function create_message(self: DB, session_id: string, role: string, parent
   end
 
   self._db:exec([[
-    insert into messages (id, session_id, parent_id, role, seq, created_at)
-    values (?, ?, ?, ?, ?, ?)
-  ]], id, session_id, parent_id, role, seq, now)
-
-  self._db:exec("update sessions set updated_at = ? where id = ?", now, session_id)
+    insert into messages (id, parent_id, role, seq, created_at)
+    values (?, ?, ?, ?, ?)
+  ]], id, parent_id, role, seq, now)
 
   set_context(self, "current_message", id)
 
   return {
     id = id,
-    session_id = session_id,
     parent_id = parent_id,
     role = role,
     seq = seq,
@@ -307,16 +196,19 @@ local function get_ancestry(self: DB, message_id: string): {Message}
   return messages
 end
 
-local function get_last_message(self: DB, session_id: string): Message
+local function get_last_message(self: DB): Message
+  -- First try current_message from context
   local current = get_current_message(self)
-  if current and current.session_id == session_id then
+  if current then
     return current
   end
 
+  -- Otherwise find the most recent leaf (message with no children)
   for row in self._db:query([[
-    select * from messages where session_id = ?
-    order by seq desc, created_at desc limit 1
-  ]], session_id) do
+    select m.* from messages m
+    where not exists (select 1 from messages c where c.parent_id = m.id)
+    order by m.created_at desc limit 1
+  ]]) do
     return row as Message
   end
   return nil
@@ -411,11 +303,11 @@ local function update_content_block(self: DB, id: string, opts: UpdateOpts)
   end
 end
 
-local function get_message_by_seq(self: DB, session_id: string, seq: integer): Message
+local function get_message_by_seq(self: DB, seq: integer): Message
   for row in self._db:query([[
-    select * from messages where session_id = ? and seq = ?
+    select * from messages where seq = ?
     order by created_at asc limit 1
-  ]], session_id, seq) do
+  ]], seq) do
     return row as Message
   end
   return nil
@@ -424,15 +316,9 @@ end
 return {
   open = open,
   close = close,
-  create_session = create_session,
-  get_session = get_session,
-  get_session_by_name = get_session_by_name,
-  list_sessions = list_sessions,
-  delete_session = delete_session,
-  get_current_session = get_current_session,
-  set_current_session = set_current_session,
   create_message = create_message,
   get_current_message = get_current_message,
+  set_current_message = set_current_message,
   get_ancestry = get_ancestry,
   get_last_message = get_last_message,
   delete_message = delete_message,
@@ -442,7 +328,6 @@ return {
   update_content_block = update_content_block,
   -- Export types for consumers
   DB = DB,
-  Session = Session,
   Message = Message,
   ContentBlock = ContentBlock,
   ContentBlockOpts = ContentBlockOpts,

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -15,12 +15,6 @@ global interrupted: boolean = false
 local DEFAULT_SYSTEM_PROMPT = [[You are a coding assistant. Tools: read, write, edit, bash.
 read: examine files. edit: precise text replacement. write: create new files. bash: run commands.]]
 
--- Get global ~/.ah directory
-local function get_global_dir(): string
-  local home = os.getenv("HOME") or ""
-  return fs.join(home, ".ah")
-end
-
 -- Load CLAUDE.md from current directory
 local function load_claude_md(cwd: string): string
   cwd = cwd or fs.getcwd()
@@ -32,28 +26,21 @@ local function load_claude_md(cwd: string): string
 end
 
 -- Load system prompt with precedence:
--- 1. session_system (via -s flag) if set
+-- 1. cli_system (via -s flag) if set
 -- 2. .ah/SYSTEM.md (project) if exists
--- 3. ~/.ah/SYSTEM.md (global) if exists
--- 4. DEFAULT_SYSTEM_PROMPT
+-- 3. DEFAULT_SYSTEM_PROMPT
 -- CLAUDE.md is always appended
-local function load_system_prompt(session_system: string, cwd: string, global_dir: string): string
+local function load_system_prompt(cli_system: string, cwd: string): string
   cwd = cwd or fs.getcwd()
-  global_dir = global_dir or get_global_dir()
   local claude_md = load_claude_md(cwd)
 
-  if session_system then
-    return session_system .. claude_md
+  if cli_system then
+    return cli_system .. claude_md
   end
 
   local project_system = cio.slurp(fs.join(cwd, ".ah", "SYSTEM.md"))
   if project_system then
     return project_system .. claude_md
-  end
-
-  local global_system = cio.slurp(fs.join(global_dir, "SYSTEM.md"))
-  if global_system then
-    return global_system .. claude_md
   end
 
   return DEFAULT_SYSTEM_PROMPT .. claude_md
@@ -66,16 +53,14 @@ commands:
   <prompt>            send prompt to agent
   (no args)           continue from last message
   @N <prompt>         fork from message N with new prompt
-  folder [+name]      list or switch sessions
-  scan [+name]        list messages in session
+  scan                list messages in current branch
   show [N]            show message(s)
   rmm N...            remove messages
-  rmf [+name]         remove session
 
 options:
   -h, --help          show this help
-  -n, --new [+name]   start new session (optionally named)
-  -s, --system PROMPT set system prompt
+  --db PATH           use custom database path (default: .ah/ah.db)
+  -s, --system PROMPT set system prompt for this invocation
   -m, --model MODEL   set model (e.g., claude-sonnet-4-20250514)
 ]])
 end
@@ -103,9 +88,9 @@ local function tool_key_param(tool_name: string, tool_input: string): string
 end
 
 -- Send prompt and run agent loop
-local function run_agent(d: db.DB, session: db.Session, prompt: string, parent_id: string)
+local function run_agent(d: db.DB, system_prompt: string, model: string, prompt: string, parent_id: string)
   -- Create user message
-  local user_msg = db.create_message(d, session.id, "user", parent_id)
+  local user_msg = db.create_message(d, "user", parent_id)
   db.add_content_block(d, user_msg.id, "text", {content = prompt})
 
   -- Build messages from ancestry
@@ -155,13 +140,13 @@ local function run_agent(d: db.DB, session: db.Session, prompt: string, parent_i
   -- Agent loop
   while not interrupted do
     -- Create assistant message
-    local assistant_msg = db.create_message(d, session.id, "assistant", user_msg.id)
+    local assistant_msg = db.create_message(d, "assistant", user_msg.id)
     local current_text = ""
 
     -- Stream response
     local response, err = api.stream(api_messages, {
-      system = session.system_prompt,
-      model = session.model,
+      system = system_prompt,
+      model = model,
       tools = tools.get_tool_definitions(),
     }, function(event: {string:any})
       if event.type == "content_block_delta" and event.delta then
@@ -224,7 +209,7 @@ local function run_agent(d: db.DB, session: db.Session, prompt: string, parent_i
     io.write("\n")
 
     -- Create a new user message for tool results (child of assistant message)
-    local tool_result_msg = db.create_message(d, session.id, "user", assistant_msg.id)
+    local tool_result_msg = db.create_message(d, "user", assistant_msg.id)
 
     -- Add tool results to API messages
     local tool_results_content: {any} = {}
@@ -274,63 +259,8 @@ local function run_agent(d: db.DB, session: db.Session, prompt: string, parent_i
   end
 end
 
--- Format relative time
-local function relative_time(ts: integer): string
-  local now = os.time()
-  local diff = now - ts
-  if diff < 60 then return "now"
-  elseif diff < 3600 then return string.format("%dm", math.floor(diff / 60))
-  elseif diff < 86400 then return string.format("%dh", math.floor(diff / 3600))
-  elseif diff < 604800 then return string.format("%dd", math.floor(diff / 86400))
-  else return string.format("%dw", math.floor(diff / 604800))
-  end
-end
-
--- List sessions
-local function cmd_folder(d: db.DB, name: string)
-  if name then
-    -- Switch to session by name
-    local session = db.get_session_by_name(d, name)
-    if not session then
-      io.stderr:write("session not found: " .. name .. "\n")
-      return
-    end
-    db.set_current_session(d, session.id)
-    io.write("switched to " .. name .. "\n")
-  else
-    -- List sessions
-    local sessions = db.list_sessions(d) as {any}
-    local current = db.get_current_session(d)
-    local current_id = current and current.id or nil
-
-    for _, session in ipairs(sessions) do
-      local s = session as {string:any}
-      local marker = (current_id and current_id == s.id) and "*" or " "
-      local name_str = (s.name or (s.id as string):sub(1, 8)) as string
-      local msg_count = (s.message_count or 0) as integer
-      local age = relative_time(s.updated_at as integer)
-      io.write(string.format("%s %-12s %3d msgs  %s\n", marker, name_str, msg_count, age))
-    end
-  end
-end
-
 -- List messages in current branch (ancestry from current message)
-local function cmd_scan(d: db.DB, name: string)
-  local session: {string:any}
-  if name then
-    session = db.get_session_by_name(d, name) as {string:any}
-    if not session then
-      io.stderr:write("session not found: " .. name .. "\n")
-      return
-    end
-  else
-    session = db.get_current_session(d) as {string:any}
-    if not session then
-      io.stderr:write("no current session\n")
-      return
-    end
-  end
-
+local function cmd_scan(d: db.DB)
   local current = db.get_current_message(d) as {string:any}
   if not current then
     io.stderr:write("no messages\n")
@@ -397,15 +327,9 @@ end
 
 -- Show message content
 local function cmd_show(d: db.DB, seq: integer)
-  local session = db.get_current_session(d)
-  if not session then
-    io.stderr:write("no current session\n")
-    return
-  end
-
   local m: db.Message
   if seq then
-    m = db.get_message_by_seq(d, session.id, seq)
+    m = db.get_message_by_seq(d, seq)
     if not m then
       io.stderr:write("message not found: @" .. seq .. "\n")
       return
@@ -441,14 +365,8 @@ end
 
 -- Remove messages
 local function cmd_rmm(d: db.DB, seqs: {integer})
-  local session = db.get_current_session(d)
-  if not session then
-    io.stderr:write("no current session\n")
-    return
-  end
-
   for _, seq in ipairs(seqs) do
-    local msg = db.get_message_by_seq(d, session.id, seq)
+    local msg = db.get_message_by_seq(d, seq)
     if msg then
       db.delete_message(d, msg.id)
       io.write("deleted @" .. seq .. "\n")
@@ -458,41 +376,19 @@ local function cmd_rmm(d: db.DB, seqs: {integer})
   end
 end
 
--- Remove session
-local function cmd_rmf(d: db.DB, name: string)
-  local session: any
-  if name then
-    session = db.get_session_by_name(d, name)
-    if not session then
-      io.stderr:write("session not found: " .. name .. "\n")
-      return
-    end
-  else
-    session = db.get_current_session(d)
-    if not session then
-      io.stderr:write("no current session\n")
-      return
-    end
-  end
-
-  local s = session as {string:any}
-  db.delete_session(d, s.id as string)
-  io.write("deleted " .. ((s.name or s.id) as string) .. "\n")
-end
-
 local function main(args: {string}): integer, string
-  local new_session = false
   local system_prompt: string = nil
   local model: string = nil
+  local db_path: string = nil
 
   local longopts = {
     {name = "help", has_arg = "none", short = "h"},
-    {name = "new", has_arg = "none", short = "n"},
+    {name = "db", has_arg = "required"},
     {name = "system", has_arg = "required", short = "s"},
     {name = "model", has_arg = "required", short = "m"},
   }
 
-  local parser = getopt.new(args, "hns:m:", longopts)
+  local parser = getopt.new(args, "hs:m:", longopts)
 
   while true do
     local opt, optarg = parser:next()
@@ -501,8 +397,8 @@ local function main(args: {string}): integer, string
     if opt == "h" or opt == "help" then
       usage()
       return 0
-    elseif opt == "n" or opt == "new" then
-      new_session = true
+    elseif opt == "db" then
+      db_path = optarg
     elseif opt == "s" or opt == "system" then
       system_prompt = optarg
     elseif opt == "m" or opt == "model" then
@@ -515,7 +411,7 @@ local function main(args: {string}): integer, string
 
   local remaining = parser:remaining() or {}
 
-  local d, err = db.open()
+  local d, err = db.open(db_path)
   if not d then
     return 1, err
   end
@@ -523,21 +419,8 @@ local function main(args: {string}): integer, string
   -- Handle commands
   local cmd = remaining[1]
 
-  if cmd == "folder" then
-    local name = remaining[2]
-    if name and name:sub(1, 1) == "+" then
-      name = name:sub(2)
-    end
-    cmd_folder(d, name)
-    db.close(d)
-    return 0
-
-  elseif cmd == "scan" then
-    local name = remaining[2]
-    if name and name:sub(1, 1) == "+" then
-      name = name:sub(2)
-    end
-    cmd_scan(d, name)
+  if cmd == "scan" then
+    cmd_scan(d)
     db.close(d)
     return 0
 
@@ -559,29 +442,11 @@ local function main(args: {string}): integer, string
     cmd_rmm(d, seqs)
     db.close(d)
     return 0
-
-  elseif cmd == "rmf" then
-    local name = remaining[2]
-    if name and name:sub(1, 1) == "+" then
-      name = name:sub(2)
-    end
-    cmd_rmf(d, name)
-    db.close(d)
-    return 0
   end
 
   -- Handle prompt or continue
-  local session = db.get_current_session(d)
   local parent_id: string = nil
   local prompt: string = nil
-  local session_name: string = nil
-
-  -- Check for +name when starting new session
-  if new_session and cmd and cmd:sub(1, 1) == "+" then
-    session_name = cmd:sub(2)
-    table.remove(remaining, 1)
-    cmd = remaining[1]
-  end
 
   -- Check for @N fork syntax
   if cmd and cmd:sub(1, 1) == "@" then
@@ -591,12 +456,7 @@ local function main(args: {string}): integer, string
       return 1, "invalid message number: " .. cmd
     end
 
-    if not session then
-      db.close(d)
-      return 1, "no current session"
-    end
-
-    local msg = db.get_message_by_seq(d, session.id, seq)
+    local msg = db.get_message_by_seq(d, seq)
     if not msg then
       db.close(d)
       return 1, "message not found: " .. cmd
@@ -608,31 +468,28 @@ local function main(args: {string}): integer, string
     prompt = table.concat(remaining, " ")
   end
 
-  -- Create or get session
-  if new_session or not session then
-    local effective_system = load_system_prompt(system_prompt, nil, nil)
-    session = db.create_session(d, session_name, fs.getcwd(), effective_system, model)
-  end
-
   -- Get parent message - always continue from last message unless forking with @N
   if not parent_id then
-    local last = db.get_last_message(d, session.id as string)
+    local last = db.get_last_message(d)
     if last then
       parent_id = (last as {string:any}).id as string
     end
-    -- If no last message and no prompt, error
-    if not parent_id and prompt == "" then
+  end
+
+  -- If no prompt, need either something to continue or show help
+  if prompt == "" then
+    if not parent_id then
+      usage()
       db.close(d)
-      return 1, "no messages to continue from"
+      return 0
+    else
+      db.close(d)
+      return 1, "no prompt provided"
     end
   end
 
-  -- If no prompt, show help
-  if prompt == "" and not parent_id then
-    usage()
-    db.close(d)
-    return 0
-  end
+  -- Load system prompt
+  local effective_system = load_system_prompt(system_prompt, nil)
 
   -- Initialize custom tools
   tools.init_custom_tools()
@@ -643,7 +500,7 @@ local function main(args: {string}): integer, string
   end)
 
   -- Run agent
-  run_agent(d, session, prompt, parent_id)
+  run_agent(d, effective_system, model, prompt, parent_id)
 
   db.close(d)
   return 0
@@ -653,7 +510,6 @@ return {
   main = main,
   load_system_prompt = load_system_prompt,
   load_claude_md = load_claude_md,
-  get_global_dir = get_global_dir,
   tool_key_param = tool_key_param,
   DEFAULT_SYSTEM_PROMPT = DEFAULT_SYSTEM_PROMPT,
 }

--- a/lib/ah/test_db.tl
+++ b/lib/ah/test_db.tl
@@ -12,59 +12,18 @@ local function test_open_close()
 end
 test_open_close()
 
-local function test_session_crud()
-  local db_path = fs.join(TEST_TMPDIR, "test.db")
-  local d = db.open(db_path)
-
-  -- Create session
-  local session = db.create_session(d, "test-session", "/tmp", "You are helpful")
-  assert(session.id, "session should have id")
-  assert(session.name == "test-session", "session name mismatch")
-  assert(session.cwd == "/tmp", "session cwd mismatch")
-  assert(session.system_prompt == "You are helpful", "session prompt mismatch")
-
-  -- Get session
-  local fetched = db.get_session(d, session.id)
-  assert(fetched, "failed to fetch session")
-  assert(fetched.id == session.id, "fetched session id mismatch")
-
-  -- Get by name
-  local by_name = db.get_session_by_name(d, "test-session")
-  assert(by_name, "failed to fetch session by name")
-  assert(by_name.id == session.id, "fetched by name id mismatch")
-
-  -- List sessions
-  local sessions = db.list_sessions(d)
-  assert(#sessions == 1, "expected 1 session")
-
-  -- Current session
-  local current = db.get_current_session(d)
-  assert(current, "no current session")
-  assert(current.id == session.id, "current session id mismatch")
-
-  -- Delete session
-  db.delete_session(d, session.id)
-  local deleted = db.get_session(d, session.id)
-  assert(not deleted, "session should be deleted")
-
-  db.close(d)
-end
-test_session_crud()
-
 local function test_messages()
   local db_path = fs.join(TEST_TMPDIR, "test.db")
   local d = db.open(db_path)
 
-  local session = db.create_session(d)
-
   -- Create root message
-  local msg1 = db.create_message(d, session.id, "user")
+  local msg1 = db.create_message(d, "user")
   assert(msg1.id, "message should have id")
   assert(msg1.role == "user", "message role mismatch")
   assert(msg1.seq == 0, "root message should have seq 0")
 
   -- Create child message
-  local msg2 = db.create_message(d, session.id, "assistant", msg1.id)
+  local msg2 = db.create_message(d, "assistant", msg1.id)
   assert(msg2.seq == 1, "child message should have seq 1")
   assert(msg2.parent_id == msg1.id, "parent_id mismatch")
 
@@ -75,12 +34,12 @@ local function test_messages()
   assert(ancestry[2].id == msg2.id, "second in ancestry should be child")
 
   -- Get last message
-  local last = db.get_last_message(d, session.id)
+  local last = db.get_last_message(d)
   assert(last, "should have last message")
   assert(last.id == msg2.id, "last message should be msg2")
 
   -- Get by seq
-  local by_seq = db.get_message_by_seq(d, session.id, 0)
+  local by_seq = db.get_message_by_seq(d, 0)
   assert(by_seq, "should find message by seq")
   assert(by_seq.id == msg1.id, "wrong message by seq")
 
@@ -92,8 +51,7 @@ local function test_content_blocks()
   local db_path = fs.join(TEST_TMPDIR, "test.db")
   local d = db.open(db_path)
 
-  local session = db.create_session(d)
-  local msg = db.create_message(d, session.id, "assistant")
+  local msg = db.create_message(d, "assistant")
 
   -- Add text block
   local block1 = db.add_content_block(d, msg.id, "text", {content = "Hello world"})
@@ -129,16 +87,14 @@ local function test_forking()
   local db_path = fs.join(TEST_TMPDIR, "test.db")
   local d = db.open(db_path)
 
-  local session = db.create_session(d)
-
   -- Create a conversation: user -> assistant -> user -> assistant
-  local msg1 = db.create_message(d, session.id, "user")
-  local msg2 = db.create_message(d, session.id, "assistant", msg1.id)
-  local msg3 = db.create_message(d, session.id, "user", msg2.id)
-  local msg4 = db.create_message(d, session.id, "assistant", msg3.id)
+  local msg1 = db.create_message(d, "user")
+  local msg2 = db.create_message(d, "assistant", msg1.id)
+  local msg3 = db.create_message(d, "user", msg2.id)
+  local msg4 = db.create_message(d, "assistant", msg3.id)
 
   -- Fork from msg2 (after first assistant response)
-  local fork_msg = db.create_message(d, session.id, "user", msg2.id)
+  local fork_msg = db.create_message(d, "user", msg2.id)
   assert(fork_msg.seq == 2, "forked message should have seq 2")
   assert(fork_msg.parent_id == msg2.id, "forked parent should be msg2")
 

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -6,56 +6,32 @@ local init = require("ah.init")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
 
-local function test_get_global_dir()
-  local dir = init.get_global_dir()
-  assert(dir:match("%.ah$"), "should end with .ah")
-  assert(dir:match("^/"), "should be absolute path")
-end
-test_get_global_dir()
-
 local function test_load_system_prompt_default()
   -- No files exist, should use default
   local empty_dir = fs.join(TEST_TMPDIR, "empty")
   fs.makedirs(empty_dir)
 
-  local prompt = init.load_system_prompt(nil, empty_dir, fs.join(TEST_TMPDIR, "no_global"))
+  local prompt = init.load_system_prompt(nil, empty_dir)
   assert(prompt == init.DEFAULT_SYSTEM_PROMPT, "should use default prompt when no files exist")
 end
 test_load_system_prompt_default()
 
-local function test_load_system_prompt_session_override()
+local function test_load_system_prompt_cli_override()
   -- -s flag should take precedence over everything
-  local prompt = init.load_system_prompt("Custom via -s", TEST_TMPDIR, TEST_TMPDIR)
-  assert(prompt:match("Custom via %-s"), "session prompt should override")
+  local prompt = init.load_system_prompt("Custom via -s", TEST_TMPDIR)
+  assert(prompt:match("Custom via %-s"), "cli prompt should override")
 end
-test_load_system_prompt_session_override()
-
-local function test_load_system_prompt_global()
-  local global_ah = fs.join(TEST_TMPDIR, "global_ah_test")
-  local cwd = fs.join(TEST_TMPDIR, "cwd_test")
-  fs.makedirs(global_ah)
-  fs.makedirs(cwd)
-
-  cio.barf(fs.join(global_ah, "SYSTEM.md"), "Global system prompt")
-
-  local prompt = init.load_system_prompt(nil, cwd, global_ah)
-  assert(prompt:match("Global system prompt"), "should load global SYSTEM.md")
-end
-test_load_system_prompt_global()
+test_load_system_prompt_cli_override()
 
 local function test_load_system_prompt_project()
-  local global_ah = fs.join(TEST_TMPDIR, "global_ah_proj")
   local cwd = fs.join(TEST_TMPDIR, "cwd_proj")
   local project_ah = fs.join(cwd, ".ah")
-  fs.makedirs(global_ah)
   fs.makedirs(project_ah)
 
-  cio.barf(fs.join(global_ah, "SYSTEM.md"), "Global")
   cio.barf(fs.join(project_ah, "SYSTEM.md"), "Project system prompt")
 
-  local prompt = init.load_system_prompt(nil, cwd, global_ah)
-  assert(prompt:match("Project system prompt"), "project should override global")
-  assert(not prompt:match("Global"), "global should not be included")
+  local prompt = init.load_system_prompt(nil, cwd)
+  assert(prompt:match("Project system prompt"), "should load project SYSTEM.md")
 end
 test_load_system_prompt_project()
 
@@ -80,31 +56,30 @@ end
 test_load_claude_md_missing()
 
 local function test_load_system_prompt_with_claude_md()
-  local global_ah = fs.join(TEST_TMPDIR, "global_ah_claude")
   local cwd = fs.join(TEST_TMPDIR, "cwd_with_claude")
-  fs.makedirs(global_ah)
-  fs.makedirs(cwd)
+  local project_ah = fs.join(cwd, ".ah")
+  fs.makedirs(project_ah)
 
-  cio.barf(fs.join(global_ah, "SYSTEM.md"), "You are a coding assistant.")
+  cio.barf(fs.join(project_ah, "SYSTEM.md"), "You are a coding assistant.")
   cio.barf(fs.join(cwd, "CLAUDE.md"), "This is my project context")
 
-  local prompt = init.load_system_prompt(nil, cwd, global_ah)
+  local prompt = init.load_system_prompt(nil, cwd)
   assert(prompt:match("You are a coding assistant"), "should include system prompt")
   assert(prompt:match("Project Context"), "should have CLAUDE.md header")
   assert(prompt:match("This is my project context"), "should append CLAUDE.md content")
 end
 test_load_system_prompt_with_claude_md()
 
-local function test_session_prompt_with_claude_md()
-  local cwd = fs.join(TEST_TMPDIR, "cwd_session_claude")
+local function test_cli_prompt_with_claude_md()
+  local cwd = fs.join(TEST_TMPDIR, "cwd_cli_claude")
   fs.makedirs(cwd)
   cio.barf(fs.join(cwd, "CLAUDE.md"), "Project notes here")
 
-  local prompt = init.load_system_prompt("Custom prompt", cwd, TEST_TMPDIR)
-  assert(prompt:match("Custom prompt"), "should use session prompt")
-  assert(prompt:match("Project notes here"), "should append CLAUDE.md to session prompt")
+  local prompt = init.load_system_prompt("Custom prompt", cwd)
+  assert(prompt:match("Custom prompt"), "should use cli prompt")
+  assert(prompt:match("Project notes here"), "should append CLAUDE.md to cli prompt")
 end
-test_session_prompt_with_claude_md()
+test_cli_prompt_with_claude_md()
 
 -- Tests for tool_key_param
 local function test_tool_key_param_bash()


### PR DESCRIPTION
## Summary

- Replace global `~/.ah/ah.db` with per-directory `.ah/ah.db`
- Remove sessions/folders concept entirely - messages form a tree via `parent_id`
- Simplify CLI: replace `-n/--new` with `--db <path>` for custom database path
- Remove `folder` and `rmf` commands
- System prompt loaded per-invocation from `-s` flag or `.ah/SYSTEM.md`

## Test plan

- [x] `make clean test` passes
- [x] Incremental build works (`make test` is instant on second run)