### PR TITLE
feat: implement work-select script for issue selection (phase 2)

### DIFF
--- a/bin/work-select
+++ b/bin/work-select
@@ -3,7 +3,7 @@
 local spawn = require("cosmic.child")
 local json = require("cosmic.json")
 local env = require("cosmic.env")
-local cosmo = require("cosmo")
+local proc = require("cosmic.proc")
 
 -- Export functions for testing
 local M = {}
@@ -81,50 +81,7 @@ function M.select_issue(issues)
   }
 end
 
-function M.test()
-  -- Test get_priority
-  assert(M.get_priority({}) == 3, "no labels should return 3")
-  assert(M.get_priority({{name = "p0"}}) == 0, "p0 should return 0")
-  assert(M.get_priority({{name = "p1"}}) == 1, "p1 should return 1")
-  assert(M.get_priority({{name = "p2"}}) == 2, "p2 should return 2")
-  print("✓ get_priority works correctly")
-  
-  -- Test sort_issues
-  local issues = {
-    {number = 1, labels = {}, createdAt = "2024-01-01T00:00:00Z"},
-    {number = 2, labels = {{name = "p2"}}, createdAt = "2024-01-02T00:00:00Z"},
-    {number = 3, labels = {{name = "p0"}}, createdAt = "2024-01-03T00:00:00Z"},
-    {number = 4, labels = {{name = "p1"}}, createdAt = "2024-01-04T00:00:00Z"}
-  }
-  
-  M.sort_issues(issues)
-  assert(issues[1].number == 3, "p0 issue should be first")
-  assert(issues[2].number == 4, "p1 issue should be second")
-  assert(issues[3].number == 2, "p2 issue should be third")
-  assert(issues[4].number == 1, "unlabeled issue should be last")
-  print("✓ sort_issues works correctly")
-  
-  -- Test select_issue
-  local test_issues = {
-    {number = 42, title = "Test", body = "Body", url = "url1", labels = {{name = "p1"}}, createdAt = "2024-01-01T00:00:00Z", extra = "field"},
-    {number = 43, title = "Higher", body = "Body2", url = "url2", labels = {{name = "p0"}}, createdAt = "2024-01-02T00:00:00Z"}
-  }
-  
-  local selected = M.select_issue(test_issues)
-  assert(selected.number == 43, "should select p0 issue")
-  assert(selected.extra == nil, "should not include extra fields")
-  print("✓ select_issue works correctly")
-  
-  print("\nAll tests passed!")
-  return 0
-end
-
 function M.main(args)
-  -- Check for test mode
-  if args[1] == "--test" then
-    return M.test()
-  end
-  
   local repo = args and args[1]
   if not repo then
     io.stderr:write("usage: work-select <owner/repo>\n")
@@ -147,7 +104,7 @@ function M.main(args)
 end
 
 -- When run as main script, execute main function
-if cosmo.is_main() then
+if proc.is_main() then
   os.exit(M.main(arg) or 0)
 end
 

