### PR TITLE
sys: move default system prompt to sys/system.md

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -38,9 +38,6 @@ local function now(): number
   return s + ns / 1e9
 end
 
-local DEFAULT_SYSTEM_PROMPT = [[You are a coding assistant. Tools: read, write, edit, bash.
-read: examine files. edit: precise text replacement. write: create new files. bash: run commands.]]
-
 -- Load CLAUDE.md with embedded base prepended
 local function load_claude_md(cwd: string): string
   cwd = cwd or fs.getcwd()
@@ -79,7 +76,7 @@ local function load_system_prompt(cwd: string): string
     return sys_system .. claude_md
   end
 
-  return DEFAULT_SYSTEM_PROMPT .. claude_md
+  return claude_md
 end
 
 -- List session files from .ah/*.db with valid ULID names
@@ -888,5 +885,4 @@ return {
   tool_key_param = tool_key_param,
   list_sessions = list_sessions,
   resolve_session = resolve_session,
-  DEFAULT_SYSTEM_PROMPT = DEFAULT_SYSTEM_PROMPT,
 }

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -8,12 +8,12 @@ local db = require("ah.db")
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
 
 local function test_load_system_prompt_default()
-  -- No files exist, should use default
+  -- No files exist, should return empty string (system prompt comes from embedded .md)
   local empty_dir = fs.join(TEST_TMPDIR, "empty")
   fs.makedirs(empty_dir)
 
   local prompt = init.load_system_prompt(empty_dir)
-  assert(prompt == init.DEFAULT_SYSTEM_PROMPT, "should use default prompt when no files exist")
+  assert(prompt == "", "should return empty when no system.md or CLAUDE.md exist")
 end
 test_load_system_prompt_default()
 

--- a/sys/system.md
+++ b/sys/system.md
@@ -1,2 +1,3 @@
 You are a coding assistant. Tools: read, write, edit, bash.
 read: examine files. edit: precise text replacement. write: create new files. bash: run commands.
+Write in short, lowercase, declarative sentences. Be direct and matter-of-fact, like terse documentation.


### PR DESCRIPTION
## Summary
Refactored system prompt handling to consolidate the default prompt into `sys/system.md` rather than hardcoding it in the initialization code. This simplifies the codebase and makes the system prompt more maintainable.

## Changes
- Removed `DEFAULT_SYSTEM_PROMPT` constant from `lib/ah/init.tl`
- Updated `load_system_prompt()` to return only the loaded markdown content (or empty string if no files exist), removing the fallback to a hardcoded default
- Removed `DEFAULT_SYSTEM_PROMPT` from the module exports
- Updated test expectations in `lib/ah/test_init.tl` to reflect that an empty directory returns an empty string
- Enhanced `sys/system.md` with the default system prompt and added guidance on writing style (short, lowercase, declarative sentences)

## Implementation Details
The system prompt is now sourced entirely from `sys/system.md`, which is embedded and prepended to `CLAUDE.md` during initialization. This centralizes prompt configuration in a single, user-editable location rather than splitting it between code and markdown files.

https://claude.ai/code/session_011T97Vyg3HL7segWACqjVxJ