### PR TITLE
loop: add repetition detection and steering injection

### DIFF
--- a/lib/ah/events.tl
+++ b/lib/ah/events.tl
@@ -55,6 +55,11 @@ local record EventData
   -- steering/followup
   content: string
   message_count: integer
+
+  -- loop_detected
+  consecutive_count: integer
+  turn_signature: string
+  action: string  -- "warn" or "break"
 end
 
 local type EventCallback = function(event: EventData)
@@ -161,6 +166,14 @@ local function followup_received(content: string, message_count: integer): Event
   return e
 end
 
+local function loop_detected(consecutive_count: integer, signature: string, action: string): EventData
+  local e = make_event("loop_detected")
+  e.consecutive_count = consecutive_count
+  e.turn_signature = signature
+  e.action = action
+  return e
+end
+
 -- Serialize an event to JSON (for persistence or JSON logging)
 local function to_json(event: EventData): string
   local t: {string:any} = {}
@@ -192,6 +205,7 @@ return {
   state_change = state_change,
   steering_received = steering_received,
   followup_received = followup_received,
+  loop_detected = loop_detected,
 
   -- Serialization
   to_json = to_json,

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -14,6 +14,10 @@ local ToolDetails = tools.ToolDetails
 -- Reference the global interrupted flag (set by application layer)
 global interrupted: boolean
 
+-- Loop detection thresholds
+local LOOP_WARN_THRESHOLD = 3   -- Consecutive identical turns before steering injection
+local LOOP_BREAK_THRESHOLD = 5  -- Consecutive identical turns before forced break
+
 -- Get monotonic time in seconds
 local function now(): number
   local s, ns = unix.clock_gettime(unix.CLOCK_MONOTONIC)
@@ -65,6 +69,36 @@ local function tool_key_param(tool_name: string, tool_input: string, details_jso
     return cmd
   end
   return ""
+end
+
+-- Compute a turn signature from a list of tool calls.
+-- The signature captures the tool names and key parameters to identify
+-- repetitive patterns across turns.
+local function turn_signature(tool_calls: {any}): string
+  local parts: {string} = {}
+  for _, tool_call in ipairs(tool_calls) do
+    local tc = tool_call as {string:any}
+    local input_json = json.encode(tc.input or {})
+    local key = tool_key_param(tc.name as string, input_json, nil)
+    table.insert(parts, (tc.name as string) .. ":" .. key)
+  end
+  return table.concat(parts, "|")
+end
+
+-- Check for consecutive identical signatures at the end of the history.
+-- Returns the count of consecutive identical entries (1 = no repetition).
+local function check_loop(history: {string}): integer
+  if #history < 2 then return #history end
+  local current = history[#history]
+  local count = 1
+  for i = #history - 1, 1, -1 do
+    if history[i] == current then
+      count = count + 1
+    else
+      break
+    end
+  end
+  return count
 end
 
 -- Emit an event through the callback, silently ignoring if no callback
@@ -166,6 +200,9 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
   -- Track final stop reason for agent_end event
   local final_stop_reason = "unknown"
+
+  -- Turn signature history for loop detection
+  local turn_history: {string} = {}
 
   -- Closure for api.stream to check interruption mid-stream
   local function is_interrupted(): boolean
@@ -526,6 +563,45 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       break
     end
 
+    -- Loop detection: check for repetitive tool call patterns
+    local sig = turn_signature(tool_calls)
+    table.insert(turn_history, sig)
+    local consecutive = check_loop(turn_history)
+
+    if consecutive >= LOOP_BREAK_THRESHOLD then
+      -- Too many identical turns even after steering - force break
+      emit(on_event, events.loop_detected(consecutive, sig, "break"))
+      db.log_event(d, "loop_detected", assistant_msg.id,
+        events.to_json(events.loop_detected(consecutive, sig, "break")))
+      final_stop_reason = "loop_detected"
+      break
+    elseif consecutive >= LOOP_WARN_THRESHOLD then
+      -- Inject steering to break the loop
+      emit(on_event, events.loop_detected(consecutive, sig, "warn"))
+      db.log_event(d, "loop_detected", assistant_msg.id,
+        events.to_json(events.loop_detected(consecutive, sig, "warn")))
+
+      local steering_text = string.format(
+        "[LOOP DETECTED] You have repeated the same tool call pattern %d times (%s). " ..
+        "This indicates you may be stuck in a loop. Try a different approach or " ..
+        "ask the user for help.",
+        consecutive, sig)
+
+      -- Create steering user message
+      db.begin_transaction(d)
+      local loop_steer_msg = db.create_message(d, "user", user_msg.id)
+      db.add_content_block(d, loop_steer_msg.id, "text", {content = steering_text})
+      db.commit(d)
+
+      -- Add to API messages
+      table.insert(api_messages, {
+        role = "user",
+        content = {{type = "text", text = steering_text}},
+      })
+
+      user_msg = loop_steer_msg
+    end
+
     final_stop_reason = "tool_use"
 
     ::continue_loop::
@@ -550,4 +626,8 @@ end
 return {
   run_agent = run_agent,
   tool_key_param = tool_key_param,
+  turn_signature = turn_signature,
+  check_loop = check_loop,
+  LOOP_WARN_THRESHOLD = LOOP_WARN_THRESHOLD,
+  LOOP_BREAK_THRESHOLD = LOOP_BREAK_THRESHOLD,
 }

--- a/lib/ah/test_events.tl
+++ b/lib/ah/test_events.tl
@@ -178,4 +178,34 @@ local function test_state_change_json()
 end
 test_state_change_json()
 
+-- Test loop_detected constructor
+local function test_loop_detected()
+  local e = events.loop_detected(3, "bash:ls|read:/tmp/foo", "warn")
+  assert(e.event_type == "loop_detected", "event_type should be loop_detected")
+  assert(e.consecutive_count == 3, "consecutive_count should be 3")
+  assert(e.turn_signature == "bash:ls|read:/tmp/foo", "turn_signature mismatch")
+  assert(e.action == "warn", "action should be warn")
+end
+test_loop_detected()
+
+-- Test loop_detected break action
+local function test_loop_detected_break()
+  local e = events.loop_detected(5, "bash:ls", "break")
+  assert(e.action == "break", "action should be break")
+  assert(e.consecutive_count == 5, "consecutive_count should be 5")
+end
+test_loop_detected_break()
+
+-- Test loop_detected serialization
+local function test_loop_detected_json()
+  local e = events.loop_detected(4, "edit:/tmp/file.lua", "warn")
+  local json_str = events.to_json(e)
+  local parsed = json.decode(json_str) as {string:any}
+  assert(parsed.event_type == "loop_detected", "event_type should survive round-trip")
+  assert(parsed.consecutive_count == 4, "consecutive_count should survive round-trip")
+  assert(parsed.turn_signature == "edit:/tmp/file.lua", "turn_signature should survive round-trip")
+  assert(parsed.action == "warn", "action should survive round-trip")
+end
+test_loop_detected_json()
+
 print("all events tests passed")

--- a/lib/ah/test_loop.tl
+++ b/lib/ah/test_loop.tl
@@ -110,4 +110,104 @@ local function test_tool_key_param_nil_details_fallback()
 end
 test_tool_key_param_nil_details_fallback()
 
+-- Tests for turn_signature
+local function test_turn_signature_single()
+  local tool_calls = {
+    {name = "bash", input = {command = "ls -la"}},
+  }
+  local sig = loop.turn_signature(tool_calls)
+  assert(sig == "bash:ls -la", "single tool call signature: " .. sig)
+end
+test_turn_signature_single()
+
+local function test_turn_signature_multiple()
+  local tool_calls = {
+    {name = "read", input = {path = "/tmp/foo.txt"}},
+    {name = "bash", input = {command = "echo hello"}},
+  }
+  local sig = loop.turn_signature(tool_calls)
+  assert(sig == "read:/tmp/foo.txt|bash:echo hello", "multi tool call signature: " .. sig)
+end
+test_turn_signature_multiple()
+
+local function test_turn_signature_empty()
+  local tool_calls: {any} = {}
+  local sig = loop.turn_signature(tool_calls)
+  assert(sig == "", "empty tool calls should give empty signature: " .. sig)
+end
+test_turn_signature_empty()
+
+local function test_turn_signature_edit()
+  local tool_calls = {
+    {name = "edit", input = {path = "/tmp/file.lua", old_string = "foo", new_string = "bar"}},
+  }
+  local sig = loop.turn_signature(tool_calls)
+  assert(sig:match("edit:"), "should start with edit: " .. sig)
+  assert(sig:match("/tmp/file.lua"), "should include path: " .. sig)
+end
+test_turn_signature_edit()
+
+local function test_turn_signature_deterministic()
+  local tool_calls = {
+    {name = "bash", input = {command = "ls"}},
+    {name = "read", input = {path = "/tmp/a.txt"}},
+  }
+  local sig1 = loop.turn_signature(tool_calls)
+  local sig2 = loop.turn_signature(tool_calls)
+  assert(sig1 == sig2, "same tool calls should produce same signature")
+end
+test_turn_signature_deterministic()
+
+-- Tests for check_loop
+local function test_check_loop_empty()
+  local count = loop.check_loop({})
+  assert(count == 0, "empty history should return 0: " .. count)
+end
+test_check_loop_empty()
+
+local function test_check_loop_single()
+  local count = loop.check_loop({"bash:ls"})
+  assert(count == 1, "single entry should return 1: " .. count)
+end
+test_check_loop_single()
+
+local function test_check_loop_no_repeat()
+  local count = loop.check_loop({"bash:ls", "read:/tmp/foo", "bash:pwd"})
+  assert(count == 1, "no repeat should return 1: " .. count)
+end
+test_check_loop_no_repeat()
+
+local function test_check_loop_two_repeat()
+  local count = loop.check_loop({"bash:ls", "bash:ls"})
+  assert(count == 2, "two identical should return 2: " .. count)
+end
+test_check_loop_two_repeat()
+
+local function test_check_loop_three_repeat()
+  local count = loop.check_loop({"read:/tmp/a", "bash:ls", "bash:ls", "bash:ls"})
+  assert(count == 3, "three consecutive identical should return 3: " .. count)
+end
+test_check_loop_three_repeat()
+
+local function test_check_loop_broken_sequence()
+  local count = loop.check_loop({"bash:ls", "bash:ls", "read:/tmp/a", "bash:ls"})
+  assert(count == 1, "broken sequence should return 1: " .. count)
+end
+test_check_loop_broken_sequence()
+
+local function test_check_loop_five_repeat()
+  local history = {"bash:ls", "bash:ls", "bash:ls", "bash:ls", "bash:ls"}
+  local count = loop.check_loop(history)
+  assert(count == 5, "five identical should return 5: " .. count)
+end
+test_check_loop_five_repeat()
+
+-- Test thresholds are exported and sensible
+local function test_thresholds()
+  assert(loop.LOOP_WARN_THRESHOLD == 3, "LOOP_WARN_THRESHOLD should be 3")
+  assert(loop.LOOP_BREAK_THRESHOLD == 5, "LOOP_BREAK_THRESHOLD should be 5")
+  assert(loop.LOOP_BREAK_THRESHOLD > loop.LOOP_WARN_THRESHOLD, "break should be greater than warn")
+end
+test_thresholds()
+
 print("all loop tests passed")


### PR DESCRIPTION
Implements loop detection as identified in the convergence analysis (PR #29,
gap #13). Tracks tool call patterns across turns and detects when the agent
repeats identical operations:

- Computes turn signatures from tool names and key parameters
- Warns via steering injection after 3 consecutive identical turns
- Forces loop break after 5 consecutive identical turns
- Emits loop_detected events for observability
- Persists loop events to the database for diagnostics

https://claude.ai/code/session_01PWrJsmJcXpt6b1KxenTje3