### PR TITLE
db: add signal safety for sqlite operations

### DIFF
--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -1,6 +1,7 @@
 -- ah/db.lua: SQLite storage for conversation tree
 local fs = require("cosmic.fs")
 local sqlite = require("cosmic.sqlite")
+local unix = require("cosmo.unix")
 local ulid = require("ulid")
 
 local SCHEMA = [[
@@ -108,18 +109,40 @@ local function open(db_path?: string): DB, string
     return nil, "failed to open database: " .. db_path .. ": " .. (err or "")
   end
 
-  local ok, schema_err = db:exec(SCHEMA)
+  -- Enable WAL mode for better crash recovery and concurrent access
+  local ok, pragma_err = db:exec("pragma journal_mode=wal")
   if not ok then
     db:close()
-    return nil, "failed to initialize schema: " .. (schema_err or "")
+    return nil, "failed to enable WAL mode: " .. (pragma_err or "")
   end
 
-  -- Enable WAL mode for better crash recovery and concurrent access
-  db:exec("PRAGMA journal_mode=WAL")
+  -- Set busy timeout to wait up to 5 seconds for locks
+  ok, pragma_err = db:exec("pragma busy_timeout=5000")
+  if not ok then
+    db:close()
+    return nil, "failed to set busy timeout: " .. (pragma_err or "")
+  end
+
   -- Ensure writes are synced to disk (safety over speed)
-  db:exec("PRAGMA synchronous=NORMAL")
+  db:exec("pragma synchronous=normal")
+
+  ok, pragma_err = db:exec(SCHEMA)
+  if not ok then
+    db:close()
+    return nil, "failed to initialize schema: " .. (pragma_err or "")
+  end
 
   return {_db = db} as DB, nil
+end
+
+-- Block signals during a database write operation to prevent corruption
+local function with_signals_blocked(fn: function())
+  local old_mask = unix.sigprocmask(unix.SIG_BLOCK, unix.Sigset(unix.SIGINT, unix.SIGTERM))
+  local ok, err = pcall(fn) as (boolean, string)
+  unix.sigprocmask(unix.SIG_SETMASK, old_mask)
+  if not ok then
+    error(err)
+  end
 end
 
 local function close(self: DB)
@@ -150,7 +173,9 @@ local function get_context(self: DB, key: string): string
 end
 
 local function set_context(self: DB, key: string, value: string)
-  self._db:exec("insert or replace into context (key, value) values (?, ?)", key, value)
+  with_signals_blocked(function()
+    self._db:exec("insert or replace into context (key, value) values (?, ?)", key, value)
+  end)
 end
 
 -- Message operations
@@ -172,12 +197,14 @@ local function create_message(self: DB, role: string, parent_id?: string): Messa
     end
   end
 
-  self._db:exec([[
-    insert into messages (id, parent_id, role, seq, created_at)
-    values (?, ?, ?, ?, ?)
-  ]], id, parent_id, role, seq, now)
+  with_signals_blocked(function()
+    self._db:exec([[
+      insert into messages (id, parent_id, role, seq, created_at)
+      values (?, ?, ?, ?, ?)
+    ]], id, parent_id, role, seq, now)
 
-  set_context(self, "current_message", id)
+    self._db:exec("insert or replace into context (key, value) values (?, ?)", "current_message", id)
+  end)
 
   return {
     id = id,
@@ -233,13 +260,15 @@ local function get_last_message(self: DB): Message
 end
 
 local function delete_message(self: DB, id: string)
-  self._db:exec("delete from content_blocks where message_id = ?", id)
-  self._db:exec("delete from messages where id = ?", id)
-
   local current = get_context(self, "current_message")
-  if current == id then
-    self._db:exec("delete from context where key = 'current_message'")
-  end
+  with_signals_blocked(function()
+    self._db:exec("delete from content_blocks where message_id = ?", id)
+    self._db:exec("delete from messages where id = ?", id)
+
+    if current == id then
+      self._db:exec("delete from context where key = 'current_message'")
+    end
+  end)
 end
 
 -- Content block operations
@@ -254,18 +283,20 @@ local function add_content_block(self: DB, message_id: string, block_type: strin
     end
   end
 
-  self._db:exec([[
-    insert into content_blocks (id, message_id, block_type, seq, content, tool_id, tool_name, tool_input, tool_output, is_error)
-    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  ]],
-    id, message_id, block_type, seq,
-    opts.content,
-    opts.tool_id,
-    opts.tool_name,
-    opts.tool_input,
-    opts.tool_output,
-    opts.is_error and 1 or 0
-  )
+  with_signals_blocked(function()
+    self._db:exec([[
+      insert into content_blocks (id, message_id, block_type, seq, content, tool_id, tool_name, tool_input, tool_output, is_error)
+      values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ]],
+      id, message_id, block_type, seq,
+      opts.content,
+      opts.tool_id,
+      opts.tool_name,
+      opts.tool_input,
+      opts.tool_output,
+      opts.is_error and 1 or 0
+    )
+  end)
 
   return {
     id = id,
@@ -313,12 +344,14 @@ local function update_content_block(self: DB, id: string, opts: UpdateOpts)
 
   table.insert(values, id)
   local sql = "update content_blocks set " .. table.concat(sets, ", ") .. " where id = ?"
-  local stmt = self._db:prepare(sql)
-  if stmt then
-    stmt:bind(table.unpack(values))
-    stmt:exec()
-    stmt:close()
-  end
+  with_signals_blocked(function()
+    local stmt = self._db:prepare(sql)
+    if stmt then
+      stmt:bind(table.unpack(values))
+      stmt:exec()
+      stmt:close()
+    end
+  end)
 end
 
 local function get_message_by_seq(self: DB, seq: integer): Message


### PR DESCRIPTION
## Summary

- Block SIGINT/SIGTERM during database writes to prevent corruption from interrupted SQLite transactions
- Add busy_timeout pragma (5s) to handle lock contention gracefully
- Move WAL/synchronous pragmas before schema execution to fail fast on errors

## Background

A segfault occurred when a signal interrupted SQLite mid-transaction, causing a null cursor dereference in `sqlite3VdbeExec`. The crash happened at vdbe.c:6300 where `pC = p->apCsr[pOp->p1]` returned NULL.

## Test plan

- [x] All existing tests pass
- [x] Manual verification that db operations complete atomically