--- a/lib/ah/test_work_select.tl
+++ b/lib/ah/test_work_select.tl
@@ -1,0 +1,111 @@
+#!/usr/bin/env cosmic
+-- test_work_select.tl: tests for work-select script
+
+local path = require("cosmo.path")
+
+local record Label
+  name: string
+end
+
+local record Issue
+  number: integer
+  title: string
+  body: string
+  url: string
+  labels: {Label}
+  createdAt: string
+  extra: string
+end
+
+local record SelectedIssue
+  number: integer
+  title: string
+  body: string
+  url: string
+end
+
+local record WorkSelect
+  get_priority: function({Label}): integer
+  sort_issues: function({Issue})
+  select_issue: function({Issue}): SelectedIssue
+end
+
+-- Load the work-select module
+local script_path = path.join(os.getenv("TEST_BIN") or "bin", "..", "bin", "work-select")
+local ws = dofile(script_path) as WorkSelect
+
+-- Test get_priority
+local function test_get_priority()
+  assert(ws.get_priority({}) == 3, "no labels should return 3")
+  assert(ws.get_priority({{name = "bug"}}) == 3, "non-priority label should return 3")
+  assert(ws.get_priority({{name = "p0"}}) == 0, "p0 should return 0")
+  assert(ws.get_priority({{name = "p1"}}) == 1, "p1 should return 1")
+  assert(ws.get_priority({{name = "p2"}}) == 2, "p2 should return 2")
+  assert(ws.get_priority({{name = "p0"}, {name = "bug"}}) == 0, "p0 with other labels should return 0")
+  print("✓ get_priority works correctly")
+end
+test_get_priority()
+
+-- Test sort_issues by priority
+local function test_priority_sorting()
+  local issues = {
+    {number = 1, labels = {}, createdAt = "2024-01-01T00:00:00Z"},
+    {number = 2, labels = {{name = "p2"}}, createdAt = "2024-01-02T00:00:00Z"},
+    {number = 3, labels = {{name = "p0"}}, createdAt = "2024-01-03T00:00:00Z"},
+    {number = 4, labels = {{name = "p1"}}, createdAt = "2024-01-04T00:00:00Z"}
+  }
+
+  ws.sort_issues(issues)
+  assert(issues[1].number == 3, "p0 issue should be first")
+  assert(issues[2].number == 4, "p1 issue should be second")
+  assert(issues[3].number == 2, "p2 issue should be third")
+  assert(issues[4].number == 1, "unlabeled issue should be last")
+  print("✓ sort_issues orders by priority")
+end
+test_priority_sorting()
+
+-- Test sort_issues by date within same priority
+local function test_date_sorting()
+  local issues = {
+    {number = 1, labels = {{name = "p1"}}, createdAt = "2024-01-05T00:00:00Z"},
+    {number = 2, labels = {{name = "p1"}}, createdAt = "2024-01-01T00:00:00Z"},
+    {number = 3, labels = {{name = "p1"}}, createdAt = "2024-01-03T00:00:00Z"}
+  }
+
+  ws.sort_issues(issues)
+  assert(issues[1].number == 2, "oldest issue should be first")
+  assert(issues[2].number == 3, "middle issue should be second")
+  assert(issues[3].number == 1, "newest issue should be last")
+  print("✓ sort_issues orders by date within priority")
+end
+test_date_sorting()
+
+-- Test select_issue returns correct format
+local function test_select_issue()
+  local issues = {
+    {number = 42, title = "Test", body = "Body", url = "url1", labels = {{name = "p1"}}, createdAt = "2024-01-01T00:00:00Z", extra = "field"},
+    {number = 43, title = "Higher", body = "Body2", url = "url2", labels = {{name = "p0"}}, createdAt = "2024-01-02T00:00:00Z"}
+  }
+
+  local selected = ws.select_issue(issues)
+  assert(selected.number == 43, "should select p0 issue")
+  assert(selected.title == "Higher", "should include title")
+  assert(selected.body == "Body2", "should include body")
+  assert(selected.url == "url2", "should include url")
+  local raw = selected as {string:any}
+  assert(raw.extra == nil, "should not include extra fields")
+  assert(raw.labels == nil, "should not include labels")
+  assert(raw.createdAt == nil, "should not include createdAt")
+  print("✓ select_issue returns correct format")
+end
+test_select_issue()
+
+-- Test select_issue with empty list
+local function test_empty_issues()
+  local selected = ws.select_issue({})
+  assert(selected == nil, "should return nil for empty list")
+  print("✓ select_issue handles empty list")
+end
+test_empty_issues()
+
+print("\nAll work-select tests passed!")


### PR DESCRIPTION
## Summary

Add `bin/work-select` script for automated GitHub issue selection.

## Changes

- Fetch open issues with 'todo' label from specified repo
- Sort by priority (p0 > p1 > p2 > unlabeled), then by date
- Return first issue as JSON with number, title, body, url
- Exit 1 if no issues found
- Export module table for testability via `cosmic.proc.is_main()`

## Usage

```
work-select owner/repo
```

## Test plan

- [x] Unit tests in `lib/ah/test_work_select.tl`
- [x] `make test` passes