### PR TITLE
tools: validate inputs against JSON schema before execution

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -457,4 +457,133 @@ local function test_read_binary_by_control_chars()
 end
 test_read_binary_by_control_chars()
 
+-- Input validation tests
+local function test_validate_input_valid()
+  local schema: {string:any} = {
+    type = "object",
+    properties = {
+      path = {type = "string"},
+      count = {type = "integer"},
+    },
+    required = {"path"},
+  }
+  local err = tools.validate_input(schema, {path = "/tmp/foo", count = 10})
+  assert(err == nil, "valid input should pass: " .. tostring(err))
+  print("✓ validate_input accepts valid input")
+end
+test_validate_input_valid()
+
+local function test_validate_input_missing_required()
+  local schema: {string:any} = {
+    type = "object",
+    properties = {
+      path = {type = "string"},
+      content = {type = "string"},
+    },
+    required = {"path", "content"},
+  }
+  local err = tools.validate_input(schema, {path = "/tmp/foo"})
+  assert(err ~= nil, "should fail for missing required property")
+  assert(err:match("missing required property: content"), "should name the missing property: " .. err)
+  print("✓ validate_input catches missing required properties")
+end
+test_validate_input_missing_required()
+
+local function test_validate_input_wrong_type()
+  local schema: {string:any} = {
+    type = "object",
+    properties = {
+      path = {type = "string"},
+      timeout = {type = "integer"},
+    },
+    required = {"path"},
+  }
+  local err = tools.validate_input(schema, {path = 123})
+  assert(err ~= nil, "should fail for wrong type")
+  assert(err:match("property 'path': expected string, got number"), "should describe type mismatch: " .. err)
+  print("✓ validate_input catches wrong property types")
+end
+test_validate_input_wrong_type()
+
+local function test_validate_input_multiple_errors()
+  local schema: {string:any} = {
+    type = "object",
+    properties = {
+      path = {type = "string"},
+      content = {type = "string"},
+    },
+    required = {"path", "content"},
+  }
+  local err = tools.validate_input(schema, {})
+  assert(err ~= nil, "should fail for multiple missing properties")
+  assert(err:match("missing required property: path"), "should report path missing: " .. err)
+  assert(err:match("missing required property: content"), "should report content missing: " .. err)
+  print("✓ validate_input reports multiple errors")
+end
+test_validate_input_multiple_errors()
+
+local function test_validate_input_optional_missing()
+  local schema: {string:any} = {
+    type = "object",
+    properties = {
+      path = {type = "string"},
+      offset = {type = "integer"},
+    },
+    required = {"path"},
+  }
+  local err = tools.validate_input(schema, {path = "/tmp/foo"})
+  assert(err == nil, "optional properties can be missing: " .. tostring(err))
+  print("✓ validate_input allows missing optional properties")
+end
+test_validate_input_optional_missing()
+
+local function test_validate_input_no_required()
+  local schema: {string:any} = {
+    type = "object",
+    properties = {
+      args = {type = "string"},
+    },
+  }
+  local err = tools.validate_input(schema, {})
+  assert(err == nil, "schema with no required should pass: " .. tostring(err))
+  print("✓ validate_input handles schema with no required array")
+end
+test_validate_input_no_required()
+
+local function test_validate_input_boolean_type()
+  local schema: {string:any} = {
+    type = "object",
+    properties = {
+      flag = {type = "boolean"},
+    },
+    required = {"flag"},
+  }
+  local err = tools.validate_input(schema, {flag = true})
+  assert(err == nil, "boolean should validate: " .. tostring(err))
+  local err2 = tools.validate_input(schema, {flag = "true"})
+  assert(err2 ~= nil, "string should not pass as boolean")
+  assert(err2:match("expected boolean, got string"), "should describe boolean mismatch: " .. err2)
+  print("✓ validate_input handles boolean types")
+end
+test_validate_input_boolean_type()
+
+local function test_execute_tool_validation_error()
+  -- execute_tool should return validation error before calling the tool
+  local result, is_error = tools.execute_tool("read", {})
+  assert(is_error, "should be an error")
+  assert(result:match("validation error"), "should be a validation error: " .. result)
+  assert(result:match("missing required property: path"), "should mention missing path: " .. result)
+  print("✓ execute_tool returns validation errors")
+end
+test_execute_tool_validation_error()
+
+local function test_execute_tool_type_validation()
+  local result, is_error = tools.execute_tool("bash", {command = 42})
+  assert(is_error, "should be an error")
+  assert(result:match("validation error"), "should be a validation error: " .. result)
+  assert(result:match("expected string, got number"), "should describe type mismatch: " .. result)
+  print("✓ execute_tool catches type mismatches")
+end
+test_execute_tool_type_validation()
+
 print("\nAll tools tests passed!")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -583,17 +583,75 @@ local function get_tool_definitions(): {{string:any}}
   return defs
 end
 
+-- Validate tool input against its JSON schema.
+-- Returns nil on success, or an error string describing all validation failures.
+local function validate_input(schema: {string:any}, input: {string:any}): string
+  local errors: {string} = {}
+
+  -- Check required properties
+  local required = schema.required as {string}
+  if required then
+    for _, prop in ipairs(required) do
+      if input[prop] == nil then
+        table.insert(errors, "missing required property: " .. prop)
+      end
+    end
+  end
+
+  -- Check property types
+  local properties = schema.properties as {string:{string:any}}
+  if properties then
+    for prop, prop_schema in pairs(properties) do
+      local value = input[prop]
+      if value ~= nil then
+        local expected_type = prop_schema.type as string
+        if expected_type then
+          local actual_type = type(value)
+          local ok = false
+          if expected_type == "string" then
+            ok = actual_type == "string"
+          elseif expected_type == "integer" or expected_type == "number" then
+            ok = actual_type == "number"
+          elseif expected_type == "boolean" then
+            ok = actual_type == "boolean"
+          elseif expected_type == "array" then
+            ok = actual_type == "table"
+          elseif expected_type == "object" then
+            ok = actual_type == "table"
+          end
+          if not ok then
+            table.insert(errors, string.format("property '%s': expected %s, got %s", prop, expected_type, actual_type))
+          end
+        end
+      end
+    end
+  end
+
+  if #errors > 0 then
+    return "validation error: " .. table.concat(errors, "; ")
+  end
+  return nil
+end
+
 local function execute_tool(name: string, input: {string:any}): string, boolean
   local tool = get_tool(name)
   if not tool then
     return "error: unknown tool: " .. name, true
   end
+
+  -- Validate input against schema before execution
+  local validation_err = validate_input(tool.input_schema, input or {})
+  if validation_err then
+    return validation_err, true
+  end
+
   return tool.execute(input)
 end
 
 return {
   get_tool_definitions = get_tool_definitions,
   execute_tool = execute_tool,
+  validate_input = validate_input,
   init_custom_tools = init_custom_tools,
   load_custom_tools = load_custom_tools,
   load_custom_tools_from_dir = load_custom_tools_from_dir,


### PR DESCRIPTION
Add centralized input validation in execute_tool() that checks required
properties and type constraints from each tool's input_schema before
calling tool.execute(). Returns structured error messages listing all
validation failures rather than letting tools fail at runtime.

Addresses the tool validation gap identified in the convergence analysis
(PR #29).

https://claude.ai/code/session_017ZSDGnZ5v9XbZ6PuvzJrFT