### PR TITLE
ah: add embed/extract commands for customization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,14 @@ $(o)/embed/.lua/%.lua: $(o)/lib/%.lua
 	@mkdir -p $(@D)
 	@cp $< $@
 
-$(o)/bin/ah: $(o)/embed/main.lua $(ah_lib_lua) $(ah_dep_lua) $(cosmic)
+$(o)/embed/embed/sys/%: sys/%
+	@mkdir -p $(@D)
+	@cp $< $@
+
+ah_sys_files := $(shell find sys -type f 2>/dev/null)
+ah_sys := $(patsubst sys/%,$(o)/embed/embed/sys/%,$(ah_sys_files))
+
+$(o)/bin/ah: $(o)/embed/main.lua $(ah_lib_lua) $(ah_dep_lua) $(ah_sys) $(cosmic)
 	@echo "==> embedding ah"
 	@$(cosmic) --embed $(o)/embed --output $@
 

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -5,6 +5,10 @@ local json = require("cosmic.json")
 local getopt = require("cosmic.getopt")
 local unix = require("cosmo.unix")
 
+local cosmo = require("cosmo")
+local zip = require("cosmic.zip")
+local embed = require("cosmic.embed")
+local pathlib = require("cosmo.path")
 local db = require("ah.db")
 local api = require("ah.api")
 local tools = require("ah.tools")
@@ -26,32 +30,42 @@ global interrupted: boolean = false
 local DEFAULT_SYSTEM_PROMPT = [[You are a coding assistant. Tools: read, write, edit, bash.
 read: examine files. edit: precise text replacement. write: create new files. bash: run commands.]]
 
--- Load CLAUDE.md from current directory
+-- Load CLAUDE.md with embedded base prepended
 local function load_claude_md(cwd: string): string
   cwd = cwd or fs.getcwd()
-  local content = cio.slurp(fs.join(cwd, "CLAUDE.md"))
-  if content then
-    return "\n\n# Project Context\n\n" .. content
+  local result = ""
+
+  -- Load embedded base claude.md first
+  local sys_claude = cio.slurp("/zip/embed/sys/claude.md")
+  if sys_claude then
+    result = "\n\n" .. sys_claude
   end
-  return ""
+
+  -- Append project CLAUDE.md
+  local project_claude = cio.slurp(fs.join(cwd, "CLAUDE.md"))
+  if project_claude then
+    result = result .. "\n\n# Project Context\n\n" .. project_claude
+  end
+
+  return result
 end
 
 -- Load system prompt with precedence:
--- 1. cli_system (via -s flag) if set
--- 2. .ah/SYSTEM.md (project) if exists
--- 3. DEFAULT_SYSTEM_PROMPT
+-- 1. /zip/embed/system.md (user override)
+-- 2. /zip/embed/sys/system.md (ah default)
 -- CLAUDE.md is always appended
-local function load_system_prompt(cli_system: string, cwd: string): string
+local function load_system_prompt(cwd: string): string
   cwd = cwd or fs.getcwd()
   local claude_md = load_claude_md(cwd)
 
-  if cli_system then
-    return cli_system .. claude_md
+  local user_system = cio.slurp("/zip/embed/system.md")
+  if user_system then
+    return user_system .. claude_md
   end
 
-  local project_system = cio.slurp(fs.join(cwd, ".ah", "SYSTEM.md"))
-  if project_system then
-    return project_system .. claude_md
+  local sys_system = cio.slurp("/zip/embed/sys/system.md")
+  if sys_system then
+    return sys_system .. claude_md
   end
 
   return DEFAULT_SYSTEM_PROMPT .. claude_md
@@ -136,13 +150,14 @@ commands:
   scan                list messages in current branch
   show [N]            show message(s)
   rmm N...            remove messages
+  embed <dir>         embed files into /zip/embed/
+  extract <dir>       extract /zip/embed/ to directory
 
 options:
   -h, --help          show this help
   -n, --new           start a new session
   -S, --session ULID  use specific session (prefix match)
   --db PATH           use custom database path (default: .ah/<ulid>.db)
-  -s, --system PROMPT set system prompt for this invocation
   -m, --model MODEL   set model (e.g., claude-sonnet-4-20250514)
 ]])
 end
@@ -488,9 +503,9 @@ local function cmd_rmm(d: db.DB, seqs: {integer})
 end
 
 local function main(args: {string}): integer, string
-  local system_prompt: string = nil
   local model: string = nil
   local db_path: string = nil
+  local output_path: string = nil
   local new_session: boolean = false
   local session_prefix: string = nil
   local cwd = fs.getcwd()
