### PR TITLE
Add structured details to tool execution results

### DIFF
--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -28,7 +28,8 @@ create table if not exists content_blocks (
   tool_input text,
   tool_output text,
   is_error integer default 0,
-  duration_ms integer
+  duration_ms integer,
+  details text
 );
 
 create table if not exists context (
@@ -95,6 +96,7 @@ local record ContentBlock
   tool_output: string
   is_error: integer
   duration_ms: integer
+  details: string
 end
 
 local record ContentBlockOpts
@@ -105,6 +107,7 @@ local record ContentBlockOpts
   tool_output: string
   is_error: boolean
   duration_ms: integer
+  details: string
 end
 
 local record UpdateOpts
@@ -334,13 +337,14 @@ local function add_content_block(self: DB, message_id: string, block_type: strin
     opts.tool_input,
     opts.tool_output,
     opts.is_error and 1 or 0,
-    opts.duration_ms
+    opts.duration_ms,
+    opts.details
   }
 
   self._db:exec_list([[
-    insert into content_blocks (id, message_id, block_type, seq, content, tool_id, tool_name, tool_input, tool_output, is_error, duration_ms)
-    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  ]], values, 11)
+    insert into content_blocks (id, message_id, block_type, seq, content, tool_id, tool_name, tool_input, tool_output, is_error, duration_ms, details)
+    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  ]], values, 12)
 
   return {
     id = id,
@@ -354,6 +358,7 @@ local function add_content_block(self: DB, message_id: string, block_type: strin
     tool_output = opts.tool_output,
     is_error = opts.is_error and 1 or 0,
     duration_ms = opts.duration_ms,
+    details = opts.details,
   }
 end
 

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -217,7 +217,7 @@ local function cmd_scan(d: db.DB)
         end
         preview = text
       elseif b.block_type == "tool_use" then
-        local key = loop.tool_key_param(b.tool_name as string, b.tool_input as string)
+        local key = loop.tool_key_param(b.tool_name as string, b.tool_input as string, b.details as string)
         if #key > 40 then key = key:sub(1, 40) .. "..." end
         local suffix = key ~= "" and " " .. key or ""
         table.insert(tool_calls, string.format("→ %s%s", b.tool_name, suffix))
@@ -260,7 +260,7 @@ local function cmd_show(d: db.DB, seq: integer)
       io.write((b.content or "") as string)
       io.write("\n")
     elseif b.block_type == "tool_use" then
-      local key = loop.tool_key_param(b.tool_name as string, b.tool_input as string)
+      local key = loop.tool_key_param(b.tool_name as string, b.tool_input as string, b.details as string)
       io.write(string.format("→ %s %s\n", b.tool_name, key))
     elseif b.block_type == "tool_result" then
       local output = ((b.tool_output or "") as string)

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -7,6 +7,8 @@ local tools = require("ah.tools")
 local auth = require("ah.auth")
 local events = require("ah.events")
 
+local ToolDetails = tools.ToolDetails
+
 -- Reference the global interrupted flag (set by application layer)
 global interrupted: boolean
 
@@ -16,8 +18,33 @@ local function now(): number
   return s + ns / 1e9
 end
 
--- Extract key parameter from tool input for display
-local function tool_key_param(tool_name: string, tool_input: string): string
+-- Extract key parameter from tool details or input for display
+local function tool_key_param(tool_name: string, tool_input: string, details_json: string): string
+  -- Try details first (structured data from tool execution)
+  if details_json then
+    local details = json.decode(details_json) as {string:any}
+    if details then
+      if details.path then
+        if tool_name == "edit" then
+          -- For edit, include line change info from details
+          local suffix = ""
+          if details.old_lines and details.new_lines then
+            suffix = string.format(" (%d → %d lines)", details.old_lines as integer, details.new_lines as integer)
+          end
+          return (details.path as string) .. suffix
+        end
+        return details.path as string
+      elseif details.command then
+        local cmd = details.command as string
+        if #cmd > 80 then
+          return cmd:sub(1, 77) .. "..."
+        end
+        return cmd
+      end
+    end
+  end
+
+  -- Fall back to parsing tool_input JSON
   if not tool_input then return "" end
   local input = json.decode(tool_input) as {string:any}
   if not input then return "" end
@@ -260,13 +287,15 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
     for i, tool_call in ipairs(tool_calls) do
       local tc = tool_call as {string:any}
       local input_json = json.encode(tc.input or {})
-      local key = tool_key_param(tc.name as string, input_json)
+
+      -- Compute preliminary key from input for tool_call_start event
+      local key = tool_key_param(tc.name as string, input_json, nil)
 
       -- Emit tool_call_start
       emit(on_event, events.tool_call_start(tc.name as string, input_json, key, i, tool_count))
 
       local start = now()
-      local result, is_error = tools.execute_tool(tc.name as string, (tc.input or {}) as {string:any})
+      local result, is_error, details = tools.execute_tool(tc.name as string, (tc.input or {}) as {string:any})
       local elapsed = now() - start
 
       -- First tool includes think time in its timing
@@ -275,6 +304,15 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
       end
 
       local elapsed_ms = math.floor(elapsed * 1000) as integer
+
+      -- Encode details for display and persistence
+      local details_json: string = nil
+      if details then
+        details_json = json.encode(details as {string:any})
+      end
+
+      -- Recompute key with details for richer display in tool_call_end
+      key = tool_key_param(tc.name as string, input_json, details_json)
 
       -- Emit tool_call_end
       emit(on_event, events.tool_call_end(tc.name as string, result, is_error, elapsed_ms, key, i, tool_count))
@@ -297,6 +335,7 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
         tool_output = result,
         is_error = is_error,
         duration_ms = elapsed_ms,
+        details = details_json,
       })
 
       -- Add to API messages content
