### PR TITLE
queue: add steering and followup message queues

### DIFF
--- a/lib/ah/events.tl
+++ b/lib/ah/events.tl
@@ -8,6 +8,7 @@ local json = require("cosmic.json")
 --   text_delta (streaming text output)
 --   error, retry
 --   state_change (session state transitions: idle/processing/closed)
+--   steering_received, followup_received (queue messages)
 
 local record EventData
   -- Common fields
@@ -50,6 +51,10 @@ local record EventData
   -- state_change
   from_state: string
   to_state: string
+
+  -- steering/followup
+  content: string
+  message_count: integer
 end
 
 local type EventCallback = function(event: EventData)
@@ -142,6 +147,20 @@ local function state_change(from_state: string, to_state: string): EventData
   return e
 end
 
+local function steering_received(content: string, message_count: integer): EventData
+  local e = make_event("steering_received")
+  e.content = content
+  e.message_count = message_count
+  return e
+end
+
+local function followup_received(content: string, message_count: integer): EventData
+  local e = make_event("followup_received")
+  e.content = content
+  e.message_count = message_count
+  return e
+end
+
 -- Serialize an event to JSON (for persistence or JSON logging)
 local function to_json(event: EventData): string
   local t: {string:any} = {}
@@ -171,6 +190,8 @@ return {
   error_event = error_event,
   retry_event = retry_event,
   state_change = state_change,
+  steering_received = steering_received,
+  followup_received = followup_received,
 
   -- Serialization
   to_json = to_json,

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -16,6 +16,7 @@ local skills = require("ah.skills")
 local loop = require("ah.loop")
 local events = require("ah.events")
 local ulid = require("ulid")
+local queue = require("ah.queue")
 
 -- Session record for listing
 local record Session
@@ -158,6 +159,8 @@ options:
   -S, --session ULID  use specific session (prefix match)
   --db PATH           use custom database path (default: .ah/<ulid>.db)
   -m, --model MODEL   set model (default: sonnet)
+  --steer MSG         send steering message to running session
+  --followup MSG      queue followup message for after session completes
 
 models:
 ]])
@@ -405,6 +408,8 @@ local function main(args: {string}): integer, string
   local output_path: string = nil
   local new_session: boolean = false
   local session_prefix: string = nil
+  local steer_msg: string = nil
+  local followup_msg: string = nil
   local cwd = fs.getcwd()
 
   local longopts = {
@@ -414,6 +419,8 @@ local function main(args: {string}): integer, string
     {name = "db", has_arg = "required"},
     {name = "model", has_arg = "required", short = "m"},
     {name = "output", has_arg = "required", short = "o"},
+    {name = "steer", has_arg = "required"},
+    {name = "followup", has_arg = "required"},
   }
 
   local parser = getopt.new(args, "hnS:m:o:", longopts)
@@ -435,6 +442,10 @@ local function main(args: {string}): integer, string
       model = optarg
     elseif opt == "o" or opt == "output" then
       output_path = optarg
+    elseif opt == "steer" then
+      steer_msg = optarg
+    elseif opt == "followup" then
+      followup_msg = optarg
     elseif opt == "?" then
       usage()
       return 1
@@ -540,6 +551,29 @@ local function main(args: {string}): integer, string
     db_path = fs.join(ah_dir, session_ulid .. ".db")
   end
 
+  -- Queue path is derived from session (same directory as db)
+  local queue_path = db_path:gsub("%.db$", ".queue.db")
+
+  -- Handle --steer and --followup options (queue and exit)
+  if steer_msg or followup_msg then
+    local qdb, qerr = queue.open(queue_path)
+    if not qdb then
+      return 1, qerr
+    end
+
+    if steer_msg then
+      queue.add_steer(qdb, steer_msg)
+      io.stderr:write("queued steering message\n")
+    end
+    if followup_msg then
+      queue.add_followup(qdb, followup_msg)
+      io.stderr:write("queued followup message\n")
+    end
+
+    queue.close(qdb)
+    return 0
+  end
+
   local d, err = db.open(db_path)
   if not d then
     return 1, err
