### PR TITLE
work-act: implement real action handlers

### DIFF
--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -1,8 +1,8 @@
 name: work
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  # schedule:
+  #   - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       issue:

--- a/bin/work-act
+++ b/bin/work-act
@@ -58,6 +58,59 @@ local function run(cmd)
   return ok and tonumber(exit_str) == 0
 end
 
+function M.validate_branch(branch)
+  if not branch then return false, "missing branch" end
+  if not branch:match("^work/") then
+    return false, "branch must start with work/"
+  end
+  return true
+end
+
+function M.execute_comment_issue(issue_url, body)
+  if not body then return false, "missing body" end
+  local ok = run({"gh", "issue", "comment", issue_url, "--body", body})
+  if not ok then return false, "gh issue comment failed" end
+  return true
+end
+
+function M.execute_create_pr(branch, title, body)
+  local valid, err = M.validate_branch(branch)
+  if not valid then return false, err end
+  if not title then return false, "missing title" end
+  if not body then return false, "missing body" end
+  local ok = run({"gh", "pr", "create", "--head", branch, "--title", title, "--body", body})
+  if not ok then return false, "gh pr create failed" end
+  return true
+end
+
+function M.execute_action(issue_url, action, log_fn)
+  local action_type = action.action or "unknown"
+  log_fn("Executing: " .. action_type)
+
+  if action_type == "comment_issue" then
+    local ok, err = M.execute_comment_issue(issue_url, action.body)
+    if not ok then
+      log_fn("  Failed: " .. (err or "unknown error"))
+      return false
+    end
+    log_fn("  Success")
+    return true
+
+  elseif action_type == "create_pr" then
+    local ok, err = M.execute_create_pr(action.branch, action.title, action.body)
+    if not ok then
+      log_fn("  Failed: " .. (err or "unknown error"))
+      return false
+    end
+    log_fn("  Success")
+    return true
+
+  else
+    log_fn("  Skipped: unknown action type")
+    return true
+  end
+end
+
 function M.update_labels(issue_url, success)
   run({"gh", "issue", "edit", issue_url, "--remove-label", "doing"})
   if success then
@@ -124,17 +177,14 @@ function M.main(args)
   tee(act_md, "## Actions")
 
   local actions = actions_data.actions or {}
+  local all_succeeded = true
   for _, action in ipairs(actions) do
-    local action_type = action.action or "unknown"
-    tee(act_md, "Would execute: " .. action_type)
-    local f = io.open(act_md, "a")
-    if f then
-      f:write("  Payload: " .. json.encode(action) .. "\n")
-      f:close()
-    end
+    local log_fn = function(msg) tee(act_md, msg) end
+    local ok = M.execute_action(issue_url, action, log_fn)
+    if not ok then all_succeeded = false end
   end
 
-  local success = verdict == "pass"
+  local success = verdict == "pass" and all_succeeded
   write_file("o/work/act/results.json", json.encode({
     verdict = verdict,
     success = success

--- a/lib/ah/test_work_act.tl
+++ b/lib/ah/test_work_act.tl
@@ -11,6 +11,10 @@ end
 
 local record WorkAct
   parse_actions: function(string): ParsedActions, string
+  validate_branch: function(string): boolean, string
+  execute_comment_issue: function(string, string): boolean, string
+  execute_create_pr: function(string, string, string): boolean, string
+  execute_action: function(string, {string:any}, function(string)): boolean
 end
 
 local script_path = path.join(os.getenv("TEST_BIN") or "bin", "..", "bin", "work-act")
@@ -77,5 +81,55 @@ local function test_parse_empty_actions()
   print("✓ parse_actions defaults missing actions to empty")
 end
 test_parse_empty_actions()
+
+-- Test validate_branch with valid branch
+local function test_validate_branch_valid()
+  local ok, err = wa.validate_branch("work/123-fix-bug")
+  assert(ok == true, "should accept work/ prefix")
+  assert(err == nil, "should not have error")
+  print("✓ validate_branch accepts work/ prefix")
+end
+test_validate_branch_valid()
+
+-- Test validate_branch with invalid branch
+local function test_validate_branch_invalid()
+  local ok, err = wa.validate_branch("main")
+  assert(ok == false, "should reject non-work branch")
+  assert(err == "branch must start with work/", "should return error")
+  print("✓ validate_branch rejects non-work/ prefix")
+end
+test_validate_branch_invalid()
+
+-- Test validate_branch with feature branch
+local function test_validate_branch_feature()
+  local ok, err = wa.validate_branch("feature/new-thing")
+  assert(ok == false, "should reject feature/ prefix")
+  assert(err == "branch must start with work/", "should return error")
+  print("✓ validate_branch rejects feature/ prefix")
+end
+test_validate_branch_feature()
+
+-- Test validate_branch with nil
+local function test_validate_branch_nil()
+  local ok, err = wa.validate_branch(nil)
+  assert(ok == false, "should reject nil branch")
+  assert(err == "missing branch", "should return missing error")
+  print("✓ validate_branch rejects nil branch")
+end
+test_validate_branch_nil()
+
+-- Test execute_action with unknown action type
+local function test_execute_action_unknown()
+  local logs = {}
+  local log_fn = function(msg: string) table.insert(logs, msg) end
+  local action = {action = "unknown_action"}
+  local ok = wa.execute_action("https://example.com", action, log_fn)
+  assert(ok == true, "unknown action should succeed (skip)")
+  assert(#logs == 2, "should have 2 log entries")
+  assert(logs[1] == "Executing: unknown_action", "should log action type")
+  assert(logs[2] == "  Skipped: unknown action type", "should log skip")
+  print("✓ execute_action skips unknown action types")
+end
+test_execute_action_unknown()
 
 print("\nAll work-act tests passed!")


### PR DESCRIPTION
## Summary
- Replace dry-run stub with actual action execution for `comment_issue` and `create_pr`
- Add branch validation (only `work/` prefixed branches allowed for PRs)
- Disable scheduled workflow runs for manual testing

## Test plan
- [x] Unit tests pass for `validate_branch`, `execute_action` with unknown type
- [ ] Manual workflow run to test full flow