### PR TITLE
ah: add sandbox mode for restricted execution

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -803,6 +803,16 @@ local function main(args: {string}): integer, string
     end
     return work.main(sub_args)
 
+  elseif cmd == "proxy" then
+    -- Internal command: run HTTP CONNECT proxy for sandboxed network access
+    local socket_path = remaining[2]
+    if not socket_path then
+      io.stderr:write("usage: ah proxy <socket-path>\n")
+      return 1
+    end
+    local proxy = require("ah.proxy")
+    return proxy.serve(socket_path)
+
   elseif cmd == "extract" then
     local output_dir = remaining[2]
     if not output_dir then

--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -1,0 +1,169 @@
+-- ah/proxy.tl: HTTP CONNECT proxy with destination allowlist
+-- Used by `ah proxy` subcommand for sandboxed network access
+
+local unix = require("cosmo.unix")
+local net = require("cosmic.net")
+
+local M = {}
+
+local ALLOWLIST: {string:boolean} = {
+  ["api.anthropic.com:443"] = true,
+}
+
+-- DNS cache (hardcoded for now, could use getaddrinfo before pledge)
+local DNS_CACHE: {string:string} = {
+  ["api.anthropic.com"] = "160.79.104.11",
+}
+
+local function log(...: string)
+  local parts: {string} = {...}
+  io.stderr:write("[proxy] " .. table.concat(parts, "\t") .. "\n")
+end
+
+local function parse_connect(request: string): string, string
+  local host, port = request:match("CONNECT%s+([^:%s]+):(%d+)")
+  return host, port
+end
+
+local function relay(client_fd: number, upstream_fd: number)
+  local BUFSIZ = 65536
+
+  -- Set non-blocking
+  unix.fcntl(client_fd, unix.F_SETFL, unix.O_NONBLOCK)
+  unix.fcntl(upstream_fd, unix.F_SETFL, unix.O_NONBLOCK)
+
+  while true do
+    local fds: {number:number} = {
+      [client_fd] = net.POLLIN,
+      [upstream_fd] = net.POLLIN,
+    }
+
+    local revents, err = net.poll(fds, 30000)
+    if not revents then
+      log("poll error:", err)
+      break
+    end
+
+    local client_ev = revents[client_fd] or 0
+    local upstream_ev = revents[upstream_fd] or 0
+
+    if client_ev & (net.POLLERR | net.POLLHUP | net.POLLNVAL) ~= 0 then
+      break
+    end
+    if upstream_ev & (net.POLLERR | net.POLLHUP | net.POLLNVAL) ~= 0 then
+      break
+    end
+
+    if client_ev & net.POLLIN ~= 0 then
+      local data = unix.read(client_fd, BUFSIZ)
+      if not data or data == "" then break end
+      unix.write(upstream_fd, data)
+    end
+
+    if upstream_ev & net.POLLIN ~= 0 then
+      local data = unix.read(upstream_fd, BUFSIZ)
+      if not data or data == "" then break end
+      unix.write(client_fd, data)
+    end
+  end
+end
+
+local function handle_client(client_fd: number)
+  local request = unix.read(client_fd, 4096)
+  if not request then
+    log("failed to read request")
+    return
+  end
+
+  local host, port = parse_connect(request)
+  if not host then
+    log("bad request:", (request as string):sub(1, 50))
+    unix.write(client_fd, "HTTP/1.1 400 Bad Request\r\n\r\nOnly CONNECT supported\r\n")
+    return
+  end
+
+  local dest = host .. ":" .. port
+  log("CONNECT", dest)
+
+  if not ALLOWLIST[dest] then
+    log("BLOCKED", dest)
+    unix.write(client_fd, "HTTP/1.1 403 Forbidden\r\n\r\nDestination not allowed: " .. dest .. "\r\n")
+    return
+  end
+
+  local ip_str = DNS_CACHE[host]
+  if not ip_str then
+    log("DNS failed:", host)
+    unix.write(client_fd, "HTTP/1.1 502 Bad Gateway\r\n\r\nDNS resolution failed\r\n")
+    return
+  end
+
+  local ip = net.parseip(ip_str)
+  if not ip then
+    log("invalid IP:", ip_str)
+    unix.write(client_fd, "HTTP/1.1 502 Bad Gateway\r\n\r\nInvalid IP\r\n")
+    return
+  end
+
+  local upstream_fd = unix.socket(unix.AF_INET, unix.SOCK_STREAM, 0)
+  if not upstream_fd or upstream_fd < 0 then
+    log("socket failed")
+    unix.write(client_fd, "HTTP/1.1 502 Bad Gateway\r\n\r\nSocket creation failed\r\n")
+    return
+  end
+
+  local ok = unix.connect(upstream_fd, ip, tonumber(port) as integer)
+  if not ok then
+    log("connect failed:", host, port)
+    unix.close(upstream_fd)
+    unix.write(client_fd, "HTTP/1.1 502 Bad Gateway\r\n\r\nConnection failed\r\n")
+    return
+  end
+
+  log("ALLOWED", dest)
+  unix.write(client_fd, "HTTP/1.1 200 Connection Established\r\n\r\n")
+
+  relay(client_fd, upstream_fd)
+  unix.close(upstream_fd)
+end
+
+-- Run proxy server on Unix socket
+-- Returns only on error
+function M.serve(socket_path: string): number
+  unix.unlink(socket_path)
+
+  local server_fd = unix.socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+  if not server_fd or server_fd < 0 then
+    io.stderr:write("error: failed to create socket\n")
+    return 1
+  end
+
+  local ok = unix.bind(server_fd, socket_path)
+  if not ok then
+    io.stderr:write("error: failed to bind to " .. socket_path .. "\n")
+    unix.close(server_fd)
+    return 1
+  end
+
+  unix.chmod(socket_path, tonumber("600", 8))
+  unix.listen(server_fd, 128)
+
+  log("listening on", socket_path)
+
+  while true do
+    local client_fd = unix.accept(server_fd, 0)
+    if client_fd and client_fd >= 0 then
+      local pid = unix.fork()
+      if pid == 0 then
+        unix.close(server_fd)
+        handle_client(client_fd)
+        unix.close(client_fd)
+        os.exit(0)
+      else
+        unix.close(client_fd)
+      end
+    end
+  end
+end
+
+return M

