### PR TITLE
Add token budget enforcement to agent loop

### DIFF
--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -478,6 +478,26 @@ local function cleanup_orphans(self: DB): integer
   return #orphans
 end
 
+-- Token totals: sum input and output tokens across all messages in the session
+local record TokenTotals
+  input_tokens: integer
+  output_tokens: integer
+end
+
+local function get_session_token_totals(self: DB): TokenTotals
+  for row in self._db:query([[
+    select coalesce(sum(input_tokens), 0) as total_input,
+           coalesce(sum(output_tokens), 0) as total_output
+    from messages
+  ]]) do
+    return {
+      input_tokens = (row.total_input or 0) as integer,
+      output_tokens = (row.total_output or 0) as integer,
+    }
+  end
+  return {input_tokens = 0, output_tokens = 0}
+end
+
 -- Session state management: idle, processing, closed
 -- States are stored in the context table under key "session_state"
 local function get_session_state(self: DB): string
@@ -640,8 +660,10 @@ return {
   get_events = get_events,
   get_session_state = get_session_state,
   set_session_state = set_session_state,
+  get_session_token_totals = get_session_token_totals,
   -- Export types for consumers
   DB = DB,
+  TokenTotals = TokenTotals,
   Message = Message,
   ContentBlock = ContentBlock,
   ContentBlockOpts = ContentBlockOpts,

--- a/lib/ah/events.tl
+++ b/lib/ah/events.tl
@@ -65,6 +65,11 @@ local record EventData
 
   -- compaction
   context_limit: integer
+
+  -- token budget
+  total_input_tokens: integer
+  total_output_tokens: integer
+  max_tokens: integer
 end
 
 local type EventCallback = function(event: EventData)
@@ -87,9 +92,11 @@ local function agent_start(model: string, prompt: string, parent_id: string): Ev
   return e
 end
 
-local function agent_end(stop_reason: string): EventData
+local function agent_end(stop_reason: string, total_input_tokens: integer, total_output_tokens: integer): EventData
   local e = make_event("agent_end")
   e.stop_reason = stop_reason
+  e.total_input_tokens = total_input_tokens
+  e.total_output_tokens = total_output_tokens
   return e
 end
 
@@ -195,6 +202,14 @@ local function compaction_complete(input_tokens: integer, output_tokens: integer
   return e
 end
 
+local function budget_exceeded(total_input_tokens: integer, total_output_tokens: integer, max_tokens: integer): EventData
+  local e = make_event("budget_exceeded")
+  e.total_input_tokens = total_input_tokens
+  e.total_output_tokens = total_output_tokens
+  e.max_tokens = max_tokens
+  return e
+end
+
 -- Serialize an event to JSON (for persistence or JSON logging)
 local function to_json(event: EventData): string
   local t: {string:any} = {}
@@ -229,6 +244,7 @@ return {
   loop_detected = loop_detected,
   compaction_triggered = compaction_triggered,
   compaction_complete = compaction_complete,
+  budget_exceeded = budget_exceeded,
 
   -- Serialization
   to_json = to_json,

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -166,6 +166,7 @@ options:
   -m, --model MODEL   set model (default: sonnet)
   --steer MSG         send steering message to running session
   --followup MSG      queue followup message for after session completes
+  --max-tokens N      stop when cumulative tokens exceed N
 
 models:
 ]])
@@ -588,6 +589,16 @@ local function make_cli_handler(): events.EventCallback
       if has_text then
         io.write("\n")
       end
+      -- Display session token totals
+      local total_in = event.total_input_tokens or 0
+      local total_out = event.total_output_tokens or 0
+      if total_in > 0 or total_out > 0 then
+        io.stderr:write(string.format("%stokens [in:%d out:%d total:%d]%s\n", DIM, total_in, total_out, total_in + total_out, RESET))
+      end
+
+    elseif t == "budget_exceeded" then
+      local total = (event.total_input_tokens or 0) + (event.total_output_tokens or 0)
+      io.stderr:write(string.format("\ntoken budget exceeded (%d/%d tokens)\n", total, event.max_tokens or 0))
 
     elseif t == "error" then
       io.stderr:write("\nerror: " .. (event.error or "unknown") .. "\n")
@@ -678,6 +689,7 @@ local function main(args: {string}): integer, string
   local session_prefix: string = nil
   local steer_msg: string = nil
   local followup_msg: string = nil
+  local max_tokens: integer = nil
   local cwd = fs.getcwd()
 
   local longopts = {
@@ -689,6 +701,7 @@ local function main(args: {string}): integer, string
     {name = "output", has_arg = "required", short = "o"},
     {name = "steer", has_arg = "required"},
     {name = "followup", has_arg = "required"},
+    {name = "max-tokens", has_arg = "required"},
   }
 
   local parser = getopt.new(args, "hnS:m:o:", longopts)
@@ -714,6 +727,8 @@ local function main(args: {string}): integer, string
       steer_msg = optarg
     elseif opt == "followup" then
       followup_msg = optarg
+    elseif opt == "max-tokens" then
+      max_tokens = tonumber(optarg) as integer
     elseif opt == "?" then
       usage()
       return 1
@@ -1120,7 +1135,11 @@ local function main(args: {string}): integer, string
 
   -- Run agent with CLI event handler
   local on_event = make_cli_handler()
-  loop.run_agent(d, qdb, effective_system, effective_model, prompt, parent_id, on_event)
+  local agent_opts: loop.AgentOpts = {}
+  if max_tokens then
+    agent_opts.max_tokens = max_tokens
+  end
+  loop.run_agent(d, qdb, effective_system, effective_model, prompt, parent_id, on_event, agent_opts)
 
   -- Mark session as closed before exit
   db.set_session_state(d, "closed")

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -128,12 +128,21 @@ local function transition_state(d: db.DB, on_event: events.EventCallback, to_sta
   end
 end
 
+-- Options for run_agent
+local record AgentOpts
+  max_tokens: integer  -- Optional token budget (input + output combined). Stop with budget_exceeded when exceeded.
+end
+
 -- Send prompt and run agent loop
 -- qdb: optional queue database for inter-process coordination (steering/followup)
 -- on_event: optional callback for structured lifecycle events.
 -- When provided, the loop emits events instead of writing directly to stderr/stdout.
 -- When nil, the loop still functions but produces no output.
-local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, model: string, prompt: string, parent_id: string, on_event: events.EventCallback)
+-- opts: optional agent options (e.g. token budget)
+local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, model: string, prompt: string, parent_id: string, on_event: events.EventCallback, opts: AgentOpts)
+  opts = opts or {}
+  local max_tokens = opts.max_tokens
+
   -- Load credentials to determine if OAuth mode
   local creds, creds_err = auth.load_credentials()
   if not creds then
@@ -216,6 +225,10 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
   -- Track input tokens from last API response for compaction decisions
   local last_input_tokens: integer = 0
+
+  -- Track cumulative tokens for budget enforcement
+  local cumulative_input_tokens: integer = 0
+  local cumulative_output_tokens: integer = 0
 
   -- Closure for api.stream to check interruption mid-stream
   local function is_interrupted(): boolean
@@ -463,6 +476,19 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       cache_read_tokens
     )))
 
+    -- Accumulate tokens for budget tracking
+    cumulative_input_tokens = cumulative_input_tokens + ((usage.input_tokens or 0) as integer)
+    cumulative_output_tokens = cumulative_output_tokens + ((usage.output_tokens or 0) as integer)
+
+    -- Check token budget
+    if max_tokens and (cumulative_input_tokens + cumulative_output_tokens) > max_tokens then
+      emit(on_event, events.budget_exceeded(cumulative_input_tokens, cumulative_output_tokens, max_tokens))
+      db.log_event(d, "budget_exceeded", assistant_msg.id,
+        events.to_json(events.budget_exceeded(cumulative_input_tokens, cumulative_output_tokens, max_tokens)))
+      final_stop_reason = "budget_exceeded"
+      break
+    end
+
     -- Add assistant message to API messages
     table.insert(api_messages, {role = "assistant", content = assistant_api_content})
 
@@ -706,15 +732,19 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
   -- Transition to idle (or closed if interrupted)
   transition_state(d, on_event, "idle")
 
-  -- Emit agent_end
-  emit(on_event, events.agent_end(final_stop_reason))
+  -- Query final token totals from DB (includes all messages in session, not just this run)
+  local totals = db.get_session_token_totals(d)
+
+  -- Emit agent_end with token totals
+  emit(on_event, events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens))
 
   -- Log agent_end event to DB
-  db.log_event(d, "agent_end", nil, events.to_json(events.agent_end(final_stop_reason)))
+  db.log_event(d, "agent_end", nil, events.to_json(events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens)))
 end
 
 return {
   run_agent = run_agent,
+  AgentOpts = AgentOpts,
   tool_key_param = tool_key_param,
   turn_signature = turn_signature,
   check_loop = check_loop,

--- a/lib/ah/test_db.tl
+++ b/lib/ah/test_db.tl
@@ -452,4 +452,60 @@ local function test_session_state_persistence()
 end
 test_session_state_persistence()
 
+-- Test get_session_token_totals
+local function test_session_token_totals_empty()
+  local db_path = fs.join(TEST_TMPDIR, "tokens_empty.db")
+  local d = db.open(db_path)
+
+  local totals = db.get_session_token_totals(d)
+  assert(totals.input_tokens == 0, "empty db should have 0 input_tokens, got " .. totals.input_tokens)
+  assert(totals.output_tokens == 0, "empty db should have 0 output_tokens, got " .. totals.output_tokens)
+
+  db.close(d)
+end
+test_session_token_totals_empty()
+
+local function test_session_token_totals()
+  local db_path = fs.join(TEST_TMPDIR, "tokens_sum.db")
+  local d = db.open(db_path)
+
+  -- Create messages with token counts
+  local msg1 = db.create_message(d, "user")
+  local msg2 = db.create_message(d, "assistant", msg1.id, {
+    input_tokens = 100,
+    output_tokens = 50,
+  })
+  local msg3 = db.create_message(d, "user", msg2.id)
+  local msg4 = db.create_message(d, "assistant", msg3.id, {
+    input_tokens = 200,
+    output_tokens = 75,
+  })
+
+  local totals = db.get_session_token_totals(d)
+  assert(totals.input_tokens == 300, "input_tokens should be 300, got " .. totals.input_tokens)
+  assert(totals.output_tokens == 125, "output_tokens should be 125, got " .. totals.output_tokens)
+
+  db.close(d)
+end
+test_session_token_totals()
+
+-- Test that user messages with nil tokens don't break the sum
+local function test_session_token_totals_with_nil()
+  local db_path = fs.join(TEST_TMPDIR, "tokens_nil.db")
+  local d = db.open(db_path)
+
+  local msg1 = db.create_message(d, "user")  -- nil tokens
+  local msg2 = db.create_message(d, "assistant", msg1.id, {
+    input_tokens = 500,
+    output_tokens = 100,
+  })
+
+  local totals = db.get_session_token_totals(d)
+  assert(totals.input_tokens == 500, "should handle nil tokens, got " .. totals.input_tokens)
+  assert(totals.output_tokens == 100, "should handle nil tokens, got " .. totals.output_tokens)
+
+  db.close(d)
+end
+test_session_token_totals_with_nil()
+
 print("all db tests passed")

--- a/lib/ah/test_events.tl
+++ b/lib/ah/test_events.tl
@@ -24,11 +24,23 @@ test_agent_start()
 
 -- Test agent_end constructor
 local function test_agent_end()
-  local e = events.agent_end("end_turn")
+  local e = events.agent_end("end_turn", 1000, 500)
   assert(e.event_type == "agent_end", "event_type should be agent_end")
   assert(e.stop_reason == "end_turn", "stop_reason mismatch")
+  assert(e.total_input_tokens == 1000, "total_input_tokens mismatch")
+  assert(e.total_output_tokens == 500, "total_output_tokens mismatch")
 end
 test_agent_end()
+
+-- Test agent_end without token totals (nil)
+local function test_agent_end_no_tokens()
+  local e = events.agent_end("interrupted", nil, nil)
+  assert(e.event_type == "agent_end", "event_type should be agent_end")
+  assert(e.stop_reason == "interrupted", "stop_reason mismatch")
+  assert(e.total_input_tokens == nil, "total_input_tokens should be nil")
+  assert(e.total_output_tokens == nil, "total_output_tokens should be nil")
+end
+test_agent_end_no_tokens()
 
 -- Test api_call_start constructor
 local function test_api_call_start()
@@ -159,7 +171,7 @@ local function test_event_callback()
 
   cb(events.agent_start("model", "prompt", nil))
   cb(events.text_delta("hello"))
-  cb(events.agent_end("end_turn"))
+  cb(events.agent_end("end_turn", nil, nil))
 
   assert(#received == 3, "should receive 3 events")
   assert(received[1].event_type == "agent_start", "first should be agent_start")
@@ -218,5 +230,27 @@ local function test_loop_detected_json()
   assert(parsed.action == "warn", "action should survive round-trip")
 end
 test_loop_detected_json()
+
+-- Test budget_exceeded constructor
+local function test_budget_exceeded()
+  local e = events.budget_exceeded(50000, 10000, 40000)
+  assert(e.event_type == "budget_exceeded", "event_type should be budget_exceeded")
+  assert(e.total_input_tokens == 50000, "total_input_tokens mismatch")
+  assert(e.total_output_tokens == 10000, "total_output_tokens mismatch")
+  assert(e.max_tokens == 40000, "max_tokens mismatch")
+end
+test_budget_exceeded()
+
+-- Test budget_exceeded serialization
+local function test_budget_exceeded_json()
+  local e = events.budget_exceeded(100000, 25000, 120000)
+  local json_str = events.to_json(e)
+  local parsed = json.decode(json_str) as {string:any}
+  assert(parsed.event_type == "budget_exceeded", "event_type should survive round-trip")
+  assert(parsed.total_input_tokens == 100000, "total_input_tokens should survive round-trip")
+  assert(parsed.total_output_tokens == 25000, "total_output_tokens should survive round-trip")
+  assert(parsed.max_tokens == 120000, "max_tokens should survive round-trip")
+end
+test_budget_exceeded_json()
 
 print("all events tests passed")


### PR DESCRIPTION
## Summary
This PR adds support for enforcing a cumulative token budget across agent sessions. When a `--max-tokens` limit is specified, the agent will stop execution and emit a `budget_exceeded` event once the combined input and output tokens exceed the limit.

## Key Changes

- **Database**: Added `get_session_token_totals()` function to query cumulative token usage across all messages in a session, and exported the `TokenTotals` type
- **Events**: 
  - Extended `agent_end` event to include `total_input_tokens` and `total_output_tokens` fields
  - Added new `budget_exceeded` event type to signal when token limit is exceeded
  - Updated `EventData` record to include token budget fields
- **Agent Loop**:
  - Added `AgentOpts` record with optional `max_tokens` field
  - Modified `run_agent()` to accept options parameter
  - Implemented cumulative token tracking during message processing
  - Added budget check after each API call that breaks the loop with `budget_exceeded` stop reason
  - Updated `agent_end` emission to include final token totals from database
- **CLI**:
  - Added `--max-tokens N` command-line option
  - Updated help text to document the new option
  - Added display of token totals in `agent_end` event handler
  - Added error message display for `budget_exceeded` events
- **Tests**: Added comprehensive test coverage for `get_session_token_totals()` and `budget_exceeded` event

## Implementation Details

- Token budget is checked as `(cumulative_input_tokens + cumulative_output_tokens) > max_tokens`
- The final `agent_end` event includes token totals queried from the database (covering all messages in the session, not just the current run)
- Budget enforcement is optional; if no `--max-tokens` is specified, the agent runs without limits
- Both the event and database log entry are created when budget is exceeded

https://claude.ai/code/session_016znSJEFjjwjQ46XWV9xJAV