@@ -317,6 +356,7 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
         tool_output = blk.tool_output as string,
         is_error = blk.is_error as boolean,
         duration_ms = blk.duration_ms as integer,
+        details = blk.details as string,
       })
     end
     db.commit(d)

--- a/lib/ah/test_db.tl
+++ b/lib/ah/test_db.tl
@@ -377,4 +377,36 @@ local function test_events()
 end
 test_events()
 
+-- Test content block details (split tool return values)
+local function test_content_block_details()
+  local db_path = fs.join(TEST_TMPDIR, "details.db")
+  local d = db.open(db_path)
+
+  local msg = db.create_message(d, "user")
+
+  -- Add tool result without details
+  local block1 = db.add_content_block(d, msg.id, "tool_result", {
+    tool_id = "t1",
+    tool_output = "output",
+  })
+  assert(block1.details == nil, "block without details should be nil")
+
+  -- Add tool result with details
+  local details_json = '{"path":"/tmp/test.txt","line_count":42}'
+  local block2 = db.add_content_block(d, msg.id, "tool_result", {
+    tool_id = "t2",
+    tool_output = "file contents",
+    details = details_json,
+  })
+  assert(block2.details == details_json, "details mismatch on insert")
+
+  -- Verify via query
+  local blocks = db.get_content_blocks(d, msg.id)
+  assert(blocks[1].details == nil, "first block details should be nil")
+  assert(blocks[2].details == details_json, "second block details should match: " .. tostring(blocks[2].details))
+
+  db.close(d)
+end
+test_content_block_details()
+
 print("all db tests passed")

--- a/lib/ah/test_loop.tl
+++ b/lib/ah/test_loop.tl
@@ -1,36 +1,37 @@
 #!/usr/bin/env cosmic
 -- test_loop.tl: tests for agent loop module (tool display helpers)
+local json = require("cosmic.json")
 local loop = require("ah.loop")
 
--- Tests for tool_key_param
+-- Tests for tool_key_param (fallback to tool_input parsing)
 local function test_tool_key_param_bash()
-  local key = loop.tool_key_param("bash", '{"command":"ls -la"}')
+  local key = loop.tool_key_param("bash", '{"command":"ls -la"}', nil)
   assert(key == "ls -la", "should extract bash command")
 end
 test_tool_key_param_bash()
 
 local function test_tool_key_param_bash_truncate()
   local long_cmd = string.rep("x", 100)
