### PR TITLE
fix: use POSIX mode in top-level arg parser to forward subcommand flags

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -679,6 +679,72 @@ local function make_cli_handler(): events.EventCallback
   end
 end
 
+local record ParsedArgs
+  model: string
+  db_path: string
+  output_path: string
+  new_session: boolean
+  session_prefix: string
+  steer_msg: string
+  followup_msg: string
+  max_tokens: integer
+  remaining: {string}
+end
+
+local function parse_args(args: {string}): ParsedArgs, string
+  local result: ParsedArgs = {
+    new_session = false,
+    remaining = {},
+  }
+
+  local longopts = {
+    {name = "help", has_arg = "none", short = "h"},
+    {name = "new", has_arg = "none", short = "n"},
+    {name = "session", has_arg = "required", short = "S"},
+    {name = "db", has_arg = "required"},
+    {name = "model", has_arg = "required", short = "m"},
+    {name = "output", has_arg = "required", short = "o"},
+    {name = "steer", has_arg = "required"},
+    {name = "followup", has_arg = "required"},
+    {name = "max-tokens", has_arg = "required"},
+  }
+
+  -- Use + prefix for POSIX mode: stop parsing options at first non-option arg.
+  -- This allows subcommands like "work" to have their own flags (--repo, --issue,
+  -- --prompt) without the top-level parser rejecting them as unknown options.
+  local parser = getopt.new(args, "+hnS:m:o:", longopts)
+
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
+
+    if opt == "h" or opt == "help" then
+      return nil, "help"
+    elseif opt == "n" or opt == "new" then
+      result.new_session = true
+    elseif opt == "S" or opt == "session" then
+      result.session_prefix = optarg
+    elseif opt == "db" then
+      result.db_path = optarg
+    elseif opt == "m" or opt == "model" then
+      result.model = optarg
+    elseif opt == "o" or opt == "output" then
+      result.output_path = optarg
+    elseif opt == "steer" then
+      result.steer_msg = optarg
+    elseif opt == "followup" then
+      result.followup_msg = optarg
+    elseif opt == "max-tokens" then
+      result.max_tokens = tonumber(optarg) as integer
+    elseif opt == "?" then
+      return nil, "unknown"
+    end
+  end
+
+  result.remaining = parser:remaining() or {}
+  return result
+end
+
 local function main(args: {string}): integer, string
   -- Enable core dumps for crash debugging
   -- RLIMIT_CORE = 4 on Linux, RLIM_INFINITY = -1
@@ -713,60 +779,26 @@ local function main(args: {string}): integer, string
     sandbox.pledge(promises, promises, PLEDGE_PENALTY_RETURN_EPERM)
   end
 
-  local model: string = nil
-  local db_path: string = nil
-  local output_path: string = nil
-  local new_session: boolean = false
-  local session_prefix: string = nil
-  local steer_msg: string = nil
-  local followup_msg: string = nil
-  local max_tokens: integer = nil
   local cwd = fs.getcwd()
 
-  local longopts = {
-    {name = "help", has_arg = "none", short = "h"},
-    {name = "new", has_arg = "none", short = "n"},
-    {name = "session", has_arg = "required", short = "S"},
-    {name = "db", has_arg = "required"},
-    {name = "model", has_arg = "required", short = "m"},
-    {name = "output", has_arg = "required", short = "o"},
-    {name = "steer", has_arg = "required"},
-    {name = "followup", has_arg = "required"},
-    {name = "max-tokens", has_arg = "required"},
-  }
-
-  local parser = getopt.new(args, "hnS:m:o:", longopts)
-
-  while true do
-    local opt, optarg = parser:next()
-    if not opt then break end
-
-    if opt == "h" or opt == "help" then
-      usage()
+  local parsed, err = parse_args(args)
+  if not parsed then
+    usage()
+    if err == "help" then
       return 0
-    elseif opt == "n" or opt == "new" then
-      new_session = true
-    elseif opt == "S" or opt == "session" then
-      session_prefix = optarg
-    elseif opt == "db" then
-      db_path = optarg
-    elseif opt == "m" or opt == "model" then
-      model = optarg
-    elseif opt == "o" or opt == "output" then
-      output_path = optarg
-    elseif opt == "steer" then
-      steer_msg = optarg
-    elseif opt == "followup" then
-      followup_msg = optarg
-    elseif opt == "max-tokens" then
-      max_tokens = tonumber(optarg) as integer
-    elseif opt == "?" then
-      usage()
-      return 1
     end
+    return 1
   end
 
-  local remaining = parser:remaining() or {}
+  local model = parsed.model
+  local db_path = parsed.db_path
+  local output_path = parsed.output_path
+  local new_session = parsed.new_session
+  local session_prefix = parsed.session_prefix
+  local steer_msg = parsed.steer_msg
+  local followup_msg = parsed.followup_msg
+  local max_tokens = parsed.max_tokens
+  local remaining = parsed.remaining
 
   -- Handle commands that don't need db
   local cmd = remaining[1]
