### PR TITLE
Add output truncation for tool results sent to LLM

### DIFF
--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -7,6 +7,7 @@ local tools = require("ah.tools")
 local auth = require("ah.auth")
 local events = require("ah.events")
 local queue = require("ah.queue")
+local truncate = require("ah.truncate")
 
 local ToolDetails = tools.ToolDetails
 
@@ -136,9 +137,11 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
           input = input,
         })
       elseif block.block_type == "tool_result" then
-        -- Check if result is structured (image content)
+        -- Truncate stored output for API (full output preserved in DB)
         local tool_output = block.tool_output as string
-        local api_content: any = tool_output
+        local truncation = truncate.truncate_output(tool_output or "", block.tool_name as string or "")
+        local api_content: any = truncation.content
+        -- Check if result is structured (image content)
         if tool_output and tool_output:sub(1, 14) == '{"__image__":' then
           local parsed = json.decode(tool_output) as {string:any}
           if parsed and parsed.__image__ and parsed.content then
@@ -458,14 +461,18 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       -- Recompute key with details for richer display in tool_call_end
       key = tool_key_param(tc.name as string, input_json, details_json)
 
-      -- Emit tool_call_end
+      -- Emit tool_call_end with full (non-truncated) output
       emit(on_event, events.tool_call_end(tc.name as string, result, is_error, elapsed_ms, key, i, tool_count))
 
-      -- Log tool_call_end event to DB
+      -- Log tool_call_end event to DB (without output to avoid bloat)
       db.log_event(d, "tool_call_end", assistant_msg.id, events.to_json(events.tool_call_end(tc.name as string, "", is_error, elapsed_ms, key, i, tool_count)))
 
-      -- Check if result is structured (image content)
-      local api_content: any = result
+      -- Truncate output for the API (full output preserved in DB and events)
+      local truncation = truncate.truncate_output(result, tc.name as string)
+      local api_result = truncation.content
+
+      -- Check if result is structured (image content) — skip truncation for images
+      local api_content: any = api_result
       if result:sub(1, 14) == '{"__image__":' then
         local parsed = json.decode(result) as {string:any}
         if parsed and parsed.__image__ and parsed.content then
@@ -473,7 +480,7 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
         end
       end
 
-      -- Collect for later atomic write
+      -- Collect for later atomic write (store full output in DB)
       table.insert(tool_result_blocks, {
         tool_id = tc.id as string,
         tool_output = result,
@@ -482,7 +489,7 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
         details = details_json,
       })
 
