### PR TITLE
Buffer agent response text output for better performance

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -468,6 +468,16 @@ local function make_cli_handler(): events.EventCallback
   local DIM = is_tty and "\27[2m" or ""
   local RESET = is_tty and "\27[0m" or ""
   local has_text = false
+  local text_buffer: {string} = {}
+
+  -- Flush buffered agent response text to stdout
+  local function flush_text()
+    if #text_buffer > 0 then
+      io.write(table.concat(text_buffer))
+      io.flush()
+      text_buffer = {}
+    end
+  end
 
   return function(event: events.EventData)
     local t = event.event_type
@@ -479,11 +489,12 @@ local function make_cli_handler(): events.EventCallback
       end
 
     elseif t == "text_delta" then
-      io.write(event.text)
-      io.flush()
+      -- Buffer text and print when the response is complete
+      table.insert(text_buffer, event.text)
       has_text = true
 
     elseif t == "agent_end" then
+      flush_text()
       -- Trailing newline after text output
       if has_text then
         io.write("\n")
@@ -493,6 +504,8 @@ local function make_cli_handler(): events.EventCallback
       io.stderr:write("\nerror: " .. (event.error or "unknown") .. "\n")
 
     elseif t == "api_call_end" then
+      -- Flush buffered agent response text now that the response is complete
+      flush_text()
       -- Show cache stats when prompt caching is active
       local cache_read = event.cache_read_input_tokens or 0
       local cache_create = event.cache_creation_input_tokens or 0


### PR DESCRIPTION
## Summary
This change improves the performance of agent response text output by buffering text deltas instead of writing them to stdout immediately. Text is now flushed to stdout only when the agent response is complete.

## Key Changes
- Added a `text_buffer` table to accumulate text delta events instead of writing immediately
- Introduced a `flush_text()` helper function that writes buffered text to stdout and clears the buffer
- Modified `text_delta` event handling to append text to the buffer instead of writing directly
- Added `flush_text()` calls at two completion points:
  - When `agent_end` event is received (agent response complete)
  - When `api_call_end` event is received (API call complete)

## Implementation Details
This buffering approach reduces the number of I/O operations by batching multiple small text writes into fewer, larger writes. This is particularly beneficial when handling streaming responses with many small text chunks, improving overall throughput and reducing system call overhead.

https://claude.ai/code/session_01TtDhEt2jEsJzkhgHQsjN3h