### PR TITLE
ah: store sessions as .ah/<ulid>.db

### DIFF
--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -313,6 +313,27 @@ local function get_message_by_seq(self: DB, seq: integer): Message
   return nil
 end
 
+local function get_message_count(self: DB): integer
+  for row in self._db:query("select count(*) as cnt from messages") do
+    return (row.cnt or 0) as integer
+  end
+  return 0
+end
+
+local function get_first_user_prompt(self: DB): string
+  for row in self._db:query([[
+    select content from content_blocks
+    where block_type = 'text'
+      and message_id in (
+        select id from messages where role = 'user' order by seq asc limit 1
+      )
+    order by seq asc limit 1
+  ]]) do
+    return (row.content or "") as string
+  end
+  return ""
+end
+
 return {
   open = open,
   close = close,
@@ -326,6 +347,8 @@ return {
   add_content_block = add_content_block,
   get_content_blocks = get_content_blocks,
   update_content_block = update_content_block,
+  get_message_count = get_message_count,
+  get_first_user_prompt = get_first_user_prompt,
   -- Export types for consumers
   DB = DB,
   Message = Message,

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -8,6 +8,16 @@ local unix = require("cosmo.unix")
 local db = require("ah.db")
 local api = require("ah.api")
 local tools = require("ah.tools")
+local ulid = require("ulid")
+
+-- Session record for listing
+local record Session
+  ulid: string
+  db_path: string
+  msg_count: integer
+  first_prompt: string
+  timestamp: number
+end
 
 -- Global for signal handling
 global interrupted: boolean = false
@@ -46,6 +56,74 @@ local function load_system_prompt(cli_system: string, cwd: string): string
   return DEFAULT_SYSTEM_PROMPT .. claude_md
 end
 
+-- List session files from .ah/*.db with valid ULID names
+local function list_sessions(cwd?: string): {Session}
+  cwd = cwd or fs.getcwd()
+  local ah_dir = fs.join(cwd, ".ah")
+  local sessions: {Session} = {}
+
+  local dir = unix.opendir(ah_dir)
+  if not dir then
+    return sessions
+  end
+
+  while true do
+    local name = dir:read()
+    if not name then break end
+
+    -- Check if it's a .db file with ULID name
+    if name:match("%.db$") then
+      local session_ulid = name:sub(1, -4)  -- remove .db
+      -- Validate ULID by checking length and trying to parse timestamp
+      if #session_ulid == 26 then
+        local ts = ulid.timestamp(session_ulid)
+        if ts then
+          local db_path = fs.join(ah_dir, name)
+          local d = db.open(db_path)
+          if d then
+            table.insert(sessions, {
+              ulid = session_ulid,
+              db_path = db_path,
+              msg_count = db.get_message_count(d),
+              first_prompt = db.get_first_user_prompt(d),
+              timestamp = ts,
+            })
+            db.close(d)
+          end
+        end
+      end
+    end
+  end
+  dir:close()
+
+  -- Sort by ULID descending (most recent first - ULID encodes timestamp)
+  table.sort(sessions, function(a: Session, b: Session): boolean
+    return a.ulid > b.ulid
+  end)
+
+  return sessions
+end
+
+-- Resolve partial ULID prefix to full session ULID
+local function resolve_session(cwd: string, prefix: string): string, string
+  local sessions = list_sessions(cwd)
+  local matches: {string} = {}
+
+  for _, s in ipairs(sessions) do
+    if s.ulid:sub(1, #prefix) == prefix then
+      table.insert(matches, s.ulid)
+    end
+  end
+
+  if #matches == 0 then
+    return nil, "no session matches prefix: " .. prefix
+  elseif #matches > 1 then
+    return nil, "ambiguous prefix: " .. prefix .. " matches " .. #matches .. " sessions"
+  end
+
+  return matches[1], nil
+end
+
 local function usage()
   io.stderr:write([[usage: ah [options] [command] [args...]
 
@@ -53,13 +131,16 @@ commands:
   <prompt>            send prompt to agent
   (no args)           continue from last message
   @N <prompt>         fork from message N with new prompt
+  sessions            list all sessions
   scan                list messages in current branch
   show [N]            show message(s)
   rmm N...            remove messages
 
 options:
   -h, --help          show this help
-  --db PATH           use custom database path (default: .ah/ah.db)
+  -n, --new           start a new session
+  -S, --session ULID  use specific session (prefix match)
+  --db PATH           use custom database path (default: .ah/<ulid>.db)
   -s, --system PROMPT set system prompt for this invocation
   -m, --model MODEL   set model (e.g., claude-sonnet-4-20250514)
 ]])
@@ -363,6 +444,27 @@ local function cmd_show(d: db.DB, seq: integer)
   end
 end
 
+-- List all sessions
+local function cmd_sessions(cwd: string, current_ulid: string)
+  local sessions = list_sessions(cwd)
+  if #sessions == 0 then
+    io.stderr:write("no sessions\n")
+    return
+  end
+
+  for _, s in ipairs(sessions) do
+    local marker = s.ulid == current_ulid and ">" or " "
+    local decoded = ulid.decode(s.ulid)
+    local time_str = decoded and decoded.time or "unknown"
+    local preview = s.first_prompt:gsub("\n", " "):sub(1, 40)
+    if #s.first_prompt > 40 then
+      preview = preview .. "..."
+    end
+    io.write(string.format("%s %s  %s  %2d msgs  %s\n",
+      marker, s.ulid, time_str, s.msg_count, preview))
+  end
+end
+
 -- Remove messages
 local function cmd_rmm(d: db.DB, seqs: {integer})
   for _, seq in ipairs(seqs) do
@@ -380,15 +482,20 @@ local function main(args: {string}): integer, string
   local system_prompt: string = nil
   local model: string = nil
   local db_path: string = nil
+  local new_session: boolean = false
+  local session_prefix: string = nil
+  local cwd = fs.getcwd()
 
   local longopts = {
     {name = "help", has_arg = "none", short = "h"},
+    {name = "new", has_arg = "none", short = "n"},
+    {name = "session", has_arg = "required", short = "S"},
     {name = "db", has_arg = "required"},
     {name = "system", has_arg = "required", short = "s"},
     {name = "model", has_arg = "required", short = "m"},
   }
 
-  local parser = getopt.new(args, "hs:m:", longopts)
+  local parser = getopt.new(args, "hnS:s:m:", longopts)
 
   while true do
     local opt, optarg = parser:next()
@@ -397,6 +504,10 @@ local function main(args: {string}): integer, string
     if opt == "h" or opt == "help" then
       usage()
       return 0
+    elseif opt == "n" or opt == "new" then
+      new_session = true
+    elseif opt == "S" or opt == "session" then
+      session_prefix = optarg
     elseif opt == "db" then
       db_path = optarg
     elseif opt == "s" or opt == "system" then
@@ -411,14 +522,52 @@ local function main(args: {string}): integer, string
 
   local remaining = parser:remaining() or {}
 
+  -- Handle sessions command first (doesn't need db)
+  local cmd = remaining[1]
+  if cmd == "sessions" then
+    -- For sessions command, we need to know which would be default
+    local sessions = list_sessions(cwd)
+    local current_ulid = sessions[1] and sessions[1].ulid or ""
+    cmd_sessions(cwd, current_ulid)
+    return 0
+  end
+
+  -- Session selection logic (only if --db not specified)
+  local session_ulid: string = nil
+  if not db_path then
+    local ah_dir = fs.join(cwd, ".ah")
+    fs.makedirs(ah_dir)
+
+    if new_session then
+      -- -n: force new session
+      session_ulid = ulid.generate()
+    elseif session_prefix then
+      -- -S PREFIX: resolve to specific session
+      local resolved, err = resolve_session(cwd, session_prefix)
+      if not resolved then
+        return 1, err
+      end
+      session_ulid = resolved
+    else
+      -- Default: use most recent session or create new if needed
+      local sessions = list_sessions(cwd)
+      if #sessions > 0 then
+        session_ulid = sessions[1].ulid
+      else
+        -- No existing sessions - will create new if prompt given
+        session_ulid = ulid.generate()
+      end
+    end
+
+    db_path = fs.join(ah_dir, session_ulid .. ".db")
+  end
+
   local d, err = db.open(db_path)
   if not d then
     return 1, err
   end
 
   -- Handle commands
-  local cmd = remaining[1]
-
   if cmd == "scan" then
     cmd_scan(d)
     db.close(d)
@@ -511,5 +660,7 @@ return {
   load_system_prompt = load_system_prompt,
   load_claude_md = load_claude_md,
   tool_key_param = tool_key_param,
+  list_sessions = list_sessions,
+  resolve_session = resolve_session,
   DEFAULT_SYSTEM_PROMPT = DEFAULT_SYSTEM_PROMPT,
 }

--- a/lib/ah/test_db.tl
+++ b/lib/ah/test_db.tl
@@ -113,4 +113,56 @@ local function test_forking()
 end
 test_forking()
 
+local function test_get_message_count()
+  -- Test empty db
+  local db_path = fs.join(TEST_TMPDIR, "count_empty.db")
+  local d = db.open(db_path)
+  assert(db.get_message_count(d) == 0, "empty db should have 0 messages")
+  db.close(d)
+
+  -- Test db with 1 message
+  db_path = fs.join(TEST_TMPDIR, "count_one.db")
+  d = db.open(db_path)
+  db.create_message(d, "user")
+  assert(db.get_message_count(d) == 1, "should have 1 message")
+  db.close(d)
+
+  -- Test db with 3 messages
+  db_path = fs.join(TEST_TMPDIR, "count_three.db")
+  d = db.open(db_path)
+  local msg1 = db.create_message(d, "user")
+  local msg2 = db.create_message(d, "assistant", msg1.id)
+  db.create_message(d, "user", msg2.id)
+  assert(db.get_message_count(d) == 3, "should have 3 messages")
+  db.close(d)
+end
+test_get_message_count()
+
+local function test_get_first_user_prompt()
+  -- Test empty db
+  local db_path = fs.join(TEST_TMPDIR, "prompt_empty.db")
+  local d = db.open(db_path)
+  assert(db.get_first_user_prompt(d) == "", "empty db should return empty string")
+  db.close(d)
+
+  -- Test db with user message
+  db_path = fs.join(TEST_TMPDIR, "prompt_user.db")
+  d = db.open(db_path)
+  local msg = db.create_message(d, "user")
+  db.add_content_block(d, msg.id, "text", {content = "Hello world"})
+  assert(db.get_first_user_prompt(d) == "Hello world", "should return first user prompt")
+  db.close(d)
+
+  -- Test db with assistant-first (edge case - shouldn't happen but should handle)
+  db_path = fs.join(TEST_TMPDIR, "prompt_assistant_first.db")
+  d = db.open(db_path)
+  local amsg = db.create_message(d, "assistant")
+  db.add_content_block(d, amsg.id, "text", {content = "I am assistant"})
+  local umsg = db.create_message(d, "user", amsg.id)
+  db.add_content_block(d, umsg.id, "text", {content = "User prompt"})
+  assert(db.get_first_user_prompt(d) == "User prompt", "should find first user message")
+  db.close(d)
+end
+test_get_first_user_prompt()
+
 print("all db tests passed")

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -3,6 +3,7 @@
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local init = require("ah.init")
+local db = require("ah.db")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
 
@@ -133,5 +134,118 @@ local function test_tool_key_param_unknown_tool()
   assert(key == "", "should return empty string for unknown tool")
 end
 test_tool_key_param_unknown_tool()
+
+-- Session management tests
+
+local function test_list_sessions_empty()
+  local cwd = fs.join(TEST_TMPDIR, "sessions_empty")
+  fs.makedirs(fs.join(cwd, ".ah"))
+
+  local sessions = init.list_sessions(cwd)
+  assert(#sessions == 0, "empty .ah should have 0 sessions")
+end
+test_list_sessions_empty()
+
+local function test_list_sessions()
+  local cwd = fs.join(TEST_TMPDIR, "sessions_list")
+  local ah_dir = fs.join(cwd, ".ah")
+  fs.makedirs(ah_dir)
+
+  -- Create two session dbs with different ULIDs (26 chars each)
+  -- Use ULIDs that sort predictably (earlier timestamp = lexically smaller)
+  local ulid1 = "01KGW111111111111111111111"  -- earlier (26 chars)
+  local ulid2 = "01KGW222222222222222222222"  -- later (26 chars)
+
+  local d1 = db.open(fs.join(ah_dir, ulid1 .. ".db"))
+  local msg1 = db.create_message(d1, "user")
+  db.add_content_block(d1, msg1.id, "text", {content = "Hello world"})
+  db.close(d1)
+
+  local d2 = db.open(fs.join(ah_dir, ulid2 .. ".db"))
+  local msg2a = db.create_message(d2, "user")
+  db.add_content_block(d2, msg2a.id, "text", {content = "Fix the login bug"})
+  local msg2b = db.create_message(d2, "assistant", msg2a.id)
+  db.add_content_block(d2, msg2b.id, "text", {content = "I'll help"})
+  local msg2c = db.create_message(d2, "user", msg2b.id)
+  db.add_content_block(d2, msg2c.id, "text", {content = "Thanks"})
+  db.close(d2)
+
+  local sessions = init.list_sessions(cwd)
+  assert(#sessions == 2, "should have 2 sessions, got " .. #sessions)
+  -- Sorted by ULID descending (most recent first)
+  assert(sessions[1].ulid == ulid2, "first should be ulid2 (most recent)")
+  assert(sessions[2].ulid == ulid1, "second should be ulid1")
+
+  assert(sessions[1].msg_count == 3, "session 2 should have 3 messages")
+  assert(sessions[1].first_prompt == "Fix the login bug", "session 2 first prompt mismatch")
+
+  assert(sessions[2].msg_count == 1, "session 1 should have 1 message")
+  assert(sessions[2].first_prompt == "Hello world", "session 1 first prompt mismatch")
+end
+test_list_sessions()
+
+local function test_resolve_session_exact()
+  local cwd = fs.join(TEST_TMPDIR, "sessions_resolve")
+  local ah_dir = fs.join(cwd, ".ah")
+  fs.makedirs(ah_dir)
+
+  local ulid1 = "01KGWAAAAAAAAAAAAAAAAAAAAA"  -- 26 chars
+  local d1 = db.open(fs.join(ah_dir, ulid1 .. ".db"))
+  db.create_message(d1, "user")
+  db.close(d1)
+
+  -- Exact match
+  local resolved, err = init.resolve_session(cwd, ulid1)
+  assert(resolved == ulid1, "exact match should work: " .. tostring(err))
+end
+test_resolve_session_exact()
+
+local function test_resolve_session_prefix()
+  local cwd = fs.join(TEST_TMPDIR, "sessions_prefix")
+  local ah_dir = fs.join(cwd, ".ah")
+  fs.makedirs(ah_dir)
+
+  local ulid1 = "01KGWBBBBBBBBBBBBBBBBBBBBB"  -- 26 chars
+  local d1 = db.open(fs.join(ah_dir, ulid1 .. ".db"))
+  db.create_message(d1, "user")
+  db.close(d1)
+
+  -- Prefix match
+  local resolved, err = init.resolve_session(cwd, "01KGWB")
+  assert(resolved == ulid1, "prefix match should work: " .. tostring(err))
+end
+test_resolve_session_prefix()
+
+local function test_resolve_session_ambiguous()
+  local cwd = fs.join(TEST_TMPDIR, "sessions_ambig")
+  local ah_dir = fs.join(cwd, ".ah")
+  fs.makedirs(ah_dir)
+
+  local ulid1 = "01KGWCCCCC1111111111111111"  -- 26 chars
+  local ulid2 = "01KGWCCCCC2222222222222222"  -- 26 chars
+  local d1 = db.open(fs.join(ah_dir, ulid1 .. ".db"))
+  db.create_message(d1, "user")
+  db.close(d1)
+  local d2 = db.open(fs.join(ah_dir, ulid2 .. ".db"))
+  db.create_message(d2, "user")
+  db.close(d2)
+
+  -- Ambiguous prefix
+  local resolved, err = init.resolve_session(cwd, "01KGWCCCCC")
+  assert(not resolved, "ambiguous prefix should fail")
+  assert(err:match("ambiguous"), "error should mention ambiguous: " .. tostring(err))
+end
+test_resolve_session_ambiguous()
+
+local function test_resolve_session_not_found()
+  local cwd = fs.join(TEST_TMPDIR, "sessions_notfound")
+  local ah_dir = fs.join(cwd, ".ah")
+  fs.makedirs(ah_dir)
+
+  local resolved, err = init.resolve_session(cwd, "NOTEXIST")
+  assert(not resolved, "non-existent should fail")
+  assert(err:match("no session"), "error should mention no session: " .. tostring(err))
+end
+test_resolve_session_not_found()
 
 print("all init tests passed")


### PR DESCRIPTION
## Summary

- Change session storage from single `.ah/ah.db` to `.ah/<ulid>.db` per session
- Add `ah sessions` command to list all sessions with metadata (message count, first prompt preview)
- Add `-n/--new` flag to force creation of a new session
- Add `-S/--session ULID` flag to switch to a specific session (supports prefix matching)
- Default behavior now continues the most recent session by ULID

## Test plan

- [x] Tests pass (`make test`)
- [ ] `ah "hello"` creates new session in `.ah/<ulid>.db`
- [ ] `ah "follow up"` continues same session
- [ ] `ah -n "new topic"` creates new session
- [ ] `ah sessions` lists sessions with previews
- [ ] `ah -S <prefix> "continue"` switches to specific session