### PR TITLE
cleanup: remove dead code and add missing event test coverage

### DIFF
--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -416,7 +416,6 @@ return {
   to_claude_code_name = to_claude_code_name,
   from_claude_code_name = from_claude_code_name,
   DEFAULT_MODEL = DEFAULT_MODEL,
-  MODELS = MODELS,
   MODEL_ALIASES = MODEL_ALIASES,
   MAX_RETRIES = MAX_RETRIES,
   BASE_DELAY_MS = BASE_DELAY_MS,

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -1155,8 +1155,6 @@ return {
   main = main,
   load_system_prompt = load_system_prompt,
   load_claude_md = load_claude_md,
-  make_cli_handler = make_cli_handler,
-  tool_key_param = loop.tool_key_param,
   list_sessions = list_sessions,
   resolve_session = resolve_session,
   -- Branch UX commands (exported for testing)

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -10,8 +10,6 @@ local queue = require("ah.queue")
 local truncate = require("ah.truncate")
 local compact = require("ah.compact")
 
-local ToolDetails = tools.ToolDetails
-
 -- Reference the global interrupted flag (set by application layer)
 global interrupted: boolean
 

--- a/lib/ah/test_events.tl
+++ b/lib/ah/test_events.tl
@@ -253,4 +253,85 @@ local function test_budget_exceeded_json()
 end
 test_budget_exceeded_json()
 
+-- Test steering_received constructor
+local function test_steering_received()
+  local e = events.steering_received("please stop", 2)
+  assert(e.event_type == "steering_received", "event_type should be steering_received")
+  assert(e.content == "please stop", "content mismatch")
+  assert(e.message_count == 2, "message_count mismatch")
+  assert(e.timestamp, "should have timestamp")
+end
+test_steering_received()
+
+-- Test steering_received serialization
+local function test_steering_received_json()
+  local e = events.steering_received("change direction", 1)
+  local json_str = events.to_json(e)
+  local parsed = json.decode(json_str) as {string:any}
+  assert(parsed.event_type == "steering_received", "event_type should survive round-trip")
+  assert(parsed.content == "change direction", "content should survive round-trip")
+  assert(parsed.message_count == 1, "message_count should survive round-trip")
+end
+test_steering_received_json()
+
+-- Test followup_received constructor
+local function test_followup_received()
+  local e = events.followup_received("do this next", 3)
+  assert(e.event_type == "followup_received", "event_type should be followup_received")
+  assert(e.content == "do this next", "content mismatch")
+  assert(e.message_count == 3, "message_count mismatch")
+  assert(e.timestamp, "should have timestamp")
+end
+test_followup_received()
+
+-- Test followup_received serialization
+local function test_followup_received_json()
+  local e = events.followup_received("follow up task", 1)
+  local json_str = events.to_json(e)
+  local parsed = json.decode(json_str) as {string:any}
+  assert(parsed.event_type == "followup_received", "event_type should survive round-trip")
+  assert(parsed.content == "follow up task", "content should survive round-trip")
+end
+test_followup_received_json()
+
+-- Test compaction_triggered constructor
+local function test_compaction_triggered()
+  local e = events.compaction_triggered(170000, 200000)
+  assert(e.event_type == "compaction_triggered", "event_type should be compaction_triggered")
+  assert(e.input_tokens == 170000, "input_tokens mismatch")
+  assert(e.context_limit == 200000, "context_limit mismatch")
+end
+test_compaction_triggered()
+
+-- Test compaction_triggered serialization
+local function test_compaction_triggered_json()
+  local e = events.compaction_triggered(180000, 200000)
+  local json_str = events.to_json(e)
+  local parsed = json.decode(json_str) as {string:any}
+  assert(parsed.event_type == "compaction_triggered", "event_type should survive round-trip")
+  assert(parsed.input_tokens == 180000, "input_tokens should survive round-trip")
+  assert(parsed.context_limit == 200000, "context_limit should survive round-trip")
+end
+test_compaction_triggered_json()
+
+-- Test compaction_complete constructor
+local function test_compaction_complete()
+  local e = events.compaction_complete(180000, 2000)
+  assert(e.event_type == "compaction_complete", "event_type should be compaction_complete")
+  assert(e.input_tokens == 180000, "input_tokens mismatch")
+  assert(e.output_tokens == 2000, "output_tokens mismatch")
+end
+test_compaction_complete()
+
+-- Test compaction_complete serialization
+local function test_compaction_complete_json()
+  local e = events.compaction_complete(150000, 3000)
+  local json_str = events.to_json(e)
+  local parsed = json.decode(json_str) as {string:any}
+  assert(parsed.event_type == "compaction_complete", "event_type should survive round-trip")
+  assert(parsed.input_tokens == 150000, "input_tokens should survive round-trip")
+  assert(parsed.output_tokens == 3000, "output_tokens should survive round-trip")
+end
+test_compaction_complete_json()
+
 print("all events tests passed")


### PR DESCRIPTION
Remove unused imports/exports found during code review:
- loop.tl: remove unused ToolDetails import
- api.tl: remove dead MODELS export (never referenced)
- init.tl: remove dead re-exports (make_cli_handler, tool_key_param)

Add test coverage for previously untested event constructors:
- steering_received (constructor + JSON round-trip)
- followup_received (constructor + JSON round-trip)
- compaction_triggered (constructor + JSON round-trip)
- compaction_complete (constructor + JSON round-trip)

https://claude.ai/code/session_016oDdwaE9FLsc6eNZbjBbkd