@@ -1202,6 +1234,7 @@ end
 
 return {
   main = main,
+  parse_args = parse_args,
   load_system_prompt = load_system_prompt,
   load_claude_md = load_claude_md,
   list_sessions = list_sessions,

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -162,4 +162,73 @@ local function test_resolve_session_not_found()
 end
 test_resolve_session_not_found()
 
+-- Arg parsing tests
+
+local function test_parse_args_help()
+  local parsed, err = init.parse_args({"-h"})
+  assert(not parsed, "help should return nil")
+  assert(err == "help", "err should be 'help', got: " .. tostring(err))
+end
+test_parse_args_help()
+
+local function test_parse_args_long_help()
+  local parsed, err = init.parse_args({"--help"})
+  assert(not parsed, "--help should return nil")
+  assert(err == "help", "err should be 'help', got: " .. tostring(err))
+end
+test_parse_args_long_help()
+
+local function test_parse_args_model()
+  local parsed = init.parse_args({"-m", "opus"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.model == "opus", "model should be opus, got: " .. tostring(parsed.model))
+end
+test_parse_args_model()
+
+local function test_parse_args_unknown_option()
+  local parsed, err = init.parse_args({"--bogus"})
+  assert(not parsed, "unknown option should return nil")
+  assert(err == "unknown", "err should be 'unknown', got: " .. tostring(err))
+end
+test_parse_args_unknown_option()
+
+local function test_parse_args_work_subcommand_flags()
+  -- This is the failing case from the workflow:
+  -- ah work --repo owner/repo --prompt update-docs
+  -- The top-level parser must NOT reject --repo and --prompt as unknown options.
+  -- Instead, it should stop at "work" and pass everything after to the subcommand.
+  local parsed, err = init.parse_args({"work", "--repo", "owner/repo", "--prompt", "update-docs"})
+  assert(parsed, "work subcommand args should not be rejected, got err: " .. tostring(err))
+  assert(parsed.remaining[1] == "work", "first remaining should be 'work', got: " .. tostring(parsed.remaining[1]))
+  assert(parsed.remaining[2] == "--repo", "second remaining should be '--repo', got: " .. tostring(parsed.remaining[2]))
+  assert(parsed.remaining[3] == "owner/repo", "third remaining should be 'owner/repo', got: " .. tostring(parsed.remaining[3]))
+  assert(parsed.remaining[4] == "--prompt", "fourth remaining should be '--prompt', got: " .. tostring(parsed.remaining[4]))
+  assert(parsed.remaining[5] == "update-docs", "fifth remaining should be 'update-docs', got: " .. tostring(parsed.remaining[5]))
+end
+test_parse_args_work_subcommand_flags()
+
+local function test_parse_args_top_level_opts_before_work()
+  -- ah -m opus work --repo owner/repo
+  -- Top-level -m should be parsed, work and its args should be in remaining.
+  local parsed, err = init.parse_args({"-m", "opus", "work", "--repo", "owner/repo"})
+  assert(parsed, "should parse successfully, got err: " .. tostring(err))
+  assert(parsed.model == "opus", "model should be opus, got: " .. tostring(parsed.model))
+  assert(parsed.remaining[1] == "work", "first remaining should be 'work', got: " .. tostring(parsed.remaining[1]))
+  assert(parsed.remaining[2] == "--repo", "second remaining should be '--repo', got: " .. tostring(parsed.remaining[2]))
+  assert(parsed.remaining[3] == "owner/repo", "third remaining should be 'owner/repo', got: " .. tostring(parsed.remaining[3]))
+end
+test_parse_args_top_level_opts_before_work()
+
+local function test_parse_args_work_with_issue()
+  -- ah work --repo owner/repo --issue 42
+  local parsed, err = init.parse_args({"work", "--repo", "owner/repo", "--issue", "42"})
+  assert(parsed, "should parse successfully, got err: " .. tostring(err))
+  assert(parsed.remaining[1] == "work", "first remaining should be 'work'")
+  assert(parsed.remaining[2] == "--repo", "--repo should be in remaining")
+  assert(parsed.remaining[3] == "owner/repo", "repo value should be in remaining")
+  assert(parsed.remaining[4] == "--issue", "--issue should be in remaining")
+  assert(parsed.remaining[5] == "42", "issue number should be in remaining")
+end
+test_parse_args_work_with_issue()
+
 print("all init tests passed")


### PR DESCRIPTION
The work workflow was failing because the top-level getopt parser in
init.tl treated work subcommand flags (--repo, --issue, --prompt) as
unknown options and rejected them before they could reach work.main().

Fix by adding the + prefix to the getopt optstring, which enables POSIX
mode where parsing stops at the first non-option argument. This lets
subcommands like "work" receive their own flags intact.

Also factor out parse_args into a standalone testable function and add
tests covering the workflow invocation pattern.

https://claude.ai/code/session_01KJHwFKH61zsanQXJwHqZfc