-  local key = loop.tool_key_param("bash", '{"command":"' .. long_cmd .. '"}')
+  local key = loop.tool_key_param("bash", '{"command":"' .. long_cmd .. '"}', nil)
   assert(#key == 80, "should truncate to 80 chars: got " .. #key)
   assert(key:sub(-3) == "...", "should end with ellipsis")
 end
 test_tool_key_param_bash_truncate()
 
 local function test_tool_key_param_read()
-  local key = loop.tool_key_param("read", '{"path":"/tmp/foo.txt"}')
+  local key = loop.tool_key_param("read", '{"path":"/tmp/foo.txt"}', nil)
   assert(key == "/tmp/foo.txt", "should extract read path")
 end
 test_tool_key_param_read()
 
 local function test_tool_key_param_write()
-  local key = loop.tool_key_param("write", '{"path":"/tmp/bar.txt","content":"hello"}')
+  local key = loop.tool_key_param("write", '{"path":"/tmp/bar.txt","content":"hello"}', nil)
   assert(key == "/tmp/bar.txt", "should extract write path")
 end
 test_tool_key_param_write()
 
 local function test_tool_key_param_edit()
-  local key = loop.tool_key_param("edit", '{"path":"/tmp/file.lua","old_string":"foo","new_string":"bar"}')
+  local key = loop.tool_key_param("edit", '{"path":"/tmp/file.lua","old_string":"foo","new_string":"bar"}', nil)
   assert(key:match("/tmp/file.lua"), "should include path")
   assert(key:match("foo"), "should include old_string preview")
   assert(key:match("bar"), "should include new_string preview")
@@ -38,21 +39,75 @@ end
 test_tool_key_param_edit()
 
 local function test_tool_key_param_nil_input()
-  local key = loop.tool_key_param("bash", nil)
+  local key = loop.tool_key_param("bash", nil, nil)
   assert(key == "", "should return empty string for nil input")
 end
 test_tool_key_param_nil_input()
 
 local function test_tool_key_param_invalid_json()
-  local key = loop.tool_key_param("bash", "not json")
+  local key = loop.tool_key_param("bash", "not json", nil)
   assert(key == "", "should return empty string for invalid json")
 end
 test_tool_key_param_invalid_json()
 
 local function test_tool_key_param_unknown_tool()
-  local key = loop.tool_key_param("unknown_tool", '{"foo":"bar"}')
+  local key = loop.tool_key_param("unknown_tool", '{"foo":"bar"}', nil)
   assert(key == "", "should return empty string for unknown tool")
 end
 test_tool_key_param_unknown_tool()
+
+-- Tests for tool_key_param with details (structured data)
+local function test_tool_key_param_details_read()
+  local details = json.encode({path = "/tmp/foo.txt", line_count = 42})
+  local key = loop.tool_key_param("read", '{"path":"/tmp/foo.txt"}', details)
+  assert(key == "/tmp/foo.txt", "should use path from details")
+end
+test_tool_key_param_details_read()
+
+local function test_tool_key_param_details_bash()
+  local details = json.encode({command = "echo hello", exit_code = 0})
+  local key = loop.tool_key_param("bash", '{"command":"echo hello"}', details)
+  assert(key == "echo hello", "should use command from details")
+end
+test_tool_key_param_details_bash()
+
+local function test_tool_key_param_details_bash_truncate()
+  local long_cmd = string.rep("y", 100)
+  local details = json.encode({command = long_cmd, exit_code = 0})
+  local key = loop.tool_key_param("bash", '{"command":"x"}', details)
+  assert(#key == 80, "should truncate details command to 80 chars: got " .. #key)
+  assert(key:sub(-3) == "...", "should end with ellipsis")
+end
+test_tool_key_param_details_bash_truncate()
+
+local function test_tool_key_param_details_edit()
+  local details = json.encode({path = "/tmp/file.lua", old_lines = 5, new_lines = 7})
+  local key = loop.tool_key_param("edit", '{"path":"/tmp/file.lua","old_string":"x","new_string":"y"}', details)
+  assert(key:match("/tmp/file.lua"), "should include path from details")
+  assert(key:match("5 → 7 lines"), "should include line change info: " .. key)
+end
+test_tool_key_param_details_edit()
+
+local function test_tool_key_param_details_write()
+  local details = json.encode({path = "/tmp/out.txt", bytes = 1024})
+  local key = loop.tool_key_param("write", '{"path":"/tmp/out.txt"}', details)
+  assert(key == "/tmp/out.txt", "should use path from details")
+end
+test_tool_key_param_details_write()
+
+local function test_tool_key_param_details_override()
+  -- Details should take precedence over tool_input
+  local details = json.encode({path = "/details/path.txt"})
+  local key = loop.tool_key_param("read", '{"path":"/input/path.txt"}', details)
+  assert(key == "/details/path.txt", "details should override tool_input: " .. key)
+end
+test_tool_key_param_details_override()
+
+local function test_tool_key_param_nil_details_fallback()
+  -- nil details should fall back to tool_input
+  local key = loop.tool_key_param("read", '{"path":"/fallback/path.txt"}', nil)
+  assert(key == "/fallback/path.txt", "should fall back to tool_input: " .. key)
+end
+test_tool_key_param_nil_details_fallback()
 
 print("all loop tests passed")

--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -7,36 +7,47 @@ local tools = require("ah.tools")
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
 
 local function test_read_tool()
-  local result, is_error = tools.execute_tool("read", {path = "/etc/hostname"})
+  local result, is_error, details = tools.execute_tool("read", {path = "/etc/hostname"})
   assert(not is_error, "read should succeed: " .. result)
   assert(result:match("1\t"), "should have line numbers")
+  assert(details, "read should return details")
+  assert(details.path == "/etc/hostname", "details should have path")
+  assert(details.line_count and details.line_count > 0, "details should have line_count")
   print("✓ read tool works")
 end
 
 local function test_read_nonexistent()
-  local result, is_error = tools.execute_tool("read", {path = "/nonexistent/file"})
+  local result, is_error, details = tools.execute_tool("read", {path = "/nonexistent/file"})
   assert(is_error, "should fail for nonexistent file")
   assert(result:match("error"), "should return error message")
+  assert(details == nil, "error should not return details")
   print("✓ read tool handles missing files")
 end
 
 local function test_write_tool()
   local test_file = os.getenv("TEST_TMPDIR") .. "/test_write.txt"
-  local result, is_error = tools.execute_tool("write", {path = test_file, content = "hello world"})
+  local result, is_error, details = tools.execute_tool("write", {path = test_file, content = "hello world"})
   assert(not is_error, "write should succeed: " .. result)
   assert(result:match("wrote.*bytes"), "should report bytes written")
+  assert(details, "write should return details")
+  assert(details.path == test_file, "details should have path")
+  assert(details.bytes == 11, "details should have bytes: " .. tostring(details.bytes))
   print("✓ write tool works")
 end
 
 local function test_edit_tool()
   local test_file = os.getenv("TEST_TMPDIR") .. "/test_edit.txt"
   tools.execute_tool("write", {path = test_file, content = "hello world"})
-  local result, is_error = tools.execute_tool("edit", {
+  local result, is_error, details = tools.execute_tool("edit", {
     path = test_file,
     old_string = "hello",
     new_string = "goodbye"
   })
   assert(not is_error, "edit should succeed: " .. result)
+  assert(details, "edit should return details")
+  assert(details.path == test_file, "details should have path")
+  assert(details.old_lines == 1, "details should have old_lines: " .. tostring(details.old_lines))
+  assert(details.new_lines == 1, "details should have new_lines: " .. tostring(details.new_lines))
 
   local content, _ = tools.execute_tool("read", {path = test_file})
   assert(content:match("goodbye world"), "content should be changed")
@@ -59,16 +70,21 @@ local function test_edit_tool_percent_in_replacement()
 end
 
 local function test_bash_tool()
-  local result, is_error = tools.execute_tool("bash", {command = "echo hello"})
+  local result, is_error, details = tools.execute_tool("bash", {command = "echo hello"})
   assert(not is_error, "bash should succeed")
   assert(result:match("hello"), "should capture stdout")
+  assert(details, "bash should return details")
+  assert(details.command == "echo hello", "details should have command")
+  assert(details.exit_code == 0, "details should have exit_code 0: " .. tostring(details.exit_code))
   print("✓ bash tool works")
 end
 
 local function test_bash_exit_code()
-  local result, is_error = tools.execute_tool("bash", {command = "exit 1"})
+  local result, is_error, details = tools.execute_tool("bash", {command = "exit 1"})
   assert(is_error, "should report error for non-zero exit")
   assert(result:match("exit code: 1"), "should report exit code")
+  assert(details, "bash error should still return details")
+  assert(details.exit_code == 1, "details should have exit_code 1: " .. tostring(details.exit_code))
   print("✓ bash tool handles exit codes")
 end
 
@@ -585,5 +601,66 @@ local function test_execute_tool_type_validation()
   print("✓ execute_tool catches type mismatches")
 end
 test_execute_tool_type_validation()
+
+-- Split return value (details) tests
+local function test_read_details_multiline()
+  local test_file = fs.join(TEST_TMPDIR, "test_multiline.txt")
+  cio.barf(test_file, "line1\nline2\nline3\n")
+
+  local result, is_error, details = tools.execute_tool("read", {path = test_file})
+  assert(not is_error, "read should succeed")
+  assert(details, "should return details")
+  assert(details.path == test_file, "details path should match")
+  assert(details.line_count == 4, "should count lines (including trailing): " .. tostring(details.line_count))
+  print("✓ read details include line_count")
+end
+test_read_details_multiline()
+
+local function test_edit_details_multiline()
+  local test_file = fs.join(TEST_TMPDIR, "test_edit_multi.txt")
+  cio.barf(test_file, "line1\nline2\nline3\n")
+
+  local result, is_error, details = tools.execute_tool("edit", {
+    path = test_file,
+    old_string = "line2",
+    new_string = "replaced_a\nreplaced_b\nreplaced_c"
+  })
+  assert(not is_error, "edit should succeed")
+  assert(details, "should return details")
+  assert(details.old_lines == 1, "old_lines should be 1")
+  assert(details.new_lines == 3, "new_lines should be 3: " .. tostring(details.new_lines))
+  print("✓ edit details track line count changes")
+end
+test_edit_details_multiline()
+
+local function test_read_image_details()
+  local png_path = fs.join(TEST_TMPDIR, "test_details.png")
+  cio.barf(png_path, "fake png data for details test")
+
+  local result, is_error, details = tools.execute_tool("read", {path = png_path})
+  assert(not is_error, "should read image")
+  assert(details, "image read should return details")
+  assert(details.path == png_path, "details path should match")
+  assert(details.bytes == 30, "details should have bytes: " .. tostring(details.bytes))
+  assert(details.media_type == "image/png", "details should have media_type")
+  print("✓ read image returns details with media_type and bytes")
+end
+test_read_image_details()
+
+local function test_validation_error_no_details()
+  local result, is_error, details = tools.execute_tool("read", {})
+  assert(is_error, "should be error")
+  assert(details == nil, "validation errors should not return details")
+  print("✓ validation errors return nil details")
+end
+test_validation_error_no_details()
+
+local function test_unknown_tool_no_details()
+  local result, is_error, details = tools.execute_tool("nonexistent", {})
+  assert(is_error, "should be error")
+  assert(details == nil, "unknown tool should not return details")
+  print("✓ unknown tool returns nil details")
+end
+test_unknown_tool_no_details()
 
 print("\nAll tools tests passed!")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -42,11 +42,23 @@ local function is_binary(content: string): boolean
   return non_printable > sample_size * 0.1
 end
 
+local record ToolDetails
+  path: string
+  line_count: integer
+  bytes: integer
+  old_lines: integer
+  new_lines: integer
+  command: string
+  exit_code: integer
+  duration_ms: integer
+  media_type: string
+end
+
 local record Tool
   name: string
   description: string
   input_schema: {string:any}
-  execute: function(input: {string:any}): string, boolean
+  execute: function(input: {string:any}): string, boolean, ToolDetails
 end
 
 -- Custom tools loaded at runtime
@@ -66,10 +78,10 @@ local read_tool: Tool = {
     },
     required = {"path"},
   },
-  execute = function(input: {string:any}): string, boolean
+  execute = function(input: {string:any}): string, boolean, ToolDetails
     local file_path = input.path as string
     if not file_path then
-      return "error: path is required", true
+      return "error: path is required", true, nil
     end
 
     -- Check for image extension
@@ -83,7 +95,7 @@ local read_tool: Tool = {
       -- Read image file and return structured content
       local content = cio.slurp(file_path)
       if not content then
-        return "error: failed to read file: " .. file_path, true
+        return "error: failed to read file: " .. file_path, true, nil
       end
 
       local base64_data = cosmo.EncodeBase64(content)
@@ -98,22 +110,28 @@ local read_tool: Tool = {
           },
         }},
       }
-      return json.encode(image_block), false
+      return json.encode(image_block), false, {path = file_path, bytes = #content, media_type = media_type} as ToolDetails
     end
 
     -- Text file handling
     local content = cio.slurp(file_path)
     if not content then
-      return "error: failed to read file: " .. file_path, true
+      return "error: failed to read file: " .. file_path, true, nil
     end
 
     -- Check for binary content
     if is_binary(content) then
-      return string.format("error: %s appears to be a binary file (%d bytes)", file_path, #content), true
+      return string.format("error: %s appears to be a binary file (%d bytes)", file_path, #content), true, nil
     end
 
     local offset = (input.offset as integer) or 1
     local limit = (input.limit as integer) or 0
+
+    -- Count total lines
+    local total_lines = 0
+    for _ in content:gmatch("[^\n]*") do
+      total_lines = total_lines + 1
+    end
 
     if offset > 1 or limit > 0 then
       local lines: {string} = {}
@@ -127,7 +145,7 @@ local read_tool: Tool = {
           table.insert(lines, string.format("%d\t%s", line_num, line))
         end
       end
-      return table.concat(lines, "\n"), false
+      return table.concat(lines, "\n"), false, {path = file_path, line_count = total_lines} as ToolDetails
     end
 
     -- Add line numbers
@@ -137,7 +155,7 @@ local read_tool: Tool = {
       line_num = line_num + 1
       table.insert(lines, string.format("%d\t%s", line_num, line))
     end
-    return table.concat(lines, "\n"), false
+    return table.concat(lines, "\n"), false, {path = file_path, line_count = total_lines} as ToolDetails
   end,
 }
 
@@ -153,15 +171,15 @@ local write_tool: Tool = {
     },
     required = {"path", "content"},
   },
-  execute = function(input: {string:any}): string, boolean
+  execute = function(input: {string:any}): string, boolean, ToolDetails
     local file_path = input.path as string
     local content = input.content as string
 
     if not file_path then
-      return "error: path is required", true
+      return "error: path is required", true, nil
     end
     if not content then
-      return "error: content is required", true
+      return "error: content is required", true, nil
     end
 
     -- Create parent directories if needed
@@ -172,10 +190,11 @@ local write_tool: Tool = {
 
     local ok = cio.barf(file_path, content, tonumber("644", 8))
     if not ok then
-      return "error: failed to write file: " .. file_path, true
+      return "error: failed to write file: " .. file_path, true, nil
     end
 
-    return "wrote " .. tostring(#content) .. " bytes to " .. file_path, false
+    return "wrote " .. tostring(#content) .. " bytes to " .. file_path, false,
+      {path = file_path, bytes = #content} as ToolDetails
   end,
 }
 
@@ -192,34 +211,40 @@ local edit_tool: Tool = {
     },
     required = {"path", "old_string", "new_string"},
   },
-  execute = function(input: {string:any}): string, boolean
+  execute = function(input: {string:any}): string, boolean, ToolDetails
     local file_path = input.path as string
     local old_string = input.old_string as string
     local new_string = input.new_string as string
 
     if not file_path then
-      return "error: path is required", true
+      return "error: path is required", true, nil
     end
     if not old_string then
-      return "error: old_string is required", true
+      return "error: old_string is required", true, nil
     end
     if new_string == nil then
-      return "error: new_string is required", true
+      return "error: new_string is required", true, nil
     end
 
     local content = cio.slurp(file_path)
     if not content then
-      return "error: failed to read file: " .. file_path, true
+      return "error: failed to read file: " .. file_path, true, nil
     end
 
     -- Check uniqueness
     local _, count = content:gsub(old_string:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1"), "")
     if count == 0 then
-      return "error: old_string not found in file", true
+      return "error: old_string not found in file", true, nil
     end
     if count > 1 then
-      return "error: old_string is not unique (found " .. count .. " times)", true
+      return "error: old_string is not unique (found " .. count .. " times)", true, nil
     end
+
+    -- Count lines in old and new strings
+    local old_lines = 1
+    for _ in old_string:gmatch("\n") do old_lines = old_lines + 1 end
+    local new_lines = 1
+    for _ in new_string:gmatch("\n") do new_lines = new_lines + 1 end
 
     -- Perform replacement (escape % in replacement string)
     local escaped_new = new_string:gsub("%%", "%%%%")
@@ -227,10 +252,11 @@ local edit_tool: Tool = {
 
     local ok = cio.barf(file_path, new_content, tonumber("644", 8))
     if not ok then
-      return "error: failed to write file: " .. file_path, true
+      return "error: failed to write file: " .. file_path, true, nil
     end
 
-    return "edited " .. file_path, false
+    return "edited " .. file_path, false,
+      {path = file_path, old_lines = old_lines, new_lines = new_lines} as ToolDetails
   end,
 }
 
@@ -246,10 +272,10 @@ local bash_tool: Tool = {
     },
     required = {"command"},
   },
-  execute = function(input: {string:any}): string, boolean
+  execute = function(input: {string:any}): string, boolean, ToolDetails
     local command = input.command as string
     if not command then
-      return "error: command is required", true
+      return "error: command is required", true, nil
     end
 
     -- Timeout in milliseconds, default 120000 (2 minutes)
@@ -261,7 +287,7 @@ local bash_tool: Tool = {
 
     local handle, err = child.spawn({"sh", "-c", wrapped})
     if not handle then
-      return "error: failed to spawn: " .. tostring(err), true
+      return "error: failed to spawn: " .. tostring(err), true, nil
     end
 
     -- Read output: h:read() returns (ok, stdout, exit_code_as_string)
@@ -287,7 +313,8 @@ local bash_tool: Tool = {
       result = "(no output)"
     end
 
-    return result, exit_code ~= 0
+    return result, exit_code ~= 0,
+      {command = command, exit_code = exit_code} as ToolDetails
   end,
 }
 
@@ -403,7 +430,7 @@ local function load_cli_tools_from_dir(dir: string): {Tool}
           args = {type = "string", description = "Command-line arguments"},
         },
       },
-      execute = function(input: {string:any}): string, boolean
+      execute = function(input: {string:any}): string, boolean, ToolDetails
         local args_str = (input.args as string) or ""
 
         -- Parse args string into array (simple space-split, respects quotes)
@@ -414,7 +441,7 @@ local function load_cli_tools_from_dir(dir: string): {Tool}
 
         local handle, err = child.spawn(cmd)
         if not handle then
-          return "error: failed to spawn: " .. tostring(err), true
+          return "error: failed to spawn: " .. tostring(err), true, nil
         end
 
         local _, stdout, exit_str = handle:read()
@@ -434,7 +461,8 @@ local function load_cli_tools_from_dir(dir: string): {Tool}
           result = "(no output)"
         end
 
-        return result, exit_code ~= 0
+        return result, exit_code ~= 0,
+          {command = tool_name .. " " .. args_str, exit_code = exit_code} as ToolDetails
       end,
     }
 
@@ -633,16 +661,16 @@ local function validate_input(schema: {string:any}, input: {string:any}): string
   return nil
 end
 
-local function execute_tool(name: string, input: {string:any}): string, boolean
+local function execute_tool(name: string, input: {string:any}): string, boolean, ToolDetails
   local tool = get_tool(name)
   if not tool then
-    return "error: unknown tool: " .. name, true
+    return "error: unknown tool: " .. name, true, nil
   end
 
   -- Validate input against schema before execution
   local validation_err = validate_input(tool.input_schema, input or {})
   if validation_err then
-    return validation_err, true
+    return validation_err, true, nil
   end
 
   return tool.execute(input)
@@ -659,4 +687,5 @@ return {
   load_cli_tools_from_dir = load_cli_tools_from_dir,
   is_valid_tool = is_valid_tool,
   Tool = Tool,
+  ToolDetails = ToolDetails,
 }


### PR DESCRIPTION
## Summary
This PR adds a new `details` field to tool execution results, allowing tools to return structured metadata about their execution alongside the text result. This enables better display of tool information and persistence of execution details in the database.

## Key Changes

- **Database Schema**: Added `details` text column to `content_blocks` table to store structured tool execution metadata
- **Tool Execution**: Modified `execute_tool()` to return a third value (`ToolDetails`) containing structured information about tool execution:
  - `read`: Returns `path`, `line_count`, `bytes`, and `media_type`
  - `write`: Returns `path` and `bytes`
  - `edit`: Returns `path`, `old_lines`, and `new_lines`
  - `bash`: Returns `command` and `exit_code`
  - Custom CLI tools: Return `command` and `exit_code`
- **Display Logic**: Enhanced `tool_key_param()` to prioritize details over tool_input for display, enabling richer information like line change counts for edits
- **Database Persistence**: Content blocks now store and retrieve the details JSON for later reference
- **Type Safety**: Added `ToolDetails` record type to document the structure of tool metadata

## Implementation Details

- Details are only returned on successful tool execution; validation errors and unknown tools return `nil` for details
- The `tool_key_param()` function now accepts an optional `details_json` parameter and uses it preferentially when available
- Details are JSON-encoded before storage and can be decoded for display or analysis
- All existing tests updated to handle the new return value; comprehensive new tests added for details functionality

https://claude.ai/code/session_01RBvbRTg82umGeyXfwy4u4E