### PR TITLE
tools: detect binary files in read tool

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -429,6 +429,34 @@ local function test_read_text_not_image()
 end
 test_read_text_not_image()
 
+local function test_read_binary_file()
+  -- Create a file with null bytes (binary indicator)
+  local bin_path = fs.join(TEST_TMPDIR, "test.bin")
+  cio.barf(bin_path, "MZ\0\0PE\0\0binary content\0\0more")
+
+  local result, is_error = tools.execute_tool("read", {path = bin_path})
+  assert(is_error, "should report error for binary file")
+  assert(result:match("binary file"), "should indicate binary: " .. result)
+  print("✓ read tool detects binary files")
+end
+test_read_binary_file()
+
+local function test_read_binary_by_control_chars()
+  -- Create a file with many control characters (binary indicator)
+  local bin_path = fs.join(TEST_TMPDIR, "test_ctrl.bin")
+  local content = ""
+  for i = 1, 100 do
+    content = content .. string.char(1) .. string.char(2) .. string.char(3)
+  end
+  cio.barf(bin_path, content)
+
+  local result, is_error = tools.execute_tool("read", {path = bin_path})
+  assert(is_error, "should report error for binary file with control chars")
+  assert(result:match("binary file"), "should indicate binary: " .. result)
+  print("✓ read tool detects binary by control character ratio")
+end
+test_read_binary_by_control_chars()
+
 -- Tool name normalization tests (for OAuth mode)
 local function test_to_claude_code_name()
   assert(tools.to_claude_code_name("read") == "Read", "read -> Read")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -14,6 +14,34 @@ local IMAGE_TYPES: {string:string} = {
   webp = "image/webp",
 }
 
+-- Check if content appears to be binary (contains null bytes or high ratio of non-printable chars)
+local function is_binary(content: string): boolean
+  -- Check first 8KB for null bytes or excessive non-printable characters
+  local sample_size = math.min(#content, 8192)
+  local sample = content:sub(1, sample_size)
+
+  -- Null byte is a strong indicator of binary
+  if sample:find("\0") then
+    return true
+  end
+
+  -- Count non-printable, non-whitespace characters
+  local non_printable = 0
+  for i = 1, #sample do
+    local b = sample:byte(i)
+    -- Allow printable ASCII (32-126), tab (9), newline (10), carriage return (13)
+    if not ((b >= 32 and b <= 126) or b == 9 or b == 10 or b == 13) then
+      -- Also allow valid UTF-8 continuation bytes (128-255)
+      if b < 128 then
+        non_printable = non_printable + 1
+      end
+    end
+  end
+
+  -- If more than 10% is non-printable ASCII control chars, likely binary
+  return non_printable > sample_size * 0.1
+end
+
 -- Tool name mapping for Claude Code compatibility (OAuth mode)
 local CLAUDE_CODE_TOOLS: {string:string} = {
   read = "Read",
@@ -101,6 +129,11 @@ local read_tool: Tool = {
     local content = cio.slurp(file_path)
     if not content then
       return "error: failed to read file: " .. file_path, true
+    end
+
+    -- Check for binary content
+    if is_binary(content) then
+      return string.format("error: %s appears to be a binary file (%d bytes)", file_path, #content), true
     end
 
     local offset = (input.offset as integer) or 1


### PR DESCRIPTION
## Summary
- Add `is_binary()` function to detect binary files before reading
- Return helpful error message instead of causing API failures
- Binary detection checks for null bytes and control character ratio

## Context
Reading binary files (like `./o/bin/ah`) caused `API error 400: invalid high surrogate in string` because binary content with invalid UTF-8 was passed to `json.encode`.

## Test plan
- [x] Added tests for null byte detection
- [x] Added tests for control character ratio detection
- [x] Verified `make test` passes
- [x] Manually tested with `./o/bin/ah -n "read ./o/bin/ah"`