### PR TITLE
api: update model ids to 4.5 family

### DIFF
--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -35,19 +35,19 @@ local function now_ms(): integer
 end
 
 local API_URL = "https://api.anthropic.com/v1/messages"
-local DEFAULT_MODEL = "claude-sonnet-4-20250514"
+local DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
 local DEFAULT_MAX_TOKENS = 8192
 
 local MODELS: {string} = {
-  "claude-sonnet-4-20250514",
-  "claude-opus-4-20250514",
-  "claude-haiku-3-20250314",
+  "claude-sonnet-4-5-20250929",
+  "claude-opus-4-5-20251101",
+  "claude-haiku-4-5-20251001",
 }
 
 local MODEL_ALIASES: {string:string} = {
-  ["sonnet"] = "claude-sonnet-4-20250514",
-  ["opus"] = "claude-opus-4-20250514",
-  ["haiku"] = "claude-haiku-3-20250314",
+  ["sonnet"] = "claude-sonnet-4-5-20250929",
+  ["opus"] = "claude-opus-4-5-20251101",
+  ["haiku"] = "claude-haiku-4-5-20251001",
 }
 
 -- Resolve model name, expanding aliases

--- a/lib/ah/compact.tl
+++ b/lib/ah/compact.tl
@@ -9,9 +9,9 @@ local api = require("ah.api")
 
 -- Model context window limits (tokens)
 local MODEL_CONTEXT_LIMITS: {string:integer} = {
-  ["claude-sonnet-4-20250514"] = 200000,
-  ["claude-opus-4-20250514"] = 200000,
-  ["claude-haiku-3-20250314"] = 200000,
+  ["claude-sonnet-4-5-20250929"] = 200000,
+  ["claude-opus-4-5-20251101"] = 200000,
+  ["claude-haiku-4-5-20251001"] = 200000,
 }
 
 local DEFAULT_CONTEXT_LIMIT = 200000

--- a/lib/ah/test_api.tl
+++ b/lib/ah/test_api.tl
@@ -61,7 +61,7 @@ test_extract_tool_calls_mixed()
 local function test_build_request_default_model()
   local req = api.build_request({}, {}, false)
   assert(req.model == api.DEFAULT_MODEL, "should use default model")
-  assert(req.model == "claude-sonnet-4-20250514", "default model should be sonnet")
+  assert(req.model == "claude-sonnet-4-5-20250929", "default model should be sonnet")
 end
 test_build_request_default_model()
 
@@ -212,11 +212,11 @@ test_extract_retry_delay()
 
 local function test_resolve_model()
   -- Aliases should resolve to full names
-  assert(api.resolve_model("sonnet") == "claude-sonnet-4-20250514", "sonnet alias")
-  assert(api.resolve_model("opus") == "claude-opus-4-20250514", "opus alias")
-  assert(api.resolve_model("haiku") == "claude-haiku-3-20250314", "haiku alias")
+  assert(api.resolve_model("sonnet") == "claude-sonnet-4-5-20250929", "sonnet alias")
+  assert(api.resolve_model("opus") == "claude-opus-4-5-20251101", "opus alias")
+  assert(api.resolve_model("haiku") == "claude-haiku-4-5-20251001", "haiku alias")
   -- Full names should pass through
-  assert(api.resolve_model("claude-sonnet-4-20250514") == "claude-sonnet-4-20250514", "full name passthrough")
+  assert(api.resolve_model("claude-sonnet-4-5-20250929") == "claude-sonnet-4-5-20250929", "full name passthrough")
   -- Unknown names should pass through
   assert(api.resolve_model("custom-model") == "custom-model", "unknown passthrough")
   -- Nil should return nil

--- a/lib/ah/test_compact.tl
+++ b/lib/ah/test_compact.tl
@@ -5,21 +5,21 @@ local compact = require("ah.compact")
 -- get_context_limit tests
 
 local function test_get_context_limit_known_model()
-  local limit = compact.get_context_limit("claude-sonnet-4-20250514")
+  local limit = compact.get_context_limit("claude-sonnet-4-5-20250929")
   assert(limit == 200000, "sonnet context limit should be 200000: " .. tostring(limit))
   print("✓ get_context_limit known model (sonnet)")
 end
 test_get_context_limit_known_model()
 
 local function test_get_context_limit_opus()
-  local limit = compact.get_context_limit("claude-opus-4-20250514")
+  local limit = compact.get_context_limit("claude-opus-4-5-20251101")
   assert(limit == 200000, "opus context limit should be 200000: " .. tostring(limit))
   print("✓ get_context_limit known model (opus)")
 end
 test_get_context_limit_opus()
 
 local function test_get_context_limit_haiku()
-  local limit = compact.get_context_limit("claude-haiku-3-20250314")
+  local limit = compact.get_context_limit("claude-haiku-4-5-20251001")
   assert(limit == 200000, "haiku context limit should be 200000: " .. tostring(limit))
   print("✓ get_context_limit known model (haiku)")
 end
@@ -43,56 +43,56 @@ test_get_context_limit_nil_model()
 
 local function test_needs_compaction_below_threshold()
   -- 50% of 200k = 100k tokens