@@ -551,9 +585,17 @@ local function main(args: {string}): integer, string
     io.stderr:write(string.format("cleaned up %d orphan message(s) from previous crash\n", orphans_cleaned))
   end
 
-  -- Handle commands
+  -- Open queue database (will be used for lock management and steering/followup)
+  local qdb, qerr = queue.open(queue_path)
+  if not qdb then
+    db.close(d)
+    return 1, qerr
+  end
+
+  -- Handle commands (no lock needed for read-only commands)
   if cmd == "scan" then
     cmd_scan(d)
+    queue.close(qdb)
     db.close(d)
     return 0
 
@@ -564,6 +606,7 @@ local function main(args: {string}): integer, string
       seq = tonumber(seq_str) as integer
     end
     cmd_show(d, seq)
+    queue.close(qdb)
     db.close(d)
     return 0
 
@@ -573,6 +616,7 @@ local function main(args: {string}): integer, string
       table.insert(seqs, tonumber(remaining[i]) as integer)
     end
     cmd_rmm(d, seqs)
+    queue.close(qdb)
     db.close(d)
     return 0
   end
@@ -585,12 +629,14 @@ local function main(args: {string}): integer, string
   if cmd and cmd:sub(1, 1) == "@" then
     local seq = tonumber(cmd:sub(2)) as integer
     if not seq then
+      queue.close(qdb)
       db.close(d)
       return 1, "invalid message number: " .. cmd
     end
 
     local msg = db.get_message_by_seq(d, seq)
     if not msg then
+      queue.close(qdb)
       db.close(d)
       return 1, "message not found: " .. cmd
     end
@@ -620,6 +666,7 @@ local function main(args: {string}): integer, string
     if not ok or not input then
       -- Interrupted or EOF
       io.stderr:write("\n")
+      queue.close(qdb)
       db.close(d)
       return 0
     end
@@ -628,6 +675,7 @@ local function main(args: {string}): integer, string
     prompt = prompt:gsub("%s+$", "")
     if prompt == "" then
       usage()
+      queue.close(qdb)
       db.close(d)
       return 0
     end
@@ -663,12 +711,25 @@ local function main(args: {string}): integer, string
   -- Initialize custom tools
   tools.init_custom_tools()
 
+  -- Try to acquire session lock
+  local lock_acquired, lock_err = queue.try_acquire_lock(qdb)
+  if not lock_acquired then
+    -- Session is locked by another process - queue as followup
+    queue.add_followup(qdb, prompt)
+    io.stderr:write("session locked, queued as followup: " .. (lock_err or "") .. "\n")
+    queue.close(qdb)
+    db.close(d)
+    return 0
+  end
+
   -- Install SIGINT handler for graceful Ctrl+C with abort cascade:
   -- 1. Set interrupted flag (checked by loop between iterations and mid-stream)
   -- 2. Immediately abort any running tool processes (SIGTERM -> SIGKILL)
+  -- 3. Release session lock
   unix.sigaction(unix.SIGINT, function()
     interrupted = true
     tools.abort_running_tools()
+    queue.release_lock(qdb)
   end)
 
   -- Resolve model alias
@@ -676,10 +737,14 @@ local function main(args: {string}): integer, string
 
   -- Run agent with CLI event handler
   local on_event = make_cli_handler()
-  loop.run_agent(d, effective_system, effective_model, prompt, parent_id, on_event)
+  loop.run_agent(d, qdb, effective_system, effective_model, prompt, parent_id, on_event)
 
   -- Mark session as closed before exit
   db.set_session_state(d, "closed")
+
+  -- Release lock and clean up
+  queue.release_lock(qdb)
+  queue.close(qdb)
   db.close(d)
   return 0
 end

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -6,6 +6,7 @@ local api = require("ah.api")
 local tools = require("ah.tools")
 local auth = require("ah.auth")
 local events = require("ah.events")
+local queue = require("ah.queue")
 
 local ToolDetails = tools.ToolDetails
 
