### PR TITLE
Add diff command to compare conversation branches

### DIFF
--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -616,6 +616,7 @@ return {
   begin_transaction = begin_transaction,
   commit = commit,
   rollback = rollback,
+  get_message = get_message,
   create_message = create_message,
   get_current_message = get_current_message,
   set_current_message = set_current_message,

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -150,6 +150,7 @@ commands:
   scan                list messages in current branch
   tree                show full conversation tree
   branches            list all branch tips
+  diff @A @B          compare two branches
   checkout @N         switch to message N
   branch rm @N        delete branch from message N
   show [N]            show message(s)
@@ -458,6 +459,94 @@ local function cmd_branch_rm(d: db.DB, seq: integer)
   end
   local count = db.delete_branch(d, msg.id)
   io.write(string.format("deleted %d message(s) from @%d\n", count, seq))
+end
+
+-- Diff two branch tips: show messages unique to each branch after their common fork point.
+-- Accepts two message IDs directly (for programmatic use and disambiguation).
+local function cmd_diff(d: db.DB, id_a: string, id_b: string)
+  local msg_a = db.get_message(d, id_a)
+  if not msg_a then
+    io.stderr:write("message not found: " .. id_a .. "\n")
+    return
+  end
+  local msg_b = db.get_message(d, id_b)
+  if not msg_b then
+    io.stderr:write("message not found: " .. id_b .. "\n")
+    return
+  end
+
+  -- Build ancestry chains
+  local ancestry_a = db.get_ancestry(d, msg_a.id)
+  local ancestry_b = db.get_ancestry(d, msg_b.id)
+
+  -- Build id set for branch A's ancestry
+  local ids_a: {string:boolean} = {}
+  for _, m in ipairs(ancestry_a) do
+    ids_a[m.id] = true
+  end
+
+  -- Find the deepest common ancestor (last shared message in ancestry order)
+  local fork_seq = -1
+  for _, m in ipairs(ancestry_b) do
+    if ids_a[m.id] then
+      fork_seq = m.seq
+    end
+  end
+
+  -- Collect messages unique to each branch (not in the other's ancestry)
+  local ids_b: {string:boolean} = {}
+  for _, m in ipairs(ancestry_b) do
+    ids_b[m.id] = true
+  end
+
+  local only_a: {db.Message} = {}
+  for _, m in ipairs(ancestry_a) do
+    if not ids_b[m.id] then
+      table.insert(only_a, m)
+    end
+  end
+
+  local only_b: {db.Message} = {}
+  for _, m in ipairs(ancestry_b) do
+    if not ids_a[m.id] then
+      table.insert(only_b, m)
+    end
+  end
+
+  if #only_a == 0 and #only_b == 0 then
+    io.write("no differences (same branch)\n")
+    return
+  end
+
+  io.write(string.format("fork point: @%d\n\n", fork_seq))
+
+  -- Render a branch section
+  local function render_branch(label: string, messages: {db.Message})
+    if #messages == 0 then
+      io.write(string.format("--- %s: (empty) ---\n", label))
+      return
+    end
+    io.write(string.format("--- %s (%d messages) ---\n", label, #messages))
+    for _, m in ipairs(messages) do
+      local role_char = m.role == "user" and "U" or "A"
+      local blocks = db.get_content_blocks(d, m.id)
+      local preview = msg_preview(d, m, 70)
+      io.write(string.format("  @%-3d %s: %s\n", m.seq, role_char, preview))
+
+      -- Show tool calls
+      for _, b in ipairs(blocks) do
+        if b.block_type == "tool_use" then
+          local key = loop.tool_key_param(b.tool_name as string, b.tool_input as string, b.details as string)
+          if #key > 60 then key = key:sub(1, 57) .. "..." end
+          io.write(string.format("         → %s %s\n", b.tool_name, key))
+        end
+      end
+    end
+  end
+
+  render_branch(string.format("@%d", msg_a.seq), only_a)
+  io.write("\n")
+  render_branch(string.format("@%d", msg_b.seq), only_b)
 end
 
 -- CLI display handler: renders structured events to stderr/stdout for terminal use.
@@ -798,6 +887,60 @@ local function main(args: {string}): integer, string
     db.close(d)
     return 0
 
+  elseif cmd == "diff" then
+    local a_str = remaining[2]
+    local b_str = remaining[3]
+    if not a_str or not b_str then
+      io.stderr:write("usage: ah diff @A @B\n")
+      queue.close(qdb)
+      db.close(d)
+      return 1
+    end
+    local a_val = a_str:match("^@?(%d+)$")
+    local b_val = b_str:match("^@?(%d+)$")
+    if not a_val or not b_val then
+      io.stderr:write("invalid message numbers: " .. a_str .. " " .. b_str .. "\n")
+      queue.close(qdb)
+      db.close(d)
+      return 1
+    end
+    -- Resolve seq numbers to message IDs. When seqs are the same (forked
+    -- branches share seq numbers), find distinct messages with that seq
+    -- among the leaf messages' ancestries.
+    local seq_a = tonumber(a_val) as integer
+    local seq_b = tonumber(b_val) as integer
+    local leaves = db.get_leaf_messages(d)
+    local function resolve_seq_to_id(seq: integer, exclude_id: string): string
+      -- Try each leaf's ancestry for a message with the given seq
+      for _, leaf in ipairs(leaves) do
+        local ancestry = db.get_ancestry(d, leaf.id)
+        for _, m in ipairs(ancestry) do
+          if m.seq == seq and m.id ~= exclude_id then
+            return m.id
+          end
+        end
+      end
+      return nil
+    end
+    local id_a = resolve_seq_to_id(seq_a, nil)
+    if not id_a then
+      io.stderr:write("message not found: @" .. seq_a .. "\n")
+      queue.close(qdb)
+      db.close(d)
+      return 1
+    end
+    local id_b = resolve_seq_to_id(seq_b, seq_a == seq_b and id_a or nil)
+    if not id_b then
+      io.stderr:write("message not found: @" .. seq_b .. "\n")
+      queue.close(qdb)
+      db.close(d)
+      return 1
+    end
+    cmd_diff(d, id_a, id_b)
+    queue.close(qdb)
+    db.close(d)
+    return 0
+
   elseif cmd == "checkout" then
     local seq_str = remaining[2]
     if not seq_str then
@@ -989,4 +1132,5 @@ return {
   cmd_branches = cmd_branches,
   cmd_checkout = cmd_checkout,
   cmd_branch_rm = cmd_branch_rm,
+  cmd_diff = cmd_diff,
 }

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -74,13 +74,22 @@ end
 
 -- Compute a turn signature from a list of tool calls.
 -- The signature captures the tool names and key parameters to identify
--- repetitive patterns across turns.
+-- repetitive patterns across turns. For edit operations, includes the full
+-- old_string and new_string to distinguish edits to the same file.
 local function turn_signature(tool_calls: {any}): string
   local parts: {string} = {}
   for _, tool_call in ipairs(tool_calls) do
     local tc = tool_call as {string:any}
-    local input_json = json.encode(tc.input or {})
+    local input = (tc.input or {}) as {string:any}
+    local input_json = json.encode(input)
     local key = tool_key_param(tc.name as string, input_json, nil)
+    -- For edit tool, append old_string and new_string to avoid collisions
+    -- when multiple edits target the same file with different content.
+    if tc.name == "edit" and input then
+      local old_s = (input.old_string or "") as string
+      local new_s = (input.new_string or "") as string
+      key = key .. "|" .. old_s .. "|" .. new_s
+    end
     table.insert(parts, (tc.name as string) .. ":" .. key)
   end
   return table.concat(parts, "|")
@@ -248,6 +257,15 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
       local compact_result, compact_err = compact.compact(api_messages, model, is_interrupted)
       if compact_result then
+        -- Persist compaction summary as a user message so it survives crashes.
+        -- The full conversation is always preserved; this message acts as the
+        -- compaction checkpoint that a new invocation can rebuild from.
+        db.begin_transaction(d)
+        local compact_msg = db.create_message(d, "user", user_msg.id)
+        db.add_content_block(d, compact_msg.id, "text", {content = "[COMPACTION SUMMARY]\n" .. compact_result.summary})
+        db.commit(d)
+        user_msg = compact_msg
+
         -- Replace api_messages with compacted summary
         api_messages = {{
           role = "user",
@@ -626,6 +644,18 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
     -- Loop detection: check for repetitive tool call patterns
     local sig = turn_signature(tool_calls)
     table.insert(turn_history, sig)
+
+    -- Cap turn history to avoid unbounded growth. Only the most recent
+    -- entries matter for loop detection; older entries are never examined.
+    local max_history = LOOP_BREAK_THRESHOLD * 2
+    if #turn_history > max_history then
+      local trimmed: {string} = {}
+      for i = #turn_history - max_history + 1, #turn_history do
+        table.insert(trimmed, turn_history[i])
+      end
+      turn_history = trimmed
+    end
+
     local consecutive = check_loop(turn_history)
 
     if consecutive >= LOOP_BREAK_THRESHOLD then

--- a/lib/ah/test_branch.tl
+++ b/lib/ah/test_branch.tl
@@ -413,4 +413,60 @@ local function test_linear_tree()
 end
 test_linear_tree()
 
+-- Test: diff command shows divergent branches
+local function test_cmd_diff()
+  local d, _, _, _, msg4, _, fork6 = make_tree()
+  local init = require("ah.init")
+
+  -- Capture output
+  local old_write = io.write
+  local output = ""
+  io.write = function(...: any): FILE, string, integer
+    for i = 1, select("#", ...) do
+      output = output .. tostring(select(i, ...))
+    end
+    return io.stdout, nil, nil
+  end
+
+  -- Diff between msg4 (Lua branch tip) and fork6 (Python branch tip) by ID
+  init.cmd_diff(d, msg4.id, fork6.id)
+
+  io.write = old_write
+
+  -- Should show fork point (msg2 at @1 is the last common ancestor)
+  assert(output:match("fork point: @1"), "should show fork point @1: " .. output)
+  -- Should show branch sections
+  assert(output:match("@3"), "should reference branch tip seq")
+  -- Should contain branch content
+  assert(output:match("Lua"), "should show Lua branch content")
+  assert(output:match("Python"), "should show Python branch content")
+
+  db.close(d)
+end
+test_cmd_diff()
+
+-- Test: diff same message shows no differences
+local function test_cmd_diff_same()
+  local d, _, _, _, msg4 = make_tree()
+  local init = require("ah.init")
+
+  local old_write = io.write
+  local output = ""
+  io.write = function(...: any): FILE, string, integer
+    for i = 1, select("#", ...) do
+      output = output .. tostring(select(i, ...))
+    end
+    return io.stdout, nil, nil
+  end
+
+  init.cmd_diff(d, msg4.id, msg4.id)
+
+  io.write = old_write
+
+  assert(output:match("no differences"), "same branch should show no differences: " .. output)
+
+  db.close(d)
+end
+test_cmd_diff_same()
+
 print("all branch tests passed")

--- a/lib/ah/test_loop.tl
+++ b/lib/ah/test_loop.tl
@@ -144,8 +144,39 @@ local function test_turn_signature_edit()
   local sig = loop.turn_signature(tool_calls)
   assert(sig:match("edit:"), "should start with edit: " .. sig)
   assert(sig:match("/tmp/file.lua"), "should include path: " .. sig)
+  -- Should include old_string and new_string for precise signatures
+  assert(sig:match("foo"), "should include old_string: " .. sig)
+  assert(sig:match("bar"), "should include new_string: " .. sig)
 end
 test_turn_signature_edit()
+
+-- Edits to the same file with different content must produce different signatures
+local function test_turn_signature_edit_different_content()
+  local calls_a = {
+    {name = "edit", input = {path = "/tmp/file.lua", old_string = "alpha", new_string = "beta"}},
+  }
+  local calls_b = {
+    {name = "edit", input = {path = "/tmp/file.lua", old_string = "gamma", new_string = "delta"}},
+  }
+  local sig_a = loop.turn_signature(calls_a)
+  local sig_b = loop.turn_signature(calls_b)
+  assert(sig_a ~= sig_b, "edits with different content should have different signatures")
+end
+test_turn_signature_edit_different_content()
+
+-- Edits to the same file with the same content must produce identical signatures
+local function test_turn_signature_edit_same_content()
+  local calls_a = {
+    {name = "edit", input = {path = "/tmp/file.lua", old_string = "foo", new_string = "bar"}},
+  }
+  local calls_b = {
+    {name = "edit", input = {path = "/tmp/file.lua", old_string = "foo", new_string = "bar"}},
+  }
+  local sig_a = loop.turn_signature(calls_a)
+  local sig_b = loop.turn_signature(calls_b)
+  assert(sig_a == sig_b, "edits with same content should have same signatures")
+end
+test_turn_signature_edit_same_content()
 
 local function test_turn_signature_deterministic()
   local tool_calls = {


### PR DESCRIPTION
## Summary
This PR adds a new `diff` command that compares two conversation branches, showing messages unique to each branch after their common fork point. It also includes improvements to loop detection and conversation compaction.

## Key Changes

### New diff Command
- Added `cmd_diff()` function to compare two branch tips by their message IDs
- Displays the fork point (deepest common ancestor) and lists messages unique to each branch
- Includes message previews and tool call details for each branch
- Handles message resolution from sequence numbers, with disambiguation for forked branches that share sequence numbers
- Added comprehensive tests for diff functionality (same branch, divergent branches)

### Loop Detection Improvements
- Enhanced `turn_signature()` to include `old_string` and `new_string` for edit operations
- This prevents false loop detection when the same file is edited with different content
- Added tests verifying that edits with different content produce different signatures
- Added turn history capping to prevent unbounded growth while maintaining loop detection accuracy

### Conversation Compaction
- Compaction summaries are now persisted as user messages in the database
- This ensures compaction checkpoints survive crashes and can be rebuilt from on new invocations
- The full conversation history is always preserved; the summary message acts as a checkpoint

### Database and CLI Updates
- Exported `get_message()` function from db module for use in diff command
- Updated help text to document the new `diff @A @B` command
- Added `cmd_diff` to module exports

## Implementation Details
- Fork point detection uses set-based ancestry comparison for efficiency
- Branch-specific messages are collected by checking membership in each branch's ancestry
- Message previews are truncated to 70 characters for readability
- Tool calls are displayed with their key parameters for context

https://claude.ai/code/session_018474teQfno6qeA9nyQdp3w