--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -5,6 +5,18 @@ local cio = require("cosmic.io")
 local json = require("cosmic.json")
 local env = require("cosmic.env")
 local getopt = require("cosmic.getopt")
+local unix = require("cosmo.unix")
+local sandbox = require("cosmic.sandbox")
+
+-- Sandbox context for network isolation
+local record SandboxCtx
+  enabled: boolean
+  socket_path: string
+  proxy_pid: number
+  tmpdir: string
+end
+
+local sandbox_ctx: SandboxCtx = nil
 
 local record Label
   name: string
@@ -55,8 +67,77 @@ local function read_prompt(name: string): string
       or cio.slurp("sys/work/" .. name)
 end
 
+-- Start sandbox proxy
+-- Returns sandbox context or nil on error
+local function start_sandbox(): SandboxCtx, string
+  -- Create temp directory for socket
+  local tmpdir = unix.mkdtemp("/tmp/ah-sandbox-XXXXXX")
+  if not tmpdir then
+    return nil, "failed to create temp directory"
+  end
+
+  local socket_path = tmpdir .. "/proxy.sock"
+
+  -- Fork and exec proxy
+  local pid = unix.fork()
+  if pid < 0 then
+    unix.rmrf(tmpdir)
+    return nil, "fork failed"
+  end
+
+  if pid == 0 then
+    -- Child: exec proxy
+    unix.execve(ah_exe(), {ah_exe(), "proxy", socket_path}, env.all() as {string})
+    os.exit(1)  -- exec failed
+  end
+
+  -- Parent: wait for socket to appear
+  local timeout = 50  -- 5 seconds (50 * 100ms)
+  while timeout > 0 do
+    local stat = unix.stat(socket_path)
+    if stat then
+      break
+    end
+    unix.nanosleep(0, 100000000)  -- 100ms
+    timeout = timeout - 1
+  end
+
+  if timeout == 0 then
+    unix.kill(pid, unix.SIGTERM)
+    unix.wait()
+    unix.rmrf(tmpdir)
+    return nil, "proxy socket not ready"
+  end
+
+  return {
+    enabled = true,
+    socket_path = socket_path,
+    proxy_pid = pid,
+    tmpdir = tmpdir,
+  }
+end
+
+-- Stop sandbox proxy and clean up
+local function stop_sandbox(ctx: SandboxCtx)
+  if not ctx then return end
+  if ctx.proxy_pid > 0 then
+    unix.kill(ctx.proxy_pid, unix.SIGTERM)
+    unix.wait()
+  end
+  if ctx.tmpdir then
+    unix.rmrf(ctx.tmpdir)
+  end
+end
+
 local function run(cmd: {string}): boolean, string, integer