@@ -500,11 +515,11 @@ local function main(args: {string}): integer, string
     {name = "new", has_arg = "none", short = "n"},
     {name = "session", has_arg = "required", short = "S"},
     {name = "db", has_arg = "required"},
-    {name = "system", has_arg = "required", short = "s"},
     {name = "model", has_arg = "required", short = "m"},
+    {name = "output", has_arg = "required", short = "o"},
   }
 
-  local parser = getopt.new(args, "hnS:s:m:", longopts)
+  local parser = getopt.new(args, "hnS:m:o:", longopts)
 
   while true do
     local opt, optarg = parser:next()
@@ -519,10 +534,10 @@ local function main(args: {string}): integer, string
       session_prefix = optarg
     elseif opt == "db" then
       db_path = optarg
-    elseif opt == "s" or opt == "system" then
-      system_prompt = optarg
     elseif opt == "m" or opt == "model" then
       model = optarg
+    elseif opt == "o" or opt == "output" then
+      output_path = optarg
     elseif opt == "?" then
       usage()
       return 1
@@ -531,13 +546,70 @@ local function main(args: {string}): integer, string
 
   local remaining = parser:remaining() or {}
 
-  -- Handle sessions command first (doesn't need db)
+  -- Handle commands that don't need db
   local cmd = remaining[1]
   if cmd == "sessions" then
-    -- For sessions command, we need to know which would be default
     local sessions = list_sessions(cwd)
     local current_ulid = sessions[1] and sessions[1].ulid or ""
     cmd_sessions(cwd, current_ulid)
+    return 0
+
+  elseif cmd == "embed" then
+    local src_dir = remaining[2]
+    if not src_dir then
+      io.stderr:write("usage: ah embed <dir> [-o <file>]\n")
+      return 1
+    end
+    -- Create temp structure with embed/ prefix
+    local tmpdir = unix.mkdtemp("/tmp/ah-embed-XXXXXX")
+    local embed_link = pathlib.join(tmpdir, "embed")
+    unix.symlink(fs.realpath(src_dir), embed_link)
+    local result = embed.run({tmpdir}, output_path)
+    unix.rmrf(tmpdir)
+    if result.ok then
+      io.write(result.message .. "\n")
+      return 0
+    else
+      io.stderr:write("embed: " .. result.message .. "\n")
+      return 1
+    end
+
+  elseif cmd == "extract" then
+    local output_dir = remaining[2]
+    if not output_dir then
+      io.stderr:write("usage: ah extract <dir>\n")
+      return 1
+    end
+    -- Extract only files from embed/ prefix
+    local exe_path = arg[-1]
+    local exe_data = cosmo.Slurp(exe_path)
+    if not exe_data then
+      io.stderr:write("extract: cannot read executable\n")
+      return 1
+    end
+    local reader, err = zip.from(exe_data)
+    if not reader then
+      io.stderr:write("extract: " .. (err or "no zip archive found") .. "\n")
+      return 1
+    end
+    local prefix = "embed/"
+    local entries = reader:list()
+    local count = 0
+    for _, name in ipairs(entries) do
+      if name:sub(1, #prefix) == prefix and name:sub(-1) ~= "/" then
+        local content = reader:read(name)
+        if content then
+          local rel_name = name:sub(#prefix + 1)
+          local filepath = pathlib.join(output_dir, rel_name)
+          local dir = pathlib.dirname(filepath)
+          unix.makedirs(dir)
+          cosmo.Barf(filepath, content)
+          count = count + 1
+        end
+      end
+    end
+    reader:close()
+    io.write("extracted " .. count .. " file(s) to " .. output_dir .. "\n")
     return 0
   end
 
@@ -647,7 +719,7 @@ local function main(args: {string}): integer, string
   end
 
   -- Load system prompt
-  local effective_system = load_system_prompt(system_prompt, nil)
+  local effective_system = load_system_prompt(cwd)
 
   -- Initialize custom tools
   tools.init_custom_tools()

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -12,29 +12,10 @@ local function test_load_system_prompt_default()
   local empty_dir = fs.join(TEST_TMPDIR, "empty")
   fs.makedirs(empty_dir)
 
-  local prompt = init.load_system_prompt(nil, empty_dir)
+  local prompt = init.load_system_prompt(empty_dir)
   assert(prompt == init.DEFAULT_SYSTEM_PROMPT, "should use default prompt when no files exist")
 end
 test_load_system_prompt_default()
-
-local function test_load_system_prompt_cli_override()
-  -- -s flag should take precedence over everything
-  local prompt = init.load_system_prompt("Custom via -s", TEST_TMPDIR)
-  assert(prompt:match("Custom via %-s"), "cli prompt should override")
-end
-test_load_system_prompt_cli_override()
-
-local function test_load_system_prompt_project()
-  local cwd = fs.join(TEST_TMPDIR, "cwd_proj")
-  local project_ah = fs.join(cwd, ".ah")
-  fs.makedirs(project_ah)
-
-  cio.barf(fs.join(project_ah, "SYSTEM.md"), "Project system prompt")
-
-  local prompt = init.load_system_prompt(nil, cwd)
-  assert(prompt:match("Project system prompt"), "should load project SYSTEM.md")
-end
-test_load_system_prompt_project()
 
 local function test_load_claude_md()
   local cwd = fs.join(TEST_TMPDIR, "cwd_claude")
@@ -58,29 +39,15 @@ test_load_claude_md_missing()
 
 local function test_load_system_prompt_with_claude_md()
   local cwd = fs.join(TEST_TMPDIR, "cwd_with_claude")
-  local project_ah = fs.join(cwd, ".ah")
-  fs.makedirs(project_ah)
+  fs.makedirs(cwd)
 
-  cio.barf(fs.join(project_ah, "SYSTEM.md"), "You are a coding assistant.")
   cio.barf(fs.join(cwd, "CLAUDE.md"), "This is my project context")
 
-  local prompt = init.load_system_prompt(nil, cwd)
-  assert(prompt:match("You are a coding assistant"), "should include system prompt")
+  local prompt = init.load_system_prompt(cwd)
   assert(prompt:match("Project Context"), "should have CLAUDE.md header")
   assert(prompt:match("This is my project context"), "should append CLAUDE.md content")
 end
 test_load_system_prompt_with_claude_md()
-
-local function test_cli_prompt_with_claude_md()
-  local cwd = fs.join(TEST_TMPDIR, "cwd_cli_claude")
-  fs.makedirs(cwd)
-  cio.barf(fs.join(cwd, "CLAUDE.md"), "Project notes here")
-
-  local prompt = init.load_system_prompt("Custom prompt", cwd)
-  assert(prompt:match("Custom prompt"), "should use cli prompt")
-  assert(prompt:match("Project notes here"), "should append CLAUDE.md to cli prompt")
-end
-test_cli_prompt_with_claude_md()
 
 -- Tests for tool_key_param
 local function test_tool_key_param_bash()

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -494,10 +494,27 @@ local function init_custom_tools()
   local home = os.getenv("HOME") or ""
   local cwd = fs.getcwd()
 
-  -- Load Lua module tools from .ah/tools/
+  -- Load Lua module tools: embedded sys -> global -> project (later overrides earlier)
+  local sys_tools = load_custom_tools_from_dir("/zip/embed/sys/tools")
   local global_tools_dir = fs.join(home, ".ah", "tools")
   local project_tools_dir = fs.join(cwd, ".ah", "tools")
-  custom_tools = load_custom_tools(global_tools_dir, project_tools_dir)
+  local user_tools = load_custom_tools(global_tools_dir, project_tools_dir)
+
+  -- Merge: user tools override sys tools
+  custom_tools = sys_tools
+  for _, tool in ipairs(user_tools) do
+    local found = false
+    for i, existing in ipairs(custom_tools) do
+      if existing.name == tool.name then
+        custom_tools[i] = tool
+        found = true
+        break
+      end
+    end
+    if not found then
+      table.insert(custom_tools, tool)
+    end
+  end
 
   -- Load CLI tools from .ah/bin/
   local global_bin_dir = fs.join(home, ".ah", "bin")

--- a/sys/claude.md
+++ b/sys/claude.md
@@ -1,0 +1,16 @@
+# ah
+
+You are running inside `ah`, a minimal agent harness.
+
+## Tools
+
+- `read`: Read file contents
+- `write`: Create or overwrite files
+- `edit`: Find and replace text in files
+- `bash`: Execute shell commands
+
+## Guidelines
+
+- Be concise and direct
+- Prefer editing existing files over creating new ones
+- Use bash for system commands, not for file operations

--- a/sys/system.md
+++ b/sys/system.md
@@ -1,0 +1,2 @@
+You are a coding assistant. Tools: read, write, edit, bash.
+read: examine files. edit: precise text replacement. write: create new files. bash: run commands.


### PR DESCRIPTION
## Summary

- Add `ah extract <dir>` to extract bundled files from /zip/embed/
- Add `ah embed <dir> [-o file]` to create customized ah binaries
- Move system defaults to /zip/embed/sys/ (system.md, claude.md, tools/)
- Remove -s/--system CLI flag in favor of embedded configuration

## Test plan

- [x] `ah extract` extracts sys/system.md and sys/claude.md
- [x] `ah embed` creates working binary with modified defaults
- [x] Roundtrip: extract → modify → embed preserves changes
- [x] All existing tests pass