### PR TITLE
feat: implement context compaction for long conversations

### DIFF
--- a/lib/ah/compact.tl
+++ b/lib/ah/compact.tl
@@ -1,0 +1,116 @@
+-- ah/compact.tl: context compaction for long conversations
+--
+-- When a conversation approaches the model's context window limit, compaction
+-- summarizes the history so the agent can continue. This is a view-layer
+-- operation: compaction only affects what is sent to the API. The full
+-- conversation is always preserved in the database.
+
+local api = require("ah.api")
+
+-- Model context window limits (tokens)
+local MODEL_CONTEXT_LIMITS: {string:integer} = {
+  ["claude-sonnet-4-20250514"] = 200000,
+  ["claude-opus-4-20250514"] = 200000,
+  ["claude-haiku-3-20250314"] = 200000,
+}
+
+local DEFAULT_CONTEXT_LIMIT = 200000
+
+-- Compaction triggers when input_tokens / context_limit exceeds this ratio
+local DEFAULT_THRESHOLD = 0.8
+
+local COMPACTION_SYSTEM_PROMPT = [[Summarize this conversation for continuation in a new context window. Preserve:
+- What was accomplished so far
+- Current work in progress
+- Files read, written, or edited (include full paths)
+- Pending next steps
+- Key constraints or decisions made
+- Any errors encountered and how they were resolved
+
+Be thorough but concise. This summary will replace the full conversation history.]]
+
+local record CompactResult
+  summary: string
+  input_tokens: integer
+  output_tokens: integer
+end
+
+-- Get context window limit for a model (tokens)
+local function get_context_limit(model: string): integer
+  if model then
+    return MODEL_CONTEXT_LIMITS[model] or DEFAULT_CONTEXT_LIMIT
+  end
+  return DEFAULT_CONTEXT_LIMIT
+end
+
+-- Check if compaction is needed based on token usage from the last API response
+local function needs_compaction(input_tokens: integer, model: string, threshold?: number): boolean
+  if not input_tokens or input_tokens == 0 then
+    return false
+  end
+  threshold = threshold or DEFAULT_THRESHOLD
+  local limit = get_context_limit(model)
+  return (input_tokens / limit) > threshold
+end
+
+-- Perform compaction: send current conversation to the API with a summarization
+-- prompt (no tools). Returns a CompactResult with the summary text, or nil and
+-- an error string.
+local function compact(api_messages: {any}, model: string, is_interrupted: function(): boolean): CompactResult, string
+  -- Call API with existing messages and compaction system prompt (no tools)
+  local response, err = api.stream(api_messages, {
+    system = COMPACTION_SYSTEM_PROMPT,
+    model = model,
+  } as {string:any}, nil, is_interrupted)
+
+  if err then
+    return nil, "compaction failed: " .. err
+  end
+
+  if not response then
+    return nil, "compaction failed: no response"
+  end
+
+  local resp = response as {string:any}
+
+  -- If interrupted mid-compaction, bail out
+  if resp.stop_reason == "interrupted" then
+    return nil, "compaction interrupted"
+  end
+
+  -- Extract text from response content blocks
+  local summary_parts: {string} = {}
+  local resp_content = resp.content as {any}
+  if resp_content then
+    for _, block in ipairs(resp_content) do
+      local b = block as {string:any}
+      if b.type == "text" and b.text then
+        table.insert(summary_parts, b.text as string)
+      end
+    end
+  end
+
+  local summary = table.concat(summary_parts)
+  if summary == "" then
+    return nil, "compaction failed: empty summary"
+  end
+
+  local usage = (resp.usage or {}) as {string:any}
+
+  return {
+    summary = summary,
+    input_tokens = (usage.input_tokens or 0) as integer,
+    output_tokens = (usage.output_tokens or 0) as integer,
+  }, nil
+end
+
+return {
+  needs_compaction = needs_compaction,
+  compact = compact,
+  get_context_limit = get_context_limit,
+  CompactResult = CompactResult,
+  MODEL_CONTEXT_LIMITS = MODEL_CONTEXT_LIMITS,
+  DEFAULT_CONTEXT_LIMIT = DEFAULT_CONTEXT_LIMIT,
+  DEFAULT_THRESHOLD = DEFAULT_THRESHOLD,
+  COMPACTION_SYSTEM_PROMPT = COMPACTION_SYSTEM_PROMPT,
+}

--- a/lib/ah/events.tl
+++ b/lib/ah/events.tl
@@ -60,6 +60,9 @@ local record EventData
   consecutive_count: integer
   turn_signature: string
   action: string  -- "warn" or "break"
+
+  -- compaction
+  context_limit: integer
 end
 
 local type EventCallback = function(event: EventData)
@@ -174,6 +177,20 @@ local function loop_detected(consecutive_count: integer, signature: string, acti
   return e
 end
 
+local function compaction_triggered(input_tokens: integer, context_limit: integer): EventData
+  local e = make_event("compaction_triggered")
+  e.input_tokens = input_tokens
+  e.context_limit = context_limit
+  return e
+end
+
+local function compaction_complete(input_tokens: integer, output_tokens: integer): EventData
+  local e = make_event("compaction_complete")
+  e.input_tokens = input_tokens
+  e.output_tokens = output_tokens
+  return e
+end
+
 -- Serialize an event to JSON (for persistence or JSON logging)
 local function to_json(event: EventData): string
   local t: {string:any} = {}
@@ -206,6 +223,8 @@ return {
   steering_received = steering_received,
   followup_received = followup_received,
   loop_detected = loop_detected,
+  compaction_triggered = compaction_triggered,
+  compaction_complete = compaction_complete,
 
   -- Serialization
   to_json = to_json,

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -496,6 +496,12 @@ local function make_cli_handler(): events.EventCallback
       -- Text output complete for this turn; check if tool calls follow
       -- (tool_call_start will handle the newline separator)
 
+    elseif t == "compaction_triggered" then
+      io.stderr:write(string.format("\n%scompacting conversation (%d/%d tokens)...%s\n", DIM, event.input_tokens, event.context_limit, RESET))
+
+    elseif t == "compaction_complete" then
+      io.stderr:write(string.format("%scompaction complete (summary: %d tokens)%s\n\n", DIM, event.output_tokens, RESET))
+
     elseif t == "tool_call_start" then
       -- Separator between text and first tool block
       if event.tool_index == 1 then

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -8,6 +8,7 @@ local auth = require("ah.auth")
 local events = require("ah.events")
 local queue = require("ah.queue")
 local truncate = require("ah.truncate")
+local compact = require("ah.compact")
 
 local ToolDetails = tools.ToolDetails
 
@@ -204,6 +205,9 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
   -- Turn signature history for loop detection
   local turn_history: {string} = {}
 
+  -- Track input tokens from last API response for compaction decisions
+  local last_input_tokens: integer = 0
+
   -- Closure for api.stream to check interruption mid-stream
   local function is_interrupted(): boolean
     return interrupted
@@ -233,6 +237,30 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
         -- Update parent for next iteration
         user_msg = steer_user_msg
+      end
+    end
+
+    -- Check if compaction is needed before API call
+    if last_input_tokens > 0 and compact.needs_compaction(last_input_tokens, model) then
+      local context_limit = compact.get_context_limit(model)
+      emit(on_event, events.compaction_triggered(last_input_tokens, context_limit))
+      db.log_event(d, "compaction_triggered", nil, events.to_json(events.compaction_triggered(last_input_tokens, context_limit)))
+
+      local compact_result, compact_err = compact.compact(api_messages, model, is_interrupted)
+      if compact_result then
+        -- Replace api_messages with compacted summary
+        api_messages = {{
+          role = "user",
+          content = {{type = "text", text = compact_result.summary}},
+        }}
+        last_input_tokens = 0  -- Reset to avoid re-triggering
+
+        emit(on_event, events.compaction_complete(compact_result.input_tokens, compact_result.output_tokens))
+        db.log_event(d, "compaction_complete", nil, events.to_json(events.compaction_complete(compact_result.input_tokens, compact_result.output_tokens)))
+      else
+        -- Compaction failed - continue without it
+        emit(on_event, events.error_event(compact_err))
+        last_input_tokens = 0  -- Don't keep retrying
       end
     end
 
@@ -327,6 +355,7 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
     -- Extract usage and metadata from response
     local usage = (resp.usage or {}) as {string:any}
+    last_input_tokens = (usage.input_tokens or 0) as integer
     local msg_opts: db.MessageOpts = {
       input_tokens = usage.input_tokens as integer,
       output_tokens = usage.output_tokens as integer,

--- a/lib/ah/test_compact.tl
+++ b/lib/ah/test_compact.tl
@@ -1,0 +1,145 @@
+#!/usr/bin/env cosmic
+-- test_compact.tl: tests for context compaction module
+local compact = require("ah.compact")
+
+-- get_context_limit tests
+
+local function test_get_context_limit_known_model()
+  local limit = compact.get_context_limit("claude-sonnet-4-20250514")
+  assert(limit == 200000, "sonnet context limit should be 200000: " .. tostring(limit))
+  print("✓ get_context_limit known model (sonnet)")
+end
+test_get_context_limit_known_model()
+
+local function test_get_context_limit_opus()
+  local limit = compact.get_context_limit("claude-opus-4-20250514")
+  assert(limit == 200000, "opus context limit should be 200000: " .. tostring(limit))
+  print("✓ get_context_limit known model (opus)")
+end
+test_get_context_limit_opus()
+
+local function test_get_context_limit_haiku()
+  local limit = compact.get_context_limit("claude-haiku-3-20250314")
+  assert(limit == 200000, "haiku context limit should be 200000: " .. tostring(limit))
+  print("✓ get_context_limit known model (haiku)")
+end
+test_get_context_limit_haiku()
+
+local function test_get_context_limit_unknown_model()
+  local limit = compact.get_context_limit("unknown-model-v1")
+  assert(limit == compact.DEFAULT_CONTEXT_LIMIT, "unknown model should use default: " .. tostring(limit))
+  print("✓ get_context_limit unknown model")
+end
+test_get_context_limit_unknown_model()
+
+local function test_get_context_limit_nil_model()
+  local limit = compact.get_context_limit(nil)
+  assert(limit == compact.DEFAULT_CONTEXT_LIMIT, "nil model should use default: " .. tostring(limit))
+  print("✓ get_context_limit nil model")
+end
+test_get_context_limit_nil_model()
+
+-- needs_compaction tests
+
+local function test_needs_compaction_below_threshold()
+  -- 50% of 200k = 100k tokens
+  assert(not compact.needs_compaction(100000, "claude-sonnet-4-20250514"), "100k/200k should not trigger compaction")
+  print("✓ needs_compaction below threshold")
+end
+test_needs_compaction_below_threshold()
+
+local function test_needs_compaction_at_threshold()
+  -- Exactly at 80% = 160k tokens (0.8 is not > 0.8)
+  assert(not compact.needs_compaction(160000, "claude-sonnet-4-20250514"), "exactly at threshold should not trigger")
+  print("✓ needs_compaction at threshold boundary")
+end
+test_needs_compaction_at_threshold()
+
+local function test_needs_compaction_above_threshold()
+  -- 85% = 170k tokens
+  assert(compact.needs_compaction(170000, "claude-sonnet-4-20250514"), "170k/200k should trigger compaction")
+  print("✓ needs_compaction above threshold")
+end
+test_needs_compaction_above_threshold()
+
+local function test_needs_compaction_just_above_threshold()
+  -- 80.1% = 160001 tokens
+  assert(compact.needs_compaction(160001, "claude-sonnet-4-20250514"), "160001/200000 should trigger compaction")
+  print("✓ needs_compaction just above threshold")
+end
+test_needs_compaction_just_above_threshold()
+
+local function test_needs_compaction_zero_tokens()
+  assert(not compact.needs_compaction(0, "claude-sonnet-4-20250514"), "zero tokens should not trigger")
+  print("✓ needs_compaction zero tokens")
+end
+test_needs_compaction_zero_tokens()
+
+local function test_needs_compaction_custom_threshold_low()
+  -- 60% of 200k = 120k tokens, custom threshold 0.5
+  assert(compact.needs_compaction(120000, "claude-sonnet-4-20250514", 0.5), "120k at 0.5 threshold should trigger")
+  print("✓ needs_compaction custom threshold (triggers)")
+end
+test_needs_compaction_custom_threshold_low()
+
+local function test_needs_compaction_custom_threshold_high()
+  -- 80k at 0.5 threshold = 40% < 50%
+  assert(not compact.needs_compaction(80000, "claude-sonnet-4-20250514", 0.5), "80k at 0.5 threshold should not trigger")
+  print("✓ needs_compaction custom threshold (no trigger)")
+end
+test_needs_compaction_custom_threshold_high()
+
+local function test_needs_compaction_custom_threshold_tight()
+  -- Custom threshold of 0.9 (90%)
+  assert(not compact.needs_compaction(170000, "claude-sonnet-4-20250514", 0.9), "170k at 0.9 threshold should not trigger")
+  assert(compact.needs_compaction(190000, "claude-sonnet-4-20250514", 0.9), "190k at 0.9 threshold should trigger")
+  print("✓ needs_compaction custom threshold (tight)")
+end
+test_needs_compaction_custom_threshold_tight()
+
+local function test_needs_compaction_unknown_model()
+  -- Unknown model uses default limit (200000)
+  assert(compact.needs_compaction(170000, "some-future-model"), "unknown model should use default limit")
+  print("✓ needs_compaction with unknown model")
+end
+test_needs_compaction_unknown_model()
+
+-- Constants tests
+
+local function test_default_threshold()
+  assert(compact.DEFAULT_THRESHOLD == 0.8, "default threshold should be 0.8: " .. tostring(compact.DEFAULT_THRESHOLD))
+  print("✓ DEFAULT_THRESHOLD is 0.8")
+end
+test_default_threshold()
+
+local function test_default_context_limit()
+  assert(compact.DEFAULT_CONTEXT_LIMIT == 200000, "default context limit should be 200000: " .. tostring(compact.DEFAULT_CONTEXT_LIMIT))
+  print("✓ DEFAULT_CONTEXT_LIMIT is 200000")
+end
+test_default_context_limit()
+
+local function test_compaction_prompt_exists()
+  assert(compact.COMPACTION_SYSTEM_PROMPT and #compact.COMPACTION_SYSTEM_PROMPT > 0, "compaction prompt should exist and be non-empty")
+  print("✓ COMPACTION_SYSTEM_PROMPT exists")
+end
+test_compaction_prompt_exists()
+
+local function test_compaction_prompt_content()
+  local prompt = compact.COMPACTION_SYSTEM_PROMPT
+  assert(prompt:match("accomplished"), "prompt should mention what was accomplished")
+  assert(prompt:match("work in progress"), "prompt should mention work in progress")
+  assert(prompt:match("Files"), "prompt should mention files")
+  assert(prompt:match("next steps"), "prompt should mention next steps")
+  print("✓ COMPACTION_SYSTEM_PROMPT contains key instructions")
+end
+test_compaction_prompt_content()
+
+local function test_model_limits_all_present()
+  assert(compact.MODEL_CONTEXT_LIMITS["claude-sonnet-4-20250514"], "sonnet should have a limit")
+  assert(compact.MODEL_CONTEXT_LIMITS["claude-opus-4-20250514"], "opus should have a limit")
+  assert(compact.MODEL_CONTEXT_LIMITS["claude-haiku-3-20250314"], "haiku should have a limit")
+  print("✓ all models have context limits")
+end
+test_model_limits_all_present()
+
+print("\nAll compact tests passed!")


### PR DESCRIPTION
When a conversation approaches the model's context window limit (80%
threshold), the agent automatically summarizes the history and continues
with the compacted context. This prevents sessions from failing at
context limits.

Compaction is a view-layer operation: only the API messages are replaced
with the summary. The full conversation is always preserved in the
database.

Implements the context compaction pattern from the convergence analysis
(PR #29, section 4).

https://claude.ai/code/session_01LTeN9S5qD7YUKtUNNHeeqQ