@@ -83,10 +84,11 @@ local function transition_state(d: db.DB, on_event: events.EventCallback, to_sta
 end
 
 -- Send prompt and run agent loop
+-- qdb: optional queue database for inter-process coordination (steering/followup)
 -- on_event: optional callback for structured lifecycle events.
 -- When provided, the loop emits events instead of writing directly to stderr/stdout.
 -- When nil, the loop still functions but produces no output.
-local function run_agent(d: db.DB, system_prompt: string, model: string, prompt: string, parent_id: string, on_event: events.EventCallback)
+local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, model: string, prompt: string, parent_id: string, on_event: events.EventCallback)
   -- Load credentials to determine if OAuth mode
   local creds, creds_err = auth.load_credentials()
   if not creds then
@@ -169,6 +171,31 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
 
   -- Agent loop
   while not interrupted do
+    -- Update heartbeat and drain steering queue before API call
+    if qdb then
+      queue.update_heartbeat(qdb)
+
+      local steering_msgs = queue.drain_steering(qdb)
+      for _, steer_msg in ipairs(steering_msgs) do
+        emit(on_event, events.steering_received(steer_msg.content, #steering_msgs))
+
+        -- Create steering user message and add to conversation
+        db.begin_transaction(d)
+        local steer_user_msg = db.create_message(d, "user", user_msg.id)
+        db.add_content_block(d, steer_user_msg.id, "text", {content = "[STEERING] " .. steer_msg.content})
+        db.commit(d)
+
+        -- Add to API messages
+        table.insert(api_messages, {
+          role = "user",
+          content = {{type = "text", text = "[STEERING] " .. steer_msg.content}},
+        })
+
+        -- Update parent for next iteration
+        user_msg = steer_user_msg
+      end
+    end
+
     -- Emit api_call_start
     emit(on_event, events.api_call_start())
 
@@ -324,8 +351,36 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
     -- Check for tool calls
     local tool_calls = api.extract_tool_calls(response) as {any}
     if #tool_calls == 0 then
+      -- No tool calls - check for followup messages before exiting
+      if qdb then
+        local followup_msgs = queue.drain_followup(qdb)
+        if #followup_msgs > 0 then
+          -- Process followup messages by injecting them as new user messages
+          for _, followup_msg in ipairs(followup_msgs) do
+            emit(on_event, events.followup_received(followup_msg.content, #followup_msgs))
+
+            -- Create followup user message
+            db.begin_transaction(d)
+            local followup_user_msg = db.create_message(d, "user", assistant_msg.id)
+            db.add_content_block(d, followup_user_msg.id, "text", {content = followup_msg.content})
+            db.commit(d)
+
+            -- Add to API messages
+            table.insert(api_messages, {
+              role = "user",
+              content = {{type = "text", text = followup_msg.content}},
+            })
+
+            -- Update user_msg for next iteration
+            user_msg = followup_user_msg
+          end
+          -- Continue the loop with followup messages
+          goto continue_loop
+        end
+      end
+
       final_stop_reason = resp.stop_reason as string or "end_turn"
-      break  -- Done, no tool calls
+      break  -- Done, no tool calls and no followup
     end
 
     -- Execute tool calls and collect results before writing to DB
@@ -465,6 +520,8 @@ local function run_agent(d: db.DB, system_prompt: string, model: string, prompt:
     end
 
     final_stop_reason = "tool_use"
+
+    ::continue_loop::
   end
 
   if interrupted then

--- a/lib/ah/queue.tl
+++ b/lib/ah/queue.tl
@@ -1,0 +1,347 @@
+-- ah/queue.tl: steering and followup queue for inter-process coordination
+local sqlite = require("cosmic.sqlite")
+local ulid = require("ulid")
+local unix = require("cosmo.unix")
+
+local SCHEMA = [[
+create table if not exists queue_messages (
+  id text primary key,
+  message_type text not null,
+  content text not null,
+  created_at integer not null,
+  consumed_at integer
+);
+
+create table if not exists session_lock (
+  key text primary key,
+  owner_pid integer not null,
+  started_at integer not null,
+  heartbeat_at integer not null
+);
+
+create index if not exists idx_queue_type on queue_messages(message_type);
+create index if not exists idx_queue_consumed on queue_messages(consumed_at);
+]]
+
+-- Stale lock threshold in seconds
+local STALE_THRESHOLD = 30
+
+local record Statement
+  bind: function(Statement, any...)
+  exec: function(Statement)
+  close: function(Statement)
+end
+
+local record Database
+  exec: function(Database, string, any...): boolean, string
+  exec_list: function(Database, string, {any}, integer): boolean, string
+  prepare: function(Database, string): Statement, string
+  query: function(Database, string, any...): function(): {string:any}
+  close: function(Database)
+end
+
+local record QueueDB
+  _db: Database
+  _path: string
+end
+
+local record QueueMessage
+  id: string
+  message_type: string
+  content: string
+  created_at: integer
+  consumed_at: integer
+end
+
+local record LockInfo
+  owner_pid: integer
+  started_at: integer
+  heartbeat_at: integer
+end
+
+local function open(db_path: string): QueueDB, string
+  local db, err = sqlite.open(db_path) as (Database, string)
+  if not db then
+    return nil, "failed to open queue database: " .. db_path .. ": " .. (err or "")
+  end
+
+  -- Enable WAL mode for better concurrent access
+  local ok, pragma_err = db:exec("pragma journal_mode=wal")
+  if not ok then
+    db:close()
+    return nil, "failed to enable WAL mode: " .. (pragma_err or "")
+  end
+
+  -- Set busy timeout to wait for locks
+  ok, pragma_err = db:exec("pragma busy_timeout=5000")
+  if not ok then
+    db:close()
+    return nil, "failed to set busy timeout: " .. (pragma_err or "")
+  end
+
+  db:exec("pragma synchronous=normal")
+
+  ok, pragma_err = db:exec(SCHEMA)
+  if not ok then
+    db:close()
+    return nil, "failed to initialize queue schema: " .. (pragma_err or "")
+  end
+
+  return {_db = db, _path = db_path} as QueueDB, nil
+end
+
+local function close(self: QueueDB)
+  if self._db then
+    self._db:close()
+  end
+end
+
+-- Get current lock info if any
+local function get_lock_info(self: QueueDB): LockInfo
+  for row in self._db:query("select owner_pid, started_at, heartbeat_at from session_lock where key = 'lock'") do
+    return {
+      owner_pid = row.owner_pid as integer,
+      started_at = row.started_at as integer,
+      heartbeat_at = row.heartbeat_at as integer,
+    }
+  end
+  return nil
+end
+
+-- Check if session is currently locked by another process
+local function is_locked(self: QueueDB): boolean, integer
+  local info = get_lock_info(self)
+  if not info then
+    return false, nil
+  end
+
+  local now = os.time()
+  local age = now - info.heartbeat_at
+
+  -- Check if lock is stale
+  if age > STALE_THRESHOLD then
+    return false, info.owner_pid
+  end
+
+  -- Check if owner process is still alive
+  local my_pid = unix.getpid()
+  if info.owner_pid == my_pid then
+    return false, nil  -- We own it
+  end
+
+  -- Try to check if the process exists via kill(pid, 0)
+  local process_exists = unix.kill(info.owner_pid, 0)
+  if not process_exists then
+    -- Process doesn't exist, lock is stale
+    return false, info.owner_pid
+  end
+
+  return true, info.owner_pid
+end
+
+-- Try to acquire the session lock
+-- Returns: true if acquired, false if already held by another process
+local function try_acquire_lock(self: QueueDB): boolean, string
+  local now = os.time()
+  local my_pid = unix.getpid()
+
+  local info = get_lock_info(self)
+
+  if info then
+    -- Check if it's our own lock
+    if info.owner_pid == my_pid then
+      -- Update heartbeat and continue
+      self._db:exec("update session_lock set heartbeat_at = ? where key = 'lock'", now)
+      return true, nil
+    end
+
+    -- Check if lock is stale
+    local age = now - info.heartbeat_at
+    local process_dead = not unix.kill(info.owner_pid, 0)
+
+    if age > STALE_THRESHOLD or process_dead then
+      -- Claim stale lock
+      local ok, err = self._db:exec(
+        "update session_lock set owner_pid = ?, started_at = ?, heartbeat_at = ? where key = 'lock'",
+        my_pid, now, now)
+      if not ok then
+        return false, "failed to claim stale lock: " .. (err or "")
+      end
+      return true, nil
+    end
+
+    -- Lock held by active process
+    return false, "session locked by pid " .. info.owner_pid
+  end
+
+  -- No existing lock, create one
+  local ok, err = self._db:exec(
+    "insert into session_lock (key, owner_pid, started_at, heartbeat_at) values ('lock', ?, ?, ?)",
+    my_pid, now, now)
+  if not ok then
+    return false, "failed to create lock: " .. (err or "")
+  end
+
+  return true, nil
+end
+
+-- Release the session lock
+local function release_lock(self: QueueDB): boolean
+  local my_pid = unix.getpid()
+  local info = get_lock_info(self)
+
+  if info and info.owner_pid == my_pid then
+    self._db:exec("delete from session_lock where key = 'lock'")
+    return true
+  end
+
+  return false
+end
+
+-- Update heartbeat timestamp (call before each API call)
+local function update_heartbeat(self: QueueDB): boolean
+  local now = os.time()
+  local my_pid = unix.getpid()
+
+  local ok = self._db:exec(
+    "update session_lock set heartbeat_at = ? where key = 'lock' and owner_pid = ?",
+    now, my_pid)
+
+  return ok
+end
+
+-- Add a steering message to the queue
+local function add_steer(self: QueueDB, content: string): QueueMessage
+  local id = ulid.generate()
+  local now = os.time()
+
+  self._db:exec_list(
+    "insert into queue_messages (id, message_type, content, created_at) values (?, ?, ?, ?)",
+    {id, "steer", content, now}, 4)
+
+  return {
+    id = id,
+    message_type = "steer",
+    content = content,
+    created_at = now,
+  }
+end
+
+-- Add a followup message to the queue
+local function add_followup(self: QueueDB, content: string): QueueMessage
+  local id = ulid.generate()
+  local now = os.time()
+
+  self._db:exec_list(
+    "insert into queue_messages (id, message_type, content, created_at) values (?, ?, ?, ?)",
+    {id, "followup", content, now}, 4)
+
+  return {
+    id = id,
+    message_type = "followup",
+    content = content,
+    created_at = now,
+  }
+end
+
+-- Drain all unconsumed steering messages (returns them in order, marks as consumed)
+local function drain_steering(self: QueueDB): {QueueMessage}
+  local messages: {QueueMessage} = {}
+  local now = os.time()
+
+  -- Collect unconsumed steering messages (ordered by rowid for insertion order)
+  for row in self._db:query([[
+    select id, message_type, content, created_at from queue_messages
+    where message_type = 'steer' and consumed_at is null
+    order by rowid asc
+  ]]) do
+    table.insert(messages, {
+      id = row.id as string,
+      message_type = row.message_type as string,
+      content = row.content as string,
+      created_at = row.created_at as integer,
+    })
+  end
+
+  -- Mark them as consumed
+  if #messages > 0 then
+    self._db:exec(
+      "update queue_messages set consumed_at = ? where message_type = 'steer' and consumed_at is null",
+      now)
+  end
+
+  return messages
+end
+
+-- Drain all unconsumed followup messages (returns them in order, marks as consumed)
+local function drain_followup(self: QueueDB): {QueueMessage}
+  local messages: {QueueMessage} = {}
+  local now = os.time()
+
+  -- Collect unconsumed followup messages (ordered by rowid for insertion order)
+  for row in self._db:query([[
+    select id, message_type, content, created_at from queue_messages
+    where message_type = 'followup' and consumed_at is null
+    order by rowid asc
+  ]]) do
+    table.insert(messages, {
+      id = row.id as string,
+      message_type = row.message_type as string,
+      content = row.content as string,
+      created_at = row.created_at as integer,
+    })
+  end
+
+  -- Mark them as consumed
+  if #messages > 0 then
+    self._db:exec(
+      "update queue_messages set consumed_at = ? where message_type = 'followup' and consumed_at is null",
+      now)
+  end
+
+  return messages
+end
+
+-- Get count of pending messages by type
+local function pending_count(self: QueueDB, message_type?: string): integer
+  local sql = "select count(*) as cnt from queue_messages where consumed_at is null"
+  if message_type then
+    sql = sql .. " and message_type = ?"
+    for row in self._db:query(sql, message_type) do
+      return (row.cnt or 0) as integer
+    end
+  else
+    for row in self._db:query(sql) do
+      return (row.cnt or 0) as integer
+    end
+  end
+  return 0
+end
+
+return {
+  -- Database operations
+  open = open,
+  close = close,
+
+  -- Lock operations
+  try_acquire_lock = try_acquire_lock,
+  release_lock = release_lock,
+  update_heartbeat = update_heartbeat,
+  is_locked = is_locked,
+  get_lock_info = get_lock_info,
+
+  -- Queue operations
+  add_steer = add_steer,
+  add_followup = add_followup,
+  drain_steering = drain_steering,
+  drain_followup = drain_followup,
+  pending_count = pending_count,
+
+  -- Types
+  QueueDB = QueueDB,
+  QueueMessage = QueueMessage,
+  LockInfo = LockInfo,
+
+  -- Constants
+  STALE_THRESHOLD = STALE_THRESHOLD,
+}

--- a/lib/ah/test_queue.tl
+++ b/lib/ah/test_queue.tl
@@ -1,0 +1,261 @@
+#!/usr/bin/env cosmic
+local fs = require("cosmic.fs")
+local unix = require("cosmo.unix")
+local queue = require("ah.queue")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local function test_open_close()
+  local db_path = fs.join(TEST_TMPDIR, "test_queue.db")
+  local qdb, err = queue.open(db_path)
+  assert(qdb, "failed to open queue db: " .. tostring(err))
+  queue.close(qdb)
+end
+test_open_close()
+
+local function test_lock_acquire_release()
+  local db_path = fs.join(TEST_TMPDIR, "test_lock.db")
+  local qdb = queue.open(db_path)
+
+  -- Initially not locked
+  local locked, pid = queue.is_locked(qdb)
+  assert(not locked, "should not be locked initially")
+
+  -- Acquire lock
+  local acquired, err = queue.try_acquire_lock(qdb)
+  assert(acquired, "should acquire lock: " .. tostring(err))
+
+  -- Check lock info
+  local info = queue.get_lock_info(qdb)
+  assert(info, "should have lock info")
+  assert(info.owner_pid == unix.getpid(), "owner_pid should be our pid")
+
+  -- Should be able to re-acquire our own lock
+  acquired, err = queue.try_acquire_lock(qdb)
+  assert(acquired, "should re-acquire own lock: " .. tostring(err))
+
+  -- Release lock
+  local released = queue.release_lock(qdb)
+  assert(released, "should release lock")
+
+  -- Should not be locked anymore
+  info = queue.get_lock_info(qdb)
+  assert(info == nil, "should have no lock info after release")
+
+  queue.close(qdb)
+end
+test_lock_acquire_release()
+
+local function test_heartbeat()
+  local db_path = fs.join(TEST_TMPDIR, "test_heartbeat.db")
+  local qdb = queue.open(db_path)
+
+  -- Acquire lock
+  queue.try_acquire_lock(qdb)
+
+  local info1 = queue.get_lock_info(qdb)
+  local heartbeat1 = info1.heartbeat_at
+
+  -- Wait a moment and update heartbeat
+  unix.nanosleep(0, 10000000)  -- 10ms
+  queue.update_heartbeat(qdb)
+
+  local info2 = queue.get_lock_info(qdb)
+  -- Heartbeat should be same or newer (usually same since we only have second precision)
+  assert(info2.heartbeat_at >= heartbeat1, "heartbeat should not decrease")
+
+  queue.release_lock(qdb)
+  queue.close(qdb)
+end
+test_heartbeat()
+
+local function test_add_steer()
+  local db_path = fs.join(TEST_TMPDIR, "test_steer.db")
+  local qdb = queue.open(db_path)
+
+  local msg = queue.add_steer(qdb, "test steering message")
+  assert(msg.id, "message should have id")
+  assert(msg.message_type == "steer", "message_type should be steer")
+  assert(msg.content == "test steering message", "content mismatch")
+
+  -- Should have 1 pending message
+  assert(queue.pending_count(qdb, "steer") == 1, "should have 1 pending steer")
+  assert(queue.pending_count(qdb, "followup") == 0, "should have 0 pending followup")
+
+  queue.close(qdb)
+end
+test_add_steer()
+
+local function test_add_followup()
+  local db_path = fs.join(TEST_TMPDIR, "test_followup.db")
+  local qdb = queue.open(db_path)
+
+  local msg = queue.add_followup(qdb, "test followup message")
+  assert(msg.id, "message should have id")
+  assert(msg.message_type == "followup", "message_type should be followup")
+  assert(msg.content == "test followup message", "content mismatch")
+
+  -- Should have 1 pending message
+  assert(queue.pending_count(qdb, "followup") == 1, "should have 1 pending followup")
+  assert(queue.pending_count(qdb, "steer") == 0, "should have 0 pending steer")
+
+  queue.close(qdb)
+end
+test_add_followup()
+
+local function test_drain_steering()
+  local db_path = fs.join(TEST_TMPDIR, "test_drain_steer.db")
+  local qdb = queue.open(db_path)
+
+  -- Add multiple steering messages
+  queue.add_steer(qdb, "steer 1")
+  queue.add_steer(qdb, "steer 2")
+  queue.add_steer(qdb, "steer 3")
+
+  assert(queue.pending_count(qdb, "steer") == 3, "should have 3 pending")
+
+  -- Drain steering messages
+  local messages = queue.drain_steering(qdb)
+  assert(#messages == 3, "should drain 3 messages")
+  assert(messages[1].content == "steer 1", "first message mismatch")
+  assert(messages[2].content == "steer 2", "second message mismatch")
+  assert(messages[3].content == "steer 3", "third message mismatch")
+
+  -- Should have 0 pending after drain
+  assert(queue.pending_count(qdb, "steer") == 0, "should have 0 pending after drain")
+
+  -- Draining again should return empty
+  local messages2 = queue.drain_steering(qdb)
+  assert(#messages2 == 0, "second drain should be empty")
+
+  queue.close(qdb)
+end
+test_drain_steering()
+
+local function test_drain_followup()
+  local db_path = fs.join(TEST_TMPDIR, "test_drain_followup.db")
+  local qdb = queue.open(db_path)
+
+  -- Add multiple followup messages
+  queue.add_followup(qdb, "followup 1")
+  queue.add_followup(qdb, "followup 2")
+
+  assert(queue.pending_count(qdb, "followup") == 2, "should have 2 pending")
+
+  -- Drain followup messages
+  local messages = queue.drain_followup(qdb)
+  assert(#messages == 2, "should drain 2 messages")
+  assert(messages[1].content == "followup 1", "first message mismatch")
+  assert(messages[2].content == "followup 2", "second message mismatch")
+
+  -- Should have 0 pending after drain
+  assert(queue.pending_count(qdb, "followup") == 0, "should have 0 pending after drain")
+
+  queue.close(qdb)
+end
+test_drain_followup()
+
+local function test_mixed_queues()
+  local db_path = fs.join(TEST_TMPDIR, "test_mixed.db")
+  local qdb = queue.open(db_path)
+
+  -- Add both types
+  queue.add_steer(qdb, "steer msg")
+  queue.add_followup(qdb, "followup msg")
+  queue.add_steer(qdb, "steer msg 2")
+
+  assert(queue.pending_count(qdb) == 3, "should have 3 total pending")
+  assert(queue.pending_count(qdb, "steer") == 2, "should have 2 pending steer")
+  assert(queue.pending_count(qdb, "followup") == 1, "should have 1 pending followup")
+
+  -- Drain steering only
+  local steer_msgs = queue.drain_steering(qdb)
+  assert(#steer_msgs == 2, "should drain 2 steer messages")
+
+  -- Followup should still be pending
+  assert(queue.pending_count(qdb, "followup") == 1, "followup should still be pending")
+
+  -- Drain followup
+  local followup_msgs = queue.drain_followup(qdb)
+  assert(#followup_msgs == 1, "should drain 1 followup message")
+
+  assert(queue.pending_count(qdb) == 0, "should have 0 total pending")
+
+  queue.close(qdb)
+end
+test_mixed_queues()
+
+local function test_stale_lock_detection()
+  local db_path = fs.join(TEST_TMPDIR, "test_stale.db")
+  local qdb = queue.open(db_path)
+
+  -- Manually insert a stale lock (old heartbeat)
+  local stale_time = os.time() - (queue.STALE_THRESHOLD + 10)
+  qdb._db:exec([[
+    insert or replace into session_lock (key, owner_pid, started_at, heartbeat_at)
+    values ('lock', 99999, ?, ?)
+  ]], stale_time, stale_time)
+
+  -- Lock should be considered stale
+  local locked, pid = queue.is_locked(qdb)
+  assert(not locked, "stale lock should not be considered locked")
+  assert(pid == 99999, "should return stale pid")
+
+  -- Should be able to acquire (claim) the stale lock
+  local acquired, err = queue.try_acquire_lock(qdb)
+  assert(acquired, "should claim stale lock: " .. tostring(err))
+
+  -- Now we own the lock
+  local info = queue.get_lock_info(qdb)
+  assert(info.owner_pid == unix.getpid(), "should now own the lock")
+
+  queue.release_lock(qdb)
+  queue.close(qdb)
+end
+test_stale_lock_detection()
+
+local function test_dead_process_detection()
+  local db_path = fs.join(TEST_TMPDIR, "test_dead.db")
+  local qdb = queue.open(db_path)
+
+  -- Insert a lock with a PID that doesn't exist (very high PID)
+  local now = os.time()
+  qdb._db:exec([[
+    insert or replace into session_lock (key, owner_pid, started_at, heartbeat_at)
+    values ('lock', 4000000000, ?, ?)
+  ]], now, now)
+
+  -- Lock should be considered stale because process is dead
+  local locked, pid = queue.is_locked(qdb)
+  assert(not locked, "dead process lock should not be considered locked")
+
+  -- Should be able to acquire
+  local acquired, err = queue.try_acquire_lock(qdb)
+  assert(acquired, "should claim dead process lock: " .. tostring(err))
+
+  queue.release_lock(qdb)
+  queue.close(qdb)
+end
+test_dead_process_detection()
+
+local function test_message_ordering()
+  local db_path = fs.join(TEST_TMPDIR, "test_ordering.db")
+  local qdb = queue.open(db_path)
+
+  -- Add messages in specific order
+  for i = 1, 5 do
+    queue.add_steer(qdb, "msg " .. i)
+  end
+
+  -- Drain and verify order (ULID should preserve insertion order)
+  local messages = queue.drain_steering(qdb)
+  for i = 1, 5 do
+    assert(messages[i].content == "msg " .. i,
+      "message " .. i .. " out of order: got " .. messages[i].content)
+  end
+
+  queue.close(qdb)
+end
+test_message_ordering()
+
+print("all queue tests passed")


### PR DESCRIPTION
## Summary

- Add inter-process coordination for `ah` sessions via queue database
- When a session is running, other instances can send steering (mid-run) or followup (after-completion) messages
- Add `--steer` and `--followup` CLI options to queue messages explicitly
- Prompts are auto-queued as followup when session is locked by another process

## Design

### Queue Storage
Separate SQLite database: `.ah/<ulid>.queue.db` alongside the session database.

### Locking Strategy
- First `ah` acquires lock on startup
- Lock owner updates heartbeat before each API call
- Lock is stale if heartbeat > 30 seconds old (crash recovery)
- Dead process detection via `kill(pid, 0)`

### CLI Behavior
- `ah --steer "msg"` - add steering message to queue, exit
- `ah --followup "msg"` - add followup message to queue, exit
- `ah "prompt"` - if locked, add as followup and exit with message; if unlocked, run normally

### Loop Integration
- Before each API call: drain steering queue, inject as `[STEERING]` user messages
- After turn completes (no tool calls): drain followup queue, continue if messages exist
- Update heartbeat before each API call

## Test plan

- [x] Unit tests for lock acquisition, stale lock takeover, message queuing/draining
- [x] All existing tests pass
- [x] Type checks pass