### PR TITLE
tools: fix edit tool crash on % in replacement string

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -43,6 +43,21 @@ local function test_edit_tool()
   print("✓ edit tool works")
 end
 
+local function test_edit_tool_percent_in_replacement()
+  local test_file = os.getenv("TEST_TMPDIR") .. "/test_edit_percent.txt"
+  tools.execute_tool("write", {path = test_file, content = "value = 100"})
+  local result, is_error = tools.execute_tool("edit", {
+    path = test_file,
+    old_string = "100",
+    new_string = "50%"
+  })
+  assert(not is_error, "edit with % should succeed: " .. (result or "nil"))
+
+  local content, _ = tools.execute_tool("read", {path = test_file})
+  assert(content:match("value = 50%%"), "content should have 50%")
+  print("✓ edit tool handles % in replacement string")
+end
+
 local function test_bash_tool()
   local result, is_error = tools.execute_tool("bash", {command = "echo hello"})
   assert(not is_error, "bash should succeed")
@@ -89,6 +104,7 @@ test_read_tool()
 test_read_nonexistent()
 test_write_tool()
 test_edit_tool()
+test_edit_tool_percent_in_replacement()
 test_bash_tool()
 test_bash_exit_code()
 

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -212,8 +212,9 @@ local edit_tool: Tool = {
       return "error: old_string is not unique (found " .. count .. " times)", true
     end
 
-    -- Perform replacement
-    local new_content = content:gsub(old_string:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1"), new_string, 1)
+    -- Perform replacement (escape % in replacement string)
+    local escaped_new = new_string:gsub("%%", "%%%%")
+    local new_content = content:gsub(old_string:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1"), escaped_new, 1)
 
     local ok = cio.barf(file_path, new_content, tonumber("644", 8))
     if not ok then


### PR DESCRIPTION
## Summary
- Fix crash when edit tool replacement string contains `%` character
- Lua's `string.gsub` interprets `%` as special in replacement strings (for back-references like `%1`)
- Escape `%` as `%%` before using as replacement

## Test plan
- [x] Added test case `test_edit_tool_percent_in_replacement` that replaces `100` with `50%`
- [x] All existing tests pass