-  local handle, spawn_err = spawn.spawn(cmd, {env = env.all() as {string}})
+  -- Build environment, adding sandbox vars if enabled
+  local run_env = env.all()
+  if sandbox_ctx and sandbox_ctx.enabled then
+    run_env.http_proxy = "unix://" .. sandbox_ctx.socket_path
+    run_env.AH_SANDBOX = "1"
+  end
+
+  local handle, spawn_err = spawn.spawn(cmd, {env = run_env as {string}})
   if not handle then return false, spawn_err as string, -1 end
   local ok, stdout, exit_str = handle:read()
   local exit_code = (tonumber(exit_str) or 0) as integer
@@ -551,90 +632,131 @@ local function cmd_act(args: {string}): integer
 end
 
 local function main(args: {string}): integer
-  local subcmd = args[1]
+  -- Parse global options first (--no-sandbox)
+  local no_sandbox = false
+  local filtered_args: {string} = {}
 
-  if subcmd == "plan" then
-    return cmd_plan(slice(args, 2))
-  elseif subcmd == "do" then
-    return cmd_do(slice(args, 2))
-  elseif subcmd == "check" then
-    return phase_check()
-  elseif subcmd == "act" then
-    return cmd_act(slice(args, 2))
-  elseif subcmd == "push" then
-    return phase_push()
-  end
-
-  -- Unified mode: parse options, run all phases
-  local repo: string
-  local issue_number: string
-
-  local longopts = {
-    {name = "help", has_arg = "none", short = "h"},
-    {name = "repo", has_arg = "required", short = "r"},
-    {name = "issue", has_arg = "required", short = "i"},
-  }
-
-  local parser = getopt.new(args, "hr:i:", longopts)
-
-  while true do
-    local opt, optarg = parser:next()
-    if not opt then break end
-    if opt == "h" or opt == "help" then
-      usage()
-      return 0
-    elseif opt == "r" or opt == "repo" then
-      repo = optarg
-    elseif opt == "i" or opt == "issue" then
-      issue_number = optarg
-    elseif opt == "?" then
-      usage()
-      return 1
+  for _, a in ipairs(args) do
+    if a == "--no-sandbox" then
+      no_sandbox = true
+    else
+      table.insert(filtered_args, a)
     end
   end
 
-  if not repo then
-    usage()
-    return 1
+  -- Start sandbox unless disabled
+  if not no_sandbox then
+    local ctx, err = start_sandbox()
+    if not ctx then
+      io.stderr:write("warning: sandbox failed to start: " .. (err or "unknown") .. "\n")
+      io.stderr:write("continuing without sandbox\n")
+    else
+      sandbox_ctx = ctx
+      io.stderr:write("[sandbox] proxy started on " .. ctx.socket_path .. "\n")
+    end
   end
 
-  -- Phase 1: Plan
-  io.stderr:write("==> plan\n")
-  local issue_num: integer = nil
-  if issue_number then
-    issue_num = tonumber(issue_number) as integer
-  end
-  local rc: integer
-  local issue: Issue
-  rc, issue = phase_plan(repo, issue_num)
-  if rc ~= 0 then return rc end
+  -- Wrap execution to ensure sandbox cleanup
+  local function run_main(): integer
+    local subcmd = filtered_args[1]
 