-      -- Add to API messages content
+      -- Add to API messages content (truncated output)
       table.insert(tool_results_content, {
         type = "tool_result",
         tool_use_id = tc.id,

--- a/lib/ah/test_truncate.tl
+++ b/lib/ah/test_truncate.tl
@@ -1,0 +1,213 @@
+#!/usr/bin/env cosmic
+-- test_truncate.tl: tests for output truncation module
+local truncate = require("ah.truncate")
+
+-- count_lines tests
+local function test_count_lines_empty()
+  assert(truncate.count_lines("") == 0, "empty string should have 0 lines")
+  print("✓ count_lines empty")
+end
+test_count_lines_empty()
+
+local function test_count_lines_one()
+  assert(truncate.count_lines("hello") == 1, "single line should be 1")
+  print("✓ count_lines single line")
+end
+test_count_lines_one()
+
+local function test_count_lines_multiple()
+  assert(truncate.count_lines("a\nb\nc") == 3, "three lines: " .. tostring(truncate.count_lines("a\nb\nc")))
+  print("✓ count_lines multiple lines")
+end
+test_count_lines_multiple()
+
+local function test_count_lines_trailing_newline()
+  assert(truncate.count_lines("a\nb\n") == 3, "trailing newline counts: " .. tostring(truncate.count_lines("a\nb\n")))
+  print("✓ count_lines trailing newline")
+end
+test_count_lines_trailing_newline()
+
+-- truncate_chars tests
+local function test_truncate_chars_short()
+  local result, truncated = truncate.truncate_chars("hello", 100)
+  assert(result == "hello", "short string unchanged")
+  assert(not truncated, "should not be truncated")
+  print("✓ truncate_chars no-op for short strings")
+end
+test_truncate_chars_short()
+
+local function test_truncate_chars_exact()
+  local s = string.rep("x", 100)
+  local result, truncated = truncate.truncate_chars(s, 100)
+  assert(result == s, "exact length unchanged")
+  assert(not truncated, "should not be truncated")
+  print("✓ truncate_chars exact length")
+end
+test_truncate_chars_exact()
+
+local function test_truncate_chars_long()
+  local s = string.rep("x", 1000)
+  local result, truncated = truncate.truncate_chars(s, 200)
+  assert(truncated, "should be truncated")
+  assert(#result < 1000, "result should be shorter than original")
+  assert(result:match("%[output truncated:"), "should have truncation notice")
+  assert(result:match("800 bytes removed"), "should report bytes removed")
+  -- Head and tail should be present
+  assert(result:sub(1, 1) == "x", "head should be preserved")
+  assert(result:sub(-1) == "x", "tail should be preserved")
+  print("✓ truncate_chars long string")
+end
+test_truncate_chars_long()
+
+local function test_truncate_chars_preserves_head_tail()
+  -- Build distinct head and tail
+  local head = string.rep("H", 50)
+  local middle = string.rep("M", 200)
+  local tail = string.rep("T", 50)
+  local s = head .. middle .. tail
+  local result, truncated = truncate.truncate_chars(s, 120)
+  assert(truncated, "should be truncated")
+  -- Result should start with Hs and end with Ts
+  assert(result:sub(1, 10) == string.rep("H", 10), "head preserved")
+  assert(result:sub(-10) == string.rep("T", 10), "tail preserved")
+  assert(result:match("%[output truncated:"), "has truncation notice")
+  print("✓ truncate_chars preserves head and tail")
+end
+test_truncate_chars_preserves_head_tail()
+
+-- truncate_lines tests
+local function test_truncate_lines_short()
+  local result, truncated = truncate.truncate_lines("a\nb\nc", 10)
+  assert(result == "a\nb\nc", "short unchanged")
+  assert(not truncated, "should not be truncated")
+  print("✓ truncate_lines no-op for few lines")
+end
+test_truncate_lines_short()
+
+local function test_truncate_lines_long()
+  local lines = {}
+  for i = 1, 20 do
+    table.insert(lines, "line" .. tostring(i))
+  end
+  local s = table.concat(lines, "\n")
+  local result, truncated = truncate.truncate_lines(s, 10)
+  assert(truncated, "should be truncated")
+  -- First 5 lines preserved
+  assert(result:match("^line1\n"), "first line preserved")
+  assert(result:match("line5\n"), "fifth line preserved")
+  -- Last 5 lines preserved
+  assert(result:match("line16\n"), "line 16 preserved")
+  assert(result:match("line20"), "last line preserved")
+  -- Omission notice
+  assert(result:match("%[%.%.%.10 lines omitted%.%.%.%]"), "omission notice: " .. result)
+  print("✓ truncate_lines head/tail split")
+end
+test_truncate_lines_long()
+
+local function test_truncate_lines_exact()
+  local lines = {}
+  for i = 1, 10 do
+    table.insert(lines, "line" .. tostring(i))
+  end
+  local s = table.concat(lines, "\n")
+  local result, truncated = truncate.truncate_lines(s, 10)
+  assert(not truncated, "exact count should not truncate")
+  print("✓ truncate_lines exact count")
+end
+test_truncate_lines_exact()
+
+-- truncate_output integration tests
+local function test_truncate_output_short()
+  local r = truncate.truncate_output("hello world", "bash")
+  assert(r.content == "hello world", "short output unchanged")
+  assert(not r.truncated, "should not be truncated")
+  assert(r.original_bytes == 11, "original bytes: " .. tostring(r.original_bytes))
+  assert(r.original_lines == 1, "original lines: " .. tostring(r.original_lines))
+  print("✓ truncate_output short string")
+end
+test_truncate_output_short()
+
+local function test_truncate_output_bash_limit()
+  -- bash limit is 30000 chars
+  local s = string.rep("x", 40000)
+  local r = truncate.truncate_output(s, "bash")
+  assert(r.truncated, "should be truncated")
+  assert(r.original_bytes == 40000, "original bytes preserved")
+  assert(r.content:match("%[output truncated:"), "has char truncation notice")
+  print("✓ truncate_output applies bash char limit")
+end
+test_truncate_output_bash_limit()
+
+local function test_truncate_output_read_limit()
+  -- read limit is 50000 chars
+  local s = string.rep("x", 40000)
+  local r = truncate.truncate_output(s, "read")
+  assert(not r.truncated, "40K should not exceed read's 50K limit")
+
+  local s2 = string.rep("x", 60000)
+  local r2 = truncate.truncate_output(s2, "read")
+  assert(r2.truncated, "60K should exceed read's 50K limit")
+  print("✓ truncate_output applies read char limit")
+end
+test_truncate_output_read_limit()
+
+local function test_truncate_output_unknown_tool()
+  -- Unknown tools use DEFAULT_CHAR_LIMIT (30000)
+  local s = string.rep("x", 40000)
+  local r = truncate.truncate_output(s, "custom_tool")
+  assert(r.truncated, "should truncate unknown tool at default limit")
+  print("✓ truncate_output handles unknown tools")
+end
+test_truncate_output_unknown_tool()
+
+local function test_truncate_output_bash_line_limit()
+  -- bash has 256 line limit
+  local lines = {}
+  for i = 1, 300 do
+    table.insert(lines, "line" .. tostring(i))
+  end
+  local s = table.concat(lines, "\n")
+  local r = truncate.truncate_output(s, "bash")
+  assert(r.truncated, "should be truncated by line limit")
+  assert(r.content:match("lines omitted"), "has line omission notice")
+  -- First and last lines preserved
+  assert(r.content:match("line1\n"), "first line preserved")
+  assert(r.content:match("line300"), "last line preserved")
+  print("✓ truncate_output applies bash line limit")
+end
+test_truncate_output_bash_line_limit()
+
+local function test_truncate_output_read_no_line_limit()
+  -- read has no line limit, only char limit
+  local lines = {}
+  for i = 1, 300 do
+    table.insert(lines, "L" .. tostring(i))
+  end
+  local s = table.concat(lines, "\n")
+  local r = truncate.truncate_output(s, "read")
+  assert(not r.truncated, "300 short lines should be under read's 50K char limit")
+  assert(not r.content:match("lines omitted"), "no line truncation for read")
+  print("✓ truncate_output read has no line limit")
+end
+test_truncate_output_read_no_line_limit()
+
+local function test_truncate_output_empty()
+  local r = truncate.truncate_output("", "bash")
+  assert(r.content == "", "empty string unchanged")
+  assert(not r.truncated, "empty not truncated")
+  assert(r.original_bytes == 0, "0 bytes")
+  assert(r.original_lines == 0, "0 lines")
+  print("✓ truncate_output empty string")
+end
+test_truncate_output_empty()
+
+local function test_truncate_chars_notice_content()
+  -- Verify the notice shows correct byte count
+  local s = string.rep("a", 500)
+  local result, _ = truncate.truncate_chars(s, 200)
+  assert(result:match("300 bytes removed from middle"), "notice should show 300 bytes removed: " .. result)
+  print("✓ truncate_chars notice shows correct byte count")
+end
+test_truncate_chars_notice_content()
+
+print("\nAll truncate tests passed!")

--- a/lib/ah/truncate.tl
+++ b/lib/ah/truncate.tl
@@ -1,0 +1,123 @@
+-- ah/truncate.tl: output truncation for tool results
+--
+-- Truncates tool output before sending to the LLM while preserving full output
+-- in the database and event stream. Two-pass approach: character-based truncation
+-- first (primary size safeguard), then line-based truncation (readability pass).
+
+local record TruncateResult
+  content: string
+  truncated: boolean
+  original_bytes: integer
+  original_lines: integer
+end
+
+-- Default per-tool character limits
+local DEFAULT_CHAR_LIMITS: {string:integer} = {
+  bash = 30000,
+  read = 50000,
+  write = 10000,
+  edit = 10000,
+}
+
+-- Default per-tool line limits (applied after character truncation)
+local DEFAULT_LINE_LIMITS: {string:integer} = {
+  bash = 256,
+}
+
+-- Fallback limit for tools not in the table
+local DEFAULT_CHAR_LIMIT = 30000
+
+-- Count lines in a string
+local function count_lines(s: string): integer
+  if s == "" then return 0 end
+  local n = 1
+  for _ in s:gmatch("\n") do
+    n = n + 1
+  end
+  return n
+end
+
+-- Truncate by characters using head/tail split: keep the beginning and end,
+-- remove the middle. This preserves context (imports, setup) and results (final output).
+local function truncate_chars(output: string, max_chars: integer): string, boolean
+  if #output <= max_chars then
+    return output, false
+  end
+
+  local half = math.floor(max_chars / 2)
+  local removed = #output - max_chars
+  local head = output:sub(1, half)
+  local tail = output:sub(-half)
+
+  return head
+    .. "\n\n[output truncated: " .. tostring(removed) .. " bytes removed from middle]\n\n"
+    .. tail, true
+end
+
+-- Truncate by line count using head/tail split: keep first and last lines.
+local function truncate_lines(output: string, max_lines: integer): string, boolean
+  local lines: {string} = {}
+  for line in output:gmatch("([^\n]*)\n?") do
+    table.insert(lines, line)
+  end
+  -- Remove trailing empty from gmatch
+  if #lines > 0 and lines[#lines] == "" then
+    table.remove(lines)
+  end
+
+  if #lines <= max_lines then
+    return output, false
+  end
+
+  local head_count = math.floor(max_lines / 2)
+  local tail_count = max_lines - head_count
+  local omitted = #lines - head_count - tail_count
+
+  local head_lines: {string} = {}
+  for i = 1, head_count do
+    table.insert(head_lines, lines[i])
+  end
+
+  local tail_lines: {string} = {}
+  for i = #lines - tail_count + 1, #lines do
+    table.insert(tail_lines, lines[i])
+  end
+
+  return table.concat(head_lines, "\n")
+    .. "\n[..." .. tostring(omitted) .. " lines omitted...]\n"
+    .. table.concat(tail_lines, "\n"), true
+end
+
+-- Truncate tool output: character-based first, then line-based.
+-- Returns a TruncateResult with the (possibly truncated) content and metadata.
+local function truncate_output(output: string, tool_name: string): TruncateResult
+  local original_bytes: integer = #output
+  local original_lines: integer = count_lines(output)
+
+  local max_chars = DEFAULT_CHAR_LIMITS[tool_name] or DEFAULT_CHAR_LIMIT
+  local result, char_truncated = truncate_chars(output, max_chars)
+
+  local line_truncated = false
+  local max_lines = DEFAULT_LINE_LIMITS[tool_name]
+  if max_lines then
+    result, line_truncated = truncate_lines(result, max_lines)
+  end
+
+  return {
+    content = result,
+    truncated = char_truncated or line_truncated,
+    original_bytes = original_bytes,
+    original_lines = original_lines,
+  }
+end
+
+return {
+  truncate_output = truncate_output,
+  truncate_chars = truncate_chars,
+  truncate_lines = truncate_lines,
+  count_lines = count_lines,
+  TruncateResult = TruncateResult,
+  DEFAULT_CHAR_LIMITS = DEFAULT_CHAR_LIMITS,
+  DEFAULT_LINE_LIMITS = DEFAULT_LINE_LIMITS,
+  DEFAULT_CHAR_LIMIT = DEFAULT_CHAR_LIMIT,
+}


### PR DESCRIPTION
## Summary
Implement intelligent output truncation for tool results before sending to the LLM, while preserving full output in the database and event stream. This prevents context window overflow and improves API reliability without losing data.

## Key Changes
- **New `ah/truncate.tl` module**: Implements two-pass truncation strategy
  - Character-based truncation (primary safeguard): Removes middle content while preserving head and tail for context
  - Line-based truncation (readability pass): Limits output to tool-specific line counts (e.g., bash: 256 lines)
  - Per-tool limits: bash (30K chars, 256 lines), read (50K chars), write/edit (10K chars)
  
- **Updated `ah/loop.tl`**: Integrates truncation into agent loop
  - Tool results are truncated before sending to API via `truncate_output()`
  - Full output stored in database for audit trail
  - Full output emitted in events for observability
  - Special handling for structured outputs (images) that bypass truncation
  
- **Comprehensive test suite** (`ah/test_truncate.tl`): 213 lines of tests covering
  - Line counting edge cases (empty, trailing newlines)
  - Character truncation with head/tail preservation
  - Line truncation with omission notices
  - Per-tool limits and unknown tool handling
  - Integration tests for the full `truncate_output()` function

## Implementation Details
- Head/tail split strategy preserves both context (imports, setup at start) and results (final output at end)
- Truncation notices clearly indicate what was removed and how many bytes/lines
- Two-pass approach allows character limits to prevent API errors, then line limits improve readability
- Full output always preserved in DB and events—truncation only affects API messages

https://claude.ai/code/session_01ArC9yWjFbs43f3NXXLenVi