-  assert(not compact.needs_compaction(100000, "claude-sonnet-4-20250514"), "100k/200k should not trigger compaction")
+  assert(not compact.needs_compaction(100000, "claude-sonnet-4-5-20250929"), "100k/200k should not trigger compaction")
   print("✓ needs_compaction below threshold")
 end
 test_needs_compaction_below_threshold()
 
 local function test_needs_compaction_at_threshold()
   -- Exactly at 80% = 160k tokens (0.8 is not > 0.8)
-  assert(not compact.needs_compaction(160000, "claude-sonnet-4-20250514"), "exactly at threshold should not trigger")
+  assert(not compact.needs_compaction(160000, "claude-sonnet-4-5-20250929"), "exactly at threshold should not trigger")
   print("✓ needs_compaction at threshold boundary")
 end
 test_needs_compaction_at_threshold()
 
 local function test_needs_compaction_above_threshold()
   -- 85% = 170k tokens
-  assert(compact.needs_compaction(170000, "claude-sonnet-4-20250514"), "170k/200k should trigger compaction")
+  assert(compact.needs_compaction(170000, "claude-sonnet-4-5-20250929"), "170k/200k should trigger compaction")
   print("✓ needs_compaction above threshold")
 end
 test_needs_compaction_above_threshold()
 
 local function test_needs_compaction_just_above_threshold()
   -- 80.1% = 160001 tokens
-  assert(compact.needs_compaction(160001, "claude-sonnet-4-20250514"), "160001/200000 should trigger compaction")
+  assert(compact.needs_compaction(160001, "claude-sonnet-4-5-20250929"), "160001/200000 should trigger compaction")
   print("✓ needs_compaction just above threshold")
 end
 test_needs_compaction_just_above_threshold()
 
 local function test_needs_compaction_zero_tokens()
-  assert(not compact.needs_compaction(0, "claude-sonnet-4-20250514"), "zero tokens should not trigger")
+  assert(not compact.needs_compaction(0, "claude-sonnet-4-5-20250929"), "zero tokens should not trigger")
   print("✓ needs_compaction zero tokens")
 end
 test_needs_compaction_zero_tokens()
 
 local function test_needs_compaction_custom_threshold_low()
   -- 60% of 200k = 120k tokens, custom threshold 0.5
-  assert(compact.needs_compaction(120000, "claude-sonnet-4-20250514", 0.5), "120k at 0.5 threshold should trigger")
+  assert(compact.needs_compaction(120000, "claude-sonnet-4-5-20250929", 0.5), "120k at 0.5 threshold should trigger")
   print("✓ needs_compaction custom threshold (triggers)")
 end
 test_needs_compaction_custom_threshold_low()
 
 local function test_needs_compaction_custom_threshold_high()
   -- 80k at 0.5 threshold = 40% < 50%
-  assert(not compact.needs_compaction(80000, "claude-sonnet-4-20250514", 0.5), "80k at 0.5 threshold should not trigger")
+  assert(not compact.needs_compaction(80000, "claude-sonnet-4-5-20250929", 0.5), "80k at 0.5 threshold should not trigger")
   print("✓ needs_compaction custom threshold (no trigger)")
 end
 test_needs_compaction_custom_threshold_high()
 
 local function test_needs_compaction_custom_threshold_tight()
   -- Custom threshold of 0.9 (90%)
-  assert(not compact.needs_compaction(170000, "claude-sonnet-4-20250514", 0.9), "170k at 0.9 threshold should not trigger")
-  assert(compact.needs_compaction(190000, "claude-sonnet-4-20250514", 0.9), "190k at 0.9 threshold should trigger")
+  assert(not compact.needs_compaction(170000, "claude-sonnet-4-5-20250929", 0.9), "170k at 0.9 threshold should not trigger")
+  assert(compact.needs_compaction(190000, "claude-sonnet-4-5-20250929", 0.9), "190k at 0.9 threshold should trigger")
   print("✓ needs_compaction custom threshold (tight)")
 end
 test_needs_compaction_custom_threshold_tight()
@@ -135,9 +135,9 @@ end
 test_compaction_prompt_content()
 
 local function test_model_limits_all_present()
-  assert(compact.MODEL_CONTEXT_LIMITS["claude-sonnet-4-20250514"], "sonnet should have a limit")
-  assert(compact.MODEL_CONTEXT_LIMITS["claude-opus-4-20250514"], "opus should have a limit")
-  assert(compact.MODEL_CONTEXT_LIMITS["claude-haiku-3-20250314"], "haiku should have a limit")
+  assert(compact.MODEL_CONTEXT_LIMITS["claude-sonnet-4-5-20250929"], "sonnet should have a limit")
+  assert(compact.MODEL_CONTEXT_LIMITS["claude-opus-4-5-20251101"], "opus should have a limit")
+  assert(compact.MODEL_CONTEXT_LIMITS["claude-haiku-4-5-20251001"], "haiku should have a limit")
   print("✓ all models have context limits")
 end
 test_model_limits_all_present()


### PR DESCRIPTION
## Summary
- Update all model IDs to the latest 4.5 family versions
- sonnet: `claude-sonnet-4-20250514` → `claude-sonnet-4-5-20250929`
- opus: `claude-opus-4-20250514` → `claude-opus-4-5-20251101`
- haiku: `claude-haiku-3-20250314` → `claude-haiku-4-5-20251001`

## Test plan
- [x] `make test` passes