### PR TITLE
db: add session analytics for debugging and analysis

### DIFF
--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -1,8 +1,15 @@
 -- ah/api.lua: Claude Messages API with streaming
 local json = require("cosmic.json")
 local fetch = require("cosmic.fetch")
+local unix = require("cosmo.unix")
 local auth = require("ah.auth")
 local tools_mod = require("ah.tools")
+
+-- Get monotonic time in milliseconds
+local function now_ms(): integer
+  local s, ns = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  return math.floor(s * 1000 + ns / 1e6) as integer
+end
 
 local API_URL = "https://api.anthropic.com/v1/messages"
 local DEFAULT_MODEL = "claude-sonnet-4-20250514"
@@ -145,9 +152,14 @@ local function stream(messages: {any}, opts: {string:any}, callback: function({s
   opts = opts or {}
   opts.stream = true
 
+  local model = (opts.model or DEFAULT_MODEL) as string
   local req = build_request(messages, opts, creds.is_oauth or false)
   local auth_headers = auth.get_auth_headers(creds)
   local body = json.encode(req)
+
+  -- Track timing and retries
+  local start_ms = now_ms()
+  local retries: {{string:any}} = {}
 
   -- Retry loop for transient errors
   local result: fetch.Result = nil
@@ -166,6 +178,7 @@ local function stream(messages: {any}, opts: {string:any}, callback: function({s
       -- Network errors are retryable
       if attempt < MAX_RETRIES then
         local delay_ms = BASE_DELAY_MS * (2 ^ attempt)
+        table.insert(retries, {attempt = attempt, error = last_error, delay_ms = delay_ms})
         sleep_ms(delay_ms as integer)
       end
     elseif result.status == 200 then
@@ -185,6 +198,7 @@ local function stream(messages: {any}, opts: {string:any}, callback: function({s
         if delay_ms > MAX_RETRY_DELAY_MS then
           return nil, last_error
         end
+        table.insert(retries, {attempt = attempt, status = status, error = last_error, delay_ms = delay_ms})
         sleep_ms(delay_ms)
       else
         return nil, last_error
@@ -267,6 +281,15 @@ local function stream(messages: {any}, opts: {string:any}, callback: function({s
       if b.type == "tool_use" and b.name then
         b.name = tools_mod.from_claude_code_name(b.name as string)
       end
+    end
+  end
+
+  -- Add timing and metadata
+  if response then
+    response.api_latency_ms = now_ms() - start_ms
+    response.model = model
+    if #retries > 0 then
+      response.retries = retries
     end
   end
 

--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -1,8 +1,52 @@
 -- ah/db.lua: SQLite storage for conversation tree
 local fs = require("cosmic.fs")
 local sqlite = require("cosmic.sqlite")
+local sqlite3 = require("cosmo.lsqlite3")
 local unix = require("cosmo.unix")
 local ulid = require("ulid")
+
+-- Helper types for raw sqlite3 access
+local record RawStmt
+  bind: function(RawStmt, integer, any)
+  step: function(RawStmt): integer
+  finalize: function(RawStmt)
+end
+
+local record RawDb
+  prepare: function(RawDb, string): RawStmt
+  errmsg: function(RawDb): string
+end
+
+local record DbWrapper
+  exec: function
+end
+
+-- Helper to execute SQL with proper nil handling
+-- The cosmic.sqlite varargs API drops trailing nils, so we use raw lsqlite3
+-- We access the raw db via debug.getupvalue since cosmic.sqlite doesn't expose it
+local function exec_with_nils(db: DbWrapper, sql: string, values: {any}, count: integer): boolean, string
+  -- Get raw_db from the exec function's upvalues (exec is the first method in the wrapper)
+  local exec_fn = db.exec
+  local _, raw_db_any = debug.getupvalue(exec_fn, 1)
+  if not raw_db_any then
+    return false, "cannot access raw database"
+  end
+  local raw_db = raw_db_any as RawDb
+
+  local stmt = raw_db:prepare(sql)
+  if not stmt then
+    return false, raw_db:errmsg()
+  end
+  for i = 1, count do
+    stmt:bind(i, values[i])
+  end
+  local rc = stmt:step()
+  stmt:finalize()
+  if rc ~= sqlite3.DONE and rc ~= sqlite3.ROW then
+    return false, raw_db:errmsg()
+  end
+  return true, nil
+end
 
 local SCHEMA = [[
 create table if not exists messages (
@@ -10,7 +54,12 @@ create table if not exists messages (
   parent_id text references messages(id),
   role text not null,
   seq integer not null,
-  created_at integer not null
+  created_at integer not null,
+  input_tokens integer,
+  output_tokens integer,
+  stop_reason text,
+  model text,
+  api_latency_ms integer
 );
 
 create table if not exists content_blocks (
@@ -23,7 +72,8 @@ create table if not exists content_blocks (
   tool_name text,
   tool_input text,
   tool_output text,
-  is_error integer default 0
+  is_error integer default 0,
+  duration_ms integer
 );
 
 create table if not exists context (
@@ -31,8 +81,18 @@ create table if not exists context (
   value text not null
 );
 
+create table if not exists events (
+  id text primary key,
+  message_id text references messages(id),
+  event_type text not null,
+  created_at integer not null,
+  details text
+);
+
 create index if not exists idx_messages_parent on messages(parent_id);
 create index if not exists idx_content_blocks_message on content_blocks(message_id);
+create index if not exists idx_events_message on events(message_id);
+create index if not exists idx_events_type on events(event_type);
 ]]
 
 -- Type definitions
@@ -59,6 +119,11 @@ local record Message
   role: string
   seq: integer
   created_at: integer
+  input_tokens: integer
+  output_tokens: integer
+  stop_reason: string
+  model: string
+  api_latency_ms: integer
 end
 
 local record ContentBlock
@@ -72,6 +137,7 @@ local record ContentBlock
   tool_input: string
   tool_output: string
   is_error: integer
+  duration_ms: integer
 end
 
 local record ContentBlockOpts
@@ -81,12 +147,29 @@ local record ContentBlockOpts
   tool_input: string
   tool_output: string
   is_error: boolean
+  duration_ms: integer
 end
 
 local record UpdateOpts
   content: string
   tool_output: string
   is_error: boolean
+end
+
+local record MessageOpts
+  input_tokens: integer
+  output_tokens: integer
+  stop_reason: string
+  model: string
+  api_latency_ms: integer
+end
+
+local record Event
+  id: string
+  message_id: string
+  event_type: string
+  created_at: integer
+  details: string
 end
 
 local function get_db_path(): string
@@ -186,9 +269,10 @@ local function get_message(self: DB, id: string): Message
   return nil
 end
 
-local function create_message(self: DB, role: string, parent_id?: string): Message
+local function create_message(self: DB, role: string, parent_id?: string, opts?: MessageOpts): Message
   local id = ulid.generate()
   local now = os.time()
+  opts = opts or {}
 
   local seq = 0
   if parent_id then
@@ -197,11 +281,14 @@ local function create_message(self: DB, role: string, parent_id?: string): Messa
     end
   end
 
+  -- Use exec_with_nils to properly handle nil values in the insert
+  local values: {any} = {id, parent_id, role, seq, now, opts.input_tokens, opts.output_tokens, opts.stop_reason, opts.model, opts.api_latency_ms}
+
   with_signals_blocked(function()
-    self._db:exec([[
-      insert into messages (id, parent_id, role, seq, created_at)
-      values (?, ?, ?, ?, ?)
-    ]], id, parent_id, role, seq, now)
+    exec_with_nils(self._db as DbWrapper, [[
+      insert into messages (id, parent_id, role, seq, created_at, input_tokens, output_tokens, stop_reason, model, api_latency_ms)
+      values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ]], values, 10)
 
     self._db:exec("insert or replace into context (key, value) values (?, ?)", "current_message", id)
   end)
@@ -212,6 +299,11 @@ local function create_message(self: DB, role: string, parent_id?: string): Messa
     role = role,
     seq = seq,
     created_at = now,
+    input_tokens = opts.input_tokens,
+    output_tokens = opts.output_tokens,
+    stop_reason = opts.stop_reason,
+    model = opts.model,
+    api_latency_ms = opts.api_latency_ms,
   }
 end
 
@@ -283,19 +375,23 @@ local function add_content_block(self: DB, message_id: string, block_type: strin
     end
   end
 
+  -- Use exec_with_nils to properly handle nil values in the insert
+  local values: {any} = {
+    id, message_id, block_type, seq,
+    opts.content,
+    opts.tool_id,
+    opts.tool_name,
+    opts.tool_input,
+    opts.tool_output,
+    opts.is_error and 1 or 0,
+    opts.duration_ms
+  }
+
   with_signals_blocked(function()
-    self._db:exec([[
-      insert into content_blocks (id, message_id, block_type, seq, content, tool_id, tool_name, tool_input, tool_output, is_error)
-      values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ]],
-      id, message_id, block_type, seq,
-      opts.content,
-      opts.tool_id,
-      opts.tool_name,
-      opts.tool_input,
-      opts.tool_output,
-      opts.is_error and 1 or 0
-    )
+    exec_with_nils(self._db as DbWrapper, [[
+      insert into content_blocks (id, message_id, block_type, seq, content, tool_id, tool_name, tool_input, tool_output, is_error, duration_ms)
+      values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ]], values, 11)
   end)
 
   return {
@@ -309,6 +405,7 @@ local function add_content_block(self: DB, message_id: string, block_type: strin
     tool_input = opts.tool_input,
     tool_output = opts.tool_output,
     is_error = opts.is_error and 1 or 0,
+    duration_ms = opts.duration_ms,
   }
 end
 
@@ -352,6 +449,50 @@ local function update_content_block(self: DB, id: string, opts: UpdateOpts)
       stmt:close()
     end
   end)
+end
+
+-- Event logging
+local function log_event(self: DB, event_type: string, message_id?: string, details?: string): Event
+  local id = ulid.generate()
+  local now = os.time()
+
+  -- Use exec_with_nils to properly handle nil values in the insert
+  local values: {any} = {id, message_id, event_type, now, details}
+
+  with_signals_blocked(function()
+    exec_with_nils(self._db as DbWrapper, [[
+      insert into events (id, message_id, event_type, created_at, details)
+      values (?, ?, ?, ?, ?)
+    ]], values, 5)
+  end)
+
+  return {
+    id = id,
+    message_id = message_id,
+    event_type = event_type,
+    created_at = now,
+    details = details,
+  }
+end
+
+local function get_events(self: DB, event_type?: string): {Event}
+  local events: {Event} = {}
+  local sql = "select * from events"
+  if event_type then
+    sql = sql .. " where event_type = ?"
+  end
+  sql = sql .. " order by created_at asc"
+
+  if event_type then
+    for row in self._db:query(sql, event_type) do
+      table.insert(events, row as Event)
+    end
+  else
+    for row in self._db:query(sql) do
+      table.insert(events, row as Event)
+    end
+  end
+  return events
 end
 
 local function get_message_by_seq(self: DB, seq: integer): Message
@@ -427,9 +568,13 @@ return {
   get_message_count = get_message_count,
   get_first_user_prompt = get_first_user_prompt,
   cleanup_orphans = cleanup_orphans,
+  log_event = log_event,
+  get_events = get_events,
   -- Export types for consumers
   DB = DB,
   Message = Message,
   ContentBlock = ContentBlock,
   ContentBlockOpts = ContentBlockOpts,
+  MessageOpts = MessageOpts,
+  Event = Event,
 }

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -327,9 +327,19 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
       end
     end
 
+    -- Extract usage and metadata from response
+    local usage = (resp.usage or {}) as {string:any}
+    local msg_opts: db.MessageOpts = {
+      input_tokens = usage.input_tokens as integer,
+      output_tokens = usage.output_tokens as integer,
+      stop_reason = resp.stop_reason as string,
+      model = resp.model as string,
+      api_latency_ms = resp.api_latency_ms as integer,
+    }
+
     -- Atomically write assistant message + all content blocks
     db.begin_transaction(d)
-    local assistant_msg = db.create_message(d, "assistant", user_msg.id)
+    local assistant_msg = db.create_message(d, "assistant", user_msg.id, msg_opts)
     for _, blk in ipairs(assistant_blocks) do
       if blk.block_type == "text" then
         db.add_content_block(d, assistant_msg.id, "text", {content = blk.content as string})
@@ -341,6 +351,16 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
         })
       end
     end
+
+    -- Log retry events if any occurred
+    local retries = resp.retries as {{string:any}}
+    if retries then
+      for _, retry in ipairs(retries) do
+        local retry_json = json.encode(retry)
+        db.log_event(d, "retry", assistant_msg.id, retry_json)
+      end
+    end
+
     db.commit(d)
 
     -- Add assistant message to API messages
@@ -429,11 +449,12 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
         end
       end
 
-      -- Collect for later atomic write
+      -- Collect for later atomic write (elapsed is in seconds, convert to ms)
       table.insert(tool_result_blocks, {
         tool_id = tc.id as string,
         tool_output = result,
         is_error = is_error,
+        duration_ms = math.floor(elapsed * 1000) as integer,
       })
 
       -- Add to API messages content
@@ -453,6 +474,7 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
         tool_id = blk.tool_id as string,
         tool_output = blk.tool_output as string,
         is_error = blk.is_error as boolean,
+        duration_ms = blk.duration_ms as integer,
       })
     end
     db.commit(d)

--- a/lib/ah/test_db.tl
+++ b/lib/ah/test_db.tl
@@ -291,4 +291,90 @@ local function test_empty_content_serialization()
 end
 test_empty_content_serialization()
 
+-- Test message metadata (tokens, model, latency)
+local function test_message_metadata()
+  local db_path = fs.join(TEST_TMPDIR, "metadata.db")
+  local d = db.open(db_path)
+
+  -- Create message without metadata
+  local msg1 = db.create_message(d, "user")
+  assert(msg1.input_tokens == nil, "user message should have nil input_tokens")
+  assert(msg1.model == nil, "user message should have nil model")
+
+  -- Create message with metadata
+  local msg2 = db.create_message(d, "assistant", msg1.id, {
+    input_tokens = 100,
+    output_tokens = 50,
+    stop_reason = "end_turn",
+    model = "claude-sonnet",
+    api_latency_ms = 1500,
+  })
+  assert(msg2.input_tokens == 100, "input_tokens mismatch")
+  assert(msg2.output_tokens == 50, "output_tokens mismatch")
+  assert(msg2.stop_reason == "end_turn", "stop_reason mismatch")
+  assert(msg2.model == "claude-sonnet", "model mismatch")
+  assert(msg2.api_latency_ms == 1500, "api_latency_ms mismatch")
+
+  db.close(d)
+end
+test_message_metadata()
+
+-- Test content block duration
+local function test_content_block_duration()
+  local db_path = fs.join(TEST_TMPDIR, "duration.db")
+  local d = db.open(db_path)
+
+  local msg = db.create_message(d, "user")
+
+  -- Add block without duration
+  local block1 = db.add_content_block(d, msg.id, "text", {content = "hello"})
+  assert(block1.duration_ms == nil, "text block should have nil duration")
+
+  -- Add tool result with duration
+  local block2 = db.add_content_block(d, msg.id, "tool_result", {
+    tool_id = "t1",
+    tool_output = "output",
+    duration_ms = 250,
+  })
+  assert(block2.duration_ms == 250, "duration_ms mismatch")
+
+  -- Verify via query
+  local blocks = db.get_content_blocks(d, msg.id)
+  assert(blocks[1].duration_ms == nil, "first block duration should be nil")
+  assert(blocks[2].duration_ms == 250, "second block duration should be 250")
+
+  db.close(d)
+end
+test_content_block_duration()
+
+-- Test event logging
+local function test_events()
+  local db_path = fs.join(TEST_TMPDIR, "events.db")
+  local d = db.open(db_path)
+
+  -- Log event without message
+  local evt1 = db.log_event(d, "startup")
+  assert(evt1.id, "event should have id")
+  assert(evt1.event_type == "startup", "event_type mismatch")
+  assert(evt1.message_id == nil, "message_id should be nil")
+  assert(evt1.created_at, "should have created_at")
+
+  -- Log event with message and details
+  local msg = db.create_message(d, "user")
+  local evt2 = db.log_event(d, "retry", msg.id, '{"attempt":1,"delay_ms":1000}')
+  assert(evt2.message_id == msg.id, "message_id mismatch")
+  assert(evt2.details == '{"attempt":1,"delay_ms":1000}', "details mismatch")
+
+  -- Query events
+  local all_events = db.get_events(d)
+  assert(#all_events == 2, "should have 2 events")
+
+  local retry_events = db.get_events(d, "retry")
+  assert(#retry_events == 1, "should have 1 retry event")
+  assert(retry_events[1].event_type == "retry", "filtered event type mismatch")
+
+  db.close(d)
+end
+test_events()
+
 print("all db tests passed")


### PR DESCRIPTION
## Summary

- Add metadata columns to messages table: `input_tokens`, `output_tokens`, `stop_reason`, `model`, `api_latency_ms`
- Add `duration_ms` column to content_blocks for tool execution timing
- Add new `events` table for logging retries, rate limits, and other diagnostic events
- Track API latency and retry events in api.tl
- Store metadata when writing assistant messages in init.tl

## Test plan

- [x] All existing tests pass
- [x] New tests for message metadata, content block duration, and events
- [x] Incremental builds work correctly