### PR TITLE
ci: add ci target for tests and type checks

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build ah
-        run: make ah
+        run: make -j ah
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run tests
-        run: make test
+      - name: Run tests and type checks
+        run: make -j ci

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ help:
 	@echo "  build               Build all files"
 	@echo "  ah                  Build ah executable archive"
 	@echo "  check-types         Run teal type checker on all files"
+	@echo "  ci                  Run tests and type checks"
 	@echo "  clean               Remove all build artifacts"
 
 .PHONY: test
@@ -122,6 +123,10 @@ $(o)/%.tl.teal.ok: %.tl $(cosmic)
 		grep ': error:' $@.err >> $@ 2>/dev/null || true; \
 	fi; \
 	rm -f $@.err
+
+.PHONY: ci
+## Run tests and type checks
+ci: test check-types
 
 .PHONY: clean
 ## Remove all build artifacts

--- a/lib/build/reporter.tl
+++ b/lib/build/reporter.tl
@@ -102,7 +102,7 @@ local function main(...: string): integer, string
           output = parsed.output,
           name = strip_prefix(file, dir):gsub(strip_suffix, ""),
           file = file,
-          checker = checker ~= "test" and checker or nil,
+          checker = checker,
         }
         local status_list = (results as {string:{CheckResult}})[result.status]
         if status_list then


### PR DESCRIPTION
- Add `make ci` target that runs both tests and type checks
- Update reporter to show "test" column for consistency with "teal"
- Use `make -j` in workflows for parallel builds