### PR TITLE
Add help system and tools command to ah CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,17 @@ $(o)/embed/embed/sys/%: sys/%
 	@mkdir -p $(@D)
 	@cp $< $@
 
+$(o)/embed/embed/scenarios/%: scenarios/%
+	@mkdir -p $(@D)
+	@cp $< $@
+
 ah_sys_files := $(shell find sys -type f 2>/dev/null)
 ah_sys := $(patsubst sys/%,$(o)/embed/embed/sys/%,$(ah_sys_files))
 
-$(o)/bin/ah: $(o)/embed/main.lua $(ah_lib_lua) $(ah_dep_lua) $(ah_sys) $(cosmic)
+ah_scenario_files := $(shell find scenarios -type f 2>/dev/null)
+ah_scenarios := $(patsubst scenarios/%,$(o)/embed/embed/scenarios/%,$(ah_scenario_files))
+
+$(o)/bin/ah: $(o)/embed/main.lua $(ah_lib_lua) $(ah_dep_lua) $(ah_sys) $(ah_scenarios) $(cosmic)
 	@echo "==> embedding ah"
 	@$(cosmic) --embed $(o)/embed --output $@
 

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -139,6 +139,86 @@ local function resolve_session(cwd: string, prefix: string): string, string
   return matches[1], nil
 end
 
+-- List embedded help topics from /zip/embed/scenarios/
+local function list_help_topics(): {string}
+  local topics: {string} = {}
+  local dir = unix.opendir("/zip/embed/scenarios")
+  if not dir then return topics end
+
+  while true do
+    local name = dir:read()
+    if not name then break end
+    if name:match("%.md$") then
+      table.insert(topics, name:sub(1, -4))
+    end
+  end
+  dir:close()
+  table.sort(topics)
+  return topics
+end
+
+-- Show help topic content
+local function read_help_topic(topic: string): string
+  local content = cio.slurp("/zip/embed/scenarios/" .. topic .. ".md")
+  return content
+end
+
+-- help command: list topics or show a specific one
+local function cmd_help(topic: string)
+  if not topic or topic == "" then
+    io.write("ah — an agent harness\n\n")
+    io.write("topics:\n")
+    local topics = list_help_topics()
+    if #topics == 0 then
+      io.write("  (no topics found)\n")
+    else
+      for _, t in ipairs(topics) do
+        -- Read first non-heading, non-empty line as summary
+        local content = read_help_topic(t)
+        local summary = ""
+        if content then
+          for line in content:gmatch("[^\n]+") do
+            local trimmed = line:match("^%s*(.-)%s*$")
+            if trimmed and trimmed ~= "" and not trimmed:match("^#") then
+              -- Strip leading bullet, backtick-wrapped name, and markdown bold
+              summary = trimmed:gsub("^%- ", ""):gsub("^`ah` ", ""):gsub("%*%*(.-)%*%*", "%1")
+              break
+            end
+          end
+        end
+        if summary ~= "" then
+          io.write(string.format("  %-14s %s\n", t, summary))
+        else
+          io.write(string.format("  %s\n", t))
+        end
+      end
+    end
+    io.write("\nrun 'ah help <topic>' for details\n")
+    io.write("run 'ah tools' to list available tools\n")
+    return
+  end
+
+  local content = read_help_topic(topic)
+  if not content then
+    io.stderr:write("unknown topic: " .. topic .. "\n")
+    io.stderr:write("run 'ah help' to list topics\n")
+    return
+  end
+  io.write(content)
+end
+
+-- tools command: list available tools with descriptions
+local function cmd_tools()
+  -- Initialize custom tools so we see everything
+  tools.init_custom_tools()
+  local defs = tools.get_tool_definitions(false)
+  io.write("tools:\n")
+  for _, d in ipairs(defs) do
+    local def = d as {string:any}
+    io.write(string.format("  %-14s %s\n", def.name, def.description))
+  end
+end
+
 local function usage()
   io.stderr:write([[usage: ah [options] [command] [args...]
 
@@ -146,6 +226,8 @@ commands:
   <prompt>            send prompt to agent
   (no args)           continue from last message
   @N <prompt>         fork from message N with new prompt
+  help [topic]        show help topics or a specific topic
+  tools               list available tools
   sessions            list all sessions
   scan                list messages in current branch
   show [N]            show message(s)
@@ -548,7 +630,15 @@ local function main(args: {string}): integer, string
 
   -- Handle commands that don't need db
   local cmd = remaining[1]
-  if cmd == "sessions" then
+  if cmd == "help" then
+    cmd_help(remaining[2])
+    return 0
+
+  elseif cmd == "tools" then
+    cmd_tools()
+    return 0
+
+  elseif cmd == "sessions" then
     local sessions = list_sessions(cwd)
     local current_ulid = sessions[1] and sessions[1].ulid or ""
     cmd_sessions(cwd, current_ulid)
@@ -743,5 +833,7 @@ return {
   tool_key_param = tool_key_param,
   list_sessions = list_sessions,
   resolve_session = resolve_session,
+  list_help_topics = list_help_topics,
+  read_help_topic = read_help_topic,
   DEFAULT_SYSTEM_PROMPT = DEFAULT_SYSTEM_PROMPT,
 }

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -215,4 +215,44 @@ local function test_resolve_session_not_found()
 end
 test_resolve_session_not_found()
 
+-- Help system tests
+
+local function test_list_help_topics_no_archive()
+  -- When not running from archive, /zip/embed/scenarios won't exist
+  -- Should return empty list gracefully
+  local topics = init.list_help_topics()
+  assert(type(topics) == "table", "should return table")
+  -- May be empty (no archive) or populated (running from archive)
+  -- Either way it should not error
+end
+test_list_help_topics_no_archive()
+
+local function test_read_help_topic_missing()
+  -- Reading a nonexistent topic should return nil
+  local content = init.read_help_topic("nonexistent_topic_xyz")
+  assert(content == nil, "should return nil for missing topic")
+end
+test_read_help_topic_missing()
+
+local function test_main_help()
+  -- ah help should return 0
+  local code, err = init.main({"help"})
+  assert(code == 0, "help should succeed: " .. tostring(err))
+end
+test_main_help()
+
+local function test_main_help_unknown_topic()
+  -- ah help <unknown> should still return 0 (prints error to stderr)
+  local code, err = init.main({"help", "nonexistent_xyz"})
+  assert(code == 0, "help unknown topic should return 0: " .. tostring(err))
+end
+test_main_help_unknown_topic()
+
+local function test_main_tools()
+  -- ah tools should return 0
+  local code, err = init.main({"tools"})
+  assert(code == 0, "tools should succeed: " .. tostring(err))
+end
+test_main_tools()
+
 print("all init tests passed")


### PR DESCRIPTION
## Summary
This PR adds a built-in help system and tools listing command to the ah CLI, allowing users to discover available functionality without leaving the application.

## Key Changes

- **Help System**: Added `ah help [topic]` command that displays embedded markdown documentation from a new `scenarios/` directory
  - `list_help_topics()`: Scans `/zip/embed/scenarios/` for `.md` files and returns sorted list
  - `read_help_topic()`: Reads and returns the content of a specific help topic
  - `cmd_help()`: Main help command handler that lists all topics with summaries or displays a specific topic

- **Tools Command**: Added `ah tools` command that lists all available tools with descriptions
  - `cmd_tools()`: Initializes custom tools and displays formatted tool list

- **Build System**: Updated Makefile to embed scenario files
  - Added new build rule to copy scenario files into the embed directory
  - Added `ah_scenarios` variable to track scenario files
  - Updated `$(o)/bin/ah` target to include scenario files in the binary

- **Usage Documentation**: Updated help text to document new commands

- **Tests**: Added comprehensive test coverage for the new help system
  - Tests for listing help topics (graceful handling when archive unavailable)
  - Tests for reading missing topics
  - Tests for main() command routing with help and tools commands

## Implementation Details

- Help topics are extracted from markdown files in the `scenarios/` directory, embedded into the binary via the cosmic build tool
- Topic summaries are extracted from the first non-heading, non-empty line of each markdown file, with markdown formatting stripped
- Both `help` and `tools` commands return exit code 0 and don't require database access
- The help system gracefully handles missing topics and archives (returns empty list or nil)

https://claude.ai/code/session_011RFsNFxrYQiRLo38qx1FLt