-  if not issue then
-    io.stderr:write("no issues to work on\n")
+    if subcmd == "plan" then
+      return cmd_plan(slice(filtered_args, 2))
+    elseif subcmd == "do" then
+      return cmd_do(slice(filtered_args, 2))
+    elseif subcmd == "check" then
+      return phase_check()
+    elseif subcmd == "act" then
+      return cmd_act(slice(filtered_args, 2))
+    elseif subcmd == "push" then
+      return phase_push()
+    end
+
+    -- Unified mode: parse options, run all phases
+    local repo: string
+    local issue_number: string
+
+    local longopts = {
+      {name = "help", has_arg = "none", short = "h"},
+      {name = "repo", has_arg = "required", short = "r"},
+      {name = "issue", has_arg = "required", short = "i"},
+    }
+
+    local parser = getopt.new(filtered_args, "hr:i:", longopts)
+
+    while true do
+      local opt, optarg = parser:next()
+      if not opt then break end
+      if opt == "h" or opt == "help" then
+        usage()
+        return 0
+      elseif opt == "r" or opt == "repo" then
+        repo = optarg
+      elseif opt == "i" or opt == "issue" then
+        issue_number = optarg
+      elseif opt == "?" then
+        usage()
+        return 1
+      end
+    end
+
+    if not repo then
+      usage()
+      return 1
+    end
+
+    -- Phase 1: Plan
+    io.stderr:write("==> plan\n")
+    local issue_num: integer = nil
+    if issue_number then
+      issue_num = tonumber(issue_number) as integer
+    end
+    local rc: integer
+    local issue: Issue
+    rc, issue = phase_plan(repo, issue_num)
+    if rc ~= 0 then return rc end
+
+    if not issue then
+      io.stderr:write("no issues to work on\n")
+      return 0
+    end
+
+    -- Phase 2: Do
+    io.stderr:write("==> do\n")
+    rc = phase_do(issue.title, tostring(issue.number))
+    if rc ~= 0 then return rc end
+
+    -- Phase 3: Push
+    io.stderr:write("==> push\n")
+    rc = phase_push()
+    if rc ~= 0 then return rc end
+
+    -- Phase 4: Check
+    io.stderr:write("==> check\n")
+    rc = phase_check()
+    if rc ~= 0 then return rc end
+
+    -- Phase 5: Act
+    io.stderr:write("==> act\n")
+    rc = phase_act(issue.url)
+    if rc ~= 0 then return rc end
+
     return 0
   end
 
-  -- Phase 2: Do
-  io.stderr:write("==> do\n")
-  rc = phase_do(issue.title, tostring(issue.number))
-  if rc ~= 0 then return rc end
+  local ok, result = pcall(run_main)
 
-  -- Phase 3: Push
-  io.stderr:write("==> push\n")
-  rc = phase_push()
-  if rc ~= 0 then return rc end
+  -- Always clean up sandbox
+  if sandbox_ctx then
+    io.stderr:write("[sandbox] stopping proxy\n")
+    stop_sandbox(sandbox_ctx)
+    sandbox_ctx = nil
+  end
 
-  -- Phase 4: Check
-  io.stderr:write("==> check\n")
-  rc = phase_check()
-  if rc ~= 0 then return rc end
-
-  -- Phase 5: Act
-  io.stderr:write("==> act\n")
-  rc = phase_act(issue.url)
-  if rc ~= 0 then return rc end
-
-  return 0
+  if not ok then
+    error(result)
+  end
+  return result as integer
 end
 
 return {


### PR DESCRIPTION
## Summary

Adds sandbox mode for `ah work` commands to restrict network access.

### Components

1. **ah sandbox init** (`lib/ah/init.tl`)
   - When `AH_SANDBOX=1`, applies unveil + pledge
   - Drops `inet`, keeps `unix` for proxy socket

2. **ah proxy subcommand** (`lib/ah/proxy.tl`)
   - HTTP CONNECT proxy with allowlist
   - Only allows `api.anthropic.com:443`

3. **work.tl integration**
   - Sandbox enabled by default for `ah work` 
   - `--no-sandbox` flag to disable
   - Fork+exec `ah proxy` before phases
   - Uses mkdtemp for unique socket path

### Flow

```
ah work plan
  │
  ├── fork+exec "ah proxy /tmp/ah-sandbox-xxx/proxy.sock"
  │
  ├── wait for socket
  │
  ├── set http_proxy=unix://..., AH_SANDBOX=1
  │
  └── run phase (ah applies pledge, routes through proxy)
```

### Status

**WIP**: Type errors in proxy.tl need fixing.

- [x] ah sandbox init (pledge/unveil)  
- [x] ah proxy subcommand
- [x] work.tl fork+exec integration
- [ ] Fix type errors
- [ ] Test end-to-end
- [ ] Depends on cosmopolitan PR #89 for unix:// proxy scheme