### PR TITLE
feat: implement prompt caching for reduced API costs (#43)

### DIFF
--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -151,16 +151,20 @@ local function build_request(messages: {any}, opts: {string:any}, is_oauth: bool
     stream = opts.stream ~= false,
   }
 
-  -- Format system prompt
+  -- Format system prompt with cache_control on the last block
+  -- Anthropic caches up to the marked breakpoint, reducing input token costs
   if is_oauth then
     -- OAuth: Claude Code identity MUST be in first system block, user prompt in second
     local system_blocks: {{string:any}} = {{type = "text", text = CLAUDE_CODE_IDENTITY}}
     if opts.system then
-      table.insert(system_blocks, {type = "text", text = opts.system as string})
+      table.insert(system_blocks, {type = "text", text = opts.system as string, cache_control = {type = "ephemeral"}})
+    else
+      system_blocks[1].cache_control = {type = "ephemeral"}
     end
     req.system = system_blocks
   elseif opts.system then
-    req.system = opts.system
+    -- Non-OAuth: system prompt as array with cache_control on the block
+    req.system = {{type = "text", text = opts.system as string, cache_control = {type = "ephemeral"}}}
   end
 
   -- Only include tools if provided (allows testing without tools)

--- a/lib/ah/events.tl
+++ b/lib/ah/events.tl
@@ -24,6 +24,8 @@ local record EventData
   -- api_call_start / api_call_end
   input_tokens: integer
   output_tokens: integer
+  cache_creation_input_tokens: integer
+  cache_read_input_tokens: integer
   api_latency_ms: integer
   message_id: string
 
@@ -95,11 +97,13 @@ local function api_call_start(): EventData
   return make_event("api_call_start")
 end
 
-local function api_call_end(message_id: string, input_tokens: integer, output_tokens: integer, api_latency_ms: integer, model: string): EventData
+local function api_call_end(message_id: string, input_tokens: integer, output_tokens: integer, api_latency_ms: integer, model: string, cache_creation_input_tokens: integer, cache_read_input_tokens: integer): EventData
   local e = make_event("api_call_end")
   e.message_id = message_id
   e.input_tokens = input_tokens
   e.output_tokens = output_tokens
+  e.cache_creation_input_tokens = cache_creation_input_tokens
+  e.cache_read_input_tokens = cache_read_input_tokens
   e.api_latency_ms = api_latency_ms
   e.model = model
   return e

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -493,8 +493,19 @@ local function make_cli_handler(): events.EventCallback
       io.stderr:write("\nerror: " .. (event.error or "unknown") .. "\n")
 
     elseif t == "api_call_end" then
-      -- Text output complete for this turn; check if tool calls follow
-      -- (tool_call_start will handle the newline separator)
+      -- Show cache stats when prompt caching is active
+      local cache_read = event.cache_read_input_tokens or 0
+      local cache_create = event.cache_creation_input_tokens or 0
+      if cache_read > 0 or cache_create > 0 then
+        local parts: {string} = {}
+        if cache_read > 0 then
+          table.insert(parts, string.format("read:%d", cache_read))
+        end
+        if cache_create > 0 then
+          table.insert(parts, string.format("write:%d", cache_create))
+        end
+        io.stderr:write(string.format("%scache [%s]%s\n", DIM, table.concat(parts, " "), RESET))
+      end
 
     elseif t == "compaction_triggered" then
       io.stderr:write(string.format("\n%scompacting conversation (%d/%d tokens)...%s\n", DIM, event.input_tokens, event.context_limit, RESET))

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -267,6 +267,23 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
     -- Emit api_call_start
     emit(on_event, events.api_call_start())
 
+    -- Add cache_control breakpoint on the last content block of the last message.
+    -- This tells the Anthropic API to cache everything up to this point,
+    -- reducing input token costs on subsequent turns.
+    local cache_msg_idx: integer = nil
+    local cache_block_idx: integer = nil
+    for i = #api_messages, 1, -1 do
+      local msg = api_messages[i] as {string:any}
+      local content = msg.content as {any}
+      if content and #content > 0 then
+        cache_msg_idx = i
+        cache_block_idx = #content
+        local block = content[cache_block_idx] as {string:any}
+        block.cache_control = {type = "ephemeral"}
+        break
+      end
+    end
+
     -- Stream response with mid-stream interruption support
     local response, err = api.stream(api_messages, {
       system = system_prompt,
@@ -280,6 +297,14 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
         end
       end
     end, is_interrupted)
+
+    -- Remove the cache_control marker we added (clean up for next iteration)
+    if cache_msg_idx and cache_block_idx then
+      local msg = api_messages[cache_msg_idx] as {string:any}
+      local content = msg.content as {any}
+      local block = content[cache_block_idx] as {string:any}
+      block.cache_control = nil
+    end
 
     if err then
       emit(on_event, events.error_event(err))
@@ -356,6 +381,8 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
     -- Extract usage and metadata from response
     local usage = (resp.usage or {}) as {string:any}
     last_input_tokens = (usage.input_tokens or 0) as integer
+    local cache_creation_tokens = (usage.cache_creation_input_tokens or 0) as integer
+    local cache_read_tokens = (usage.cache_read_input_tokens or 0) as integer
     local msg_opts: db.MessageOpts = {
       input_tokens = usage.input_tokens as integer,
       output_tokens = usage.output_tokens as integer,
@@ -396,13 +423,15 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
     db.commit(d)
 
-    -- Emit api_call_end with message metadata
+    -- Emit api_call_end with message metadata and cache stats
     emit(on_event, events.api_call_end(
       assistant_msg.id,
       usage.input_tokens as integer,
       usage.output_tokens as integer,
       resp.api_latency_ms as integer,
-      resp.model as string
+      resp.model as string,
+      cache_creation_tokens,
+      cache_read_tokens
     ))
 
     -- Log api_call_end event to DB
@@ -411,7 +440,9 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       usage.input_tokens as integer,
       usage.output_tokens as integer,
       resp.api_latency_ms as integer,
-      resp.model as string
+      resp.model as string,
+      cache_creation_tokens,
+      cache_read_tokens
     )))
 
     -- Add assistant message to API messages

--- a/lib/ah/test_api.tl
+++ b/lib/ah/test_api.tl
@@ -79,7 +79,14 @@ test_build_request_nil_model()
 
 local function test_build_request_with_system()
   local req = api.build_request({}, {system = "You are a helpful assistant"}, false)
-  assert(req.system == "You are a helpful assistant", "should include system prompt")
+  -- Non-OAuth system prompt is now an array with cache_control
+  local system_arr = req.system as {{string:any}}
+  assert(type(req.system) == "table", "system should be array")
+  assert(#system_arr == 1, "should have 1 system block")
+  assert(system_arr[1].text == "You are a helpful assistant", "should include system prompt text")
+  assert(system_arr[1].cache_control ~= nil, "should have cache_control")
+  local cc = system_arr[1].cache_control as {string:any}
+  assert(cc.type == "ephemeral", "cache_control type should be ephemeral")
 end
 test_build_request_with_system()
 
@@ -99,8 +106,24 @@ local function test_build_request_oauth_system_prompt()
   assert(#system_arr == 2, "should have 2 system blocks")
   assert((system_arr[1].text as string):match("Claude Code"), "first block should be Claude Code identity")
   assert(system_arr[2].text == "Custom prompt", "second block should be custom prompt")
+  -- cache_control should be on the last block (second block)
+  assert(system_arr[1].cache_control == nil, "first block should not have cache_control")
+  assert(system_arr[2].cache_control ~= nil, "last block should have cache_control")
+  local cc = system_arr[2].cache_control as {string:any}
+  assert(cc.type == "ephemeral", "cache_control type should be ephemeral")
 end
 test_build_request_oauth_system_prompt()
+
+local function test_build_request_oauth_no_system_cache()
+  -- OAuth mode without system prompt should cache the identity block
+  local req = api.build_request({}, {}, true)
+  local system_arr = req.system as {{string:any}}
+  assert(#system_arr == 1, "should have 1 system block (identity only)")
+  assert(system_arr[1].cache_control ~= nil, "identity block should have cache_control when no user system")
+  local cc = system_arr[1].cache_control as {string:any}
+  assert(cc.type == "ephemeral", "cache_control type should be ephemeral")
+end
+test_build_request_oauth_no_system_cache()
 
 -- Tests for parse_api_error
 local function test_parse_api_error_rate_limit()

--- a/lib/ah/test_events.tl
+++ b/lib/ah/test_events.tl
@@ -40,15 +40,26 @@ test_api_call_start()
 
 -- Test api_call_end constructor
 local function test_api_call_end()
-  local e = events.api_call_end("msg123", 100, 50, 1500, "claude-sonnet")
+  local e = events.api_call_end("msg123", 100, 50, 1500, "claude-sonnet", 0, 0)
   assert(e.event_type == "api_call_end", "event_type should be api_call_end")
   assert(e.message_id == "msg123", "message_id mismatch")
   assert(e.input_tokens == 100, "input_tokens mismatch")
   assert(e.output_tokens == 50, "output_tokens mismatch")
   assert(e.api_latency_ms == 1500, "api_latency_ms mismatch")
   assert(e.model == "claude-sonnet", "model mismatch")
+  assert(e.cache_creation_input_tokens == 0, "cache_creation should be 0")
+  assert(e.cache_read_input_tokens == 0, "cache_read should be 0")
 end
 test_api_call_end()
+
+-- Test api_call_end with cache tokens
+local function test_api_call_end_cache()
+  local e = events.api_call_end("msg456", 5000, 200, 800, "claude-sonnet", 3000, 1500)
+  assert(e.cache_creation_input_tokens == 3000, "cache_creation_input_tokens mismatch")
+  assert(e.cache_read_input_tokens == 1500, "cache_read_input_tokens mismatch")
+  assert(e.input_tokens == 5000, "input_tokens should still be set")
+end
+test_api_call_end_cache()
 
 -- Test tool_call_start constructor
 local function test_tool_call_start()


### PR DESCRIPTION
Add Anthropic cache_control breakpoints to system prompts and
conversation message boundaries. On multi-turn sessions, cached
prefix tokens are billed at a discount instead of being re-processed.

- api.tl: add cache_control={type="ephemeral"} to the last system
  prompt block in build_request (both OAuth and non-OAuth paths)
- loop.tl: mark the last content block of the last message with
  cache_control before each API call; clean up after call returns
- loop.tl: extract cache_creation_input_tokens and
  cache_read_input_tokens from API response usage
- events.tl: add cache token fields to api_call_end event
- init.tl: display cache stats (read/write counts) in CLI handler
  when prompt caching is active

https://claude.ai/code/session_01UBtQ4YZoHkqFEzCdE8yd5q