### PR TITLE
fix: pass environment variables to child processes in tools

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -263,6 +263,24 @@ local function test_bash_timeout_not_triggered()
 end
 test_bash_timeout_not_triggered()
 
+local function test_bash_env_passthrough()
+  -- Verify that environment variables are passed to child processes
+  -- HOME should always be set and passed through
+  local home = os.getenv("HOME")
+  assert(home, "HOME should be set in test environment")
+
+  local result, is_error = tools.execute_tool("bash", {command = "echo $HOME"})
+  assert(not is_error, "bash should succeed")
+  assert(result:match(home), "child process should see HOME env var: " .. result)
+
+  -- Also verify PATH is passed (needed for commands to work)
+  local path_result, path_error = tools.execute_tool("bash", {command = "echo $PATH"})
+  assert(not path_error, "bash should succeed")
+  assert(path_result:match("/"), "child process should see PATH with directories: " .. path_result)
+  print("✓ bash tool passes environment variables to child processes")
+end
+test_bash_env_passthrough()
+
 -- CLI tool tests
 local function test_load_cli_tools_empty_dir()
   local empty_dir = fs.join(TEST_TMPDIR, "empty_bin")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -292,13 +292,8 @@ local bash_tool: Tool = {
     local wrapped = string.format("timeout %d sh -c %q", timeout_sec, command)
 
     -- Pass current environment to the child process
-    local current_env = env.all()
-    local env_list: {string} = {}
-    for k, v in pairs(current_env) do
-      table.insert(env_list, k .. "=" .. v)
-    end
-
-    local handle, err = child.spawn({"sh", "-c", wrapped}, {env = env_list})
+    -- env.all() returns an array of "key=value" strings
+    local handle, err = child.spawn({"sh", "-c", wrapped}, {env = env.all() as {string}})
     if not handle then
       return "error: failed to spawn: " .. tostring(err), true, nil
     end
@@ -390,13 +385,7 @@ end
 
 -- Check if a file is executable
 local function is_executable(path: string): boolean
-  -- Pass current environment
-  local current_env = env.all()
-  local env_list: {string} = {}
-  for k, v in pairs(current_env) do
-    table.insert(env_list, k .. "=" .. v)
-  end
-  local handle, err = child.spawn({"test", "-x", path}, {env = env_list})
+  local handle, err = child.spawn({"test", "-x", path}, {env = env.all() as {string}})
   if not handle then return false end
   local _, _, exit_str = handle:read()
   return tonumber(exit_str) == 0
@@ -436,12 +425,7 @@ local function load_cli_tools_from_dir(dir: string): {Tool}
       end
     else
       -- Try --help
-      local current_env = env.all()
-      local env_list: {string} = {}
-      for k, v in pairs(current_env) do
-        table.insert(env_list, k .. "=" .. v)
-      end
-      local handle = child.spawn({bin_path, "--help"}, {env = env_list})
+      local handle = child.spawn({bin_path, "--help"}, {env = env.all() as {string}})
       if handle then
         local _, stdout = handle:read()
         if stdout and stdout ~= "" then
@@ -474,14 +458,7 @@ local function load_cli_tools_from_dir(dir: string): {Tool}
           table.insert(cmd, arg)
         end
 
-        -- Pass current environment to the child process
-        local current_env = env.all()
-        local env_list: {string} = {}
-        for k, v in pairs(current_env) do
-          table.insert(env_list, k .. "=" .. v)
-        end
-
-        local handle, err = child.spawn(cmd, {env = env_list})
+        local handle, err = child.spawn(cmd, {env = env.all() as {string}})
         if not handle then
           return "error: failed to spawn: " .. tostring(err), true, nil
         end


### PR DESCRIPTION
## Summary
- Add cosmic.env module import to tools.tl
- Use env.all() to get current environment
- Pass environment to all child.spawn calls (bash tool, CLI tools, test -x)

Ensures child processes inherit the environment that ah has access to. This fixes the issue where bash commands spawned by the tools don't have access to environment variables.

## Test plan
- [ ] Verify bash commands can access environment variables (e.g., `echo $HOME`)
- [ ] Verify CLI tools receive environment correctly