### PR TITLE
api: add model aliases and show models in help

### DIFF
--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -14,6 +14,24 @@ end
 local API_URL = "https://api.anthropic.com/v1/messages"
 local DEFAULT_MODEL = "claude-sonnet-4-20250514"
 local DEFAULT_MAX_TOKENS = 8192
+
+local MODELS: {string} = {
+  "claude-sonnet-4-20250514",
+  "claude-opus-4-20250514",
+  "claude-haiku-3-20250314",
+}
+
+local MODEL_ALIASES: {string:string} = {
+  ["sonnet"] = "claude-sonnet-4-20250514",
+  ["opus"] = "claude-opus-4-20250514",
+  ["haiku"] = "claude-haiku-3-20250314",
+}
+
+-- Resolve model name, expanding aliases
+local function resolve_model(name: string): string
+  if not name then return nil end
+  return MODEL_ALIASES[name] or name
+end
 local CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude."
 
 local MAX_RETRIES = 3
@@ -317,7 +335,10 @@ return {
   parse_api_error = parse_api_error,
   is_retryable_error = is_retryable_error,
   extract_retry_delay = extract_retry_delay,
+  resolve_model = resolve_model,
   DEFAULT_MODEL = DEFAULT_MODEL,
+  MODELS = MODELS,
+  MODEL_ALIASES = MODEL_ALIASES,
   MAX_RETRIES = MAX_RETRIES,
   BASE_DELAY_MS = BASE_DELAY_MS,
   MAX_RETRY_DELAY_MS = MAX_RETRY_DELAY_MS,

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -167,8 +167,13 @@ options:
   -n, --new           start a new session
   -S, --session ULID  use specific session (prefix match)
   --db PATH           use custom database path (default: .ah/<ulid>.db)
-  -m, --model MODEL   set model (e.g., claude-sonnet-4-20250514)
+  -m, --model MODEL   set model (default: sonnet)
+
+models:
 ]])
+  for alias, full in pairs(api.MODEL_ALIASES) do
+    io.stderr:write(string.format("  %-8s %s\n", alias, full))
+  end
 end
 
 -- Extract key parameter from tool input for display
@@ -879,8 +884,11 @@ local function main(args: {string}): integer, string
     interrupted = true
   end)
 
+  -- Resolve model alias
+  local effective_model = api.resolve_model(model)
+
   -- Run agent
-  run_agent(d, effective_system, model, prompt, parent_id)
+  run_agent(d, effective_system, effective_model, prompt, parent_id)
 
   db.close(d)
   return 0

--- a/lib/ah/test_api.tl
+++ b/lib/ah/test_api.tl
@@ -179,4 +179,18 @@ local function test_extract_retry_delay()
 end
 test_extract_retry_delay()
 
+local function test_resolve_model()
+  -- Aliases should resolve to full names
+  assert(api.resolve_model("sonnet") == "claude-sonnet-4-20250514", "sonnet alias")
+  assert(api.resolve_model("opus") == "claude-opus-4-20250514", "opus alias")
+  assert(api.resolve_model("haiku") == "claude-haiku-3-20250314", "haiku alias")
+  -- Full names should pass through
+  assert(api.resolve_model("claude-sonnet-4-20250514") == "claude-sonnet-4-20250514", "full name passthrough")
+  -- Unknown names should pass through
+  assert(api.resolve_model("custom-model") == "custom-model", "unknown passthrough")
+  -- Nil should return nil
+  assert(api.resolve_model(nil) == nil, "nil returns nil")
+end
+test_resolve_model()
+
 print("all api tests passed")


### PR DESCRIPTION
## Summary
- Add short model aliases: `sonnet`, `opus`, `haiku`
- Show available models in `--help` output
- Users can now use `-m opus` instead of `-m claude-opus-4-20250514`

## Test plan
- [x] `make test` passes
- [x] Test `resolve_model()` for aliases, full names, unknown names, and nil