### PR TITLE
fix: remove unsupported --json flag from gh issue create

### DIFF
--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -260,14 +260,13 @@ local function create_issue_from_prompt(repo: string, prompt_name: string): inte
     "--title", "work: " .. prompt_name,
     "--body", body,
     "--label", "todo",
-    "--json", "number",
   })
   if not ok then return nil, "gh issue create failed" end
-  local success, data = pcall(json.decode, stdout)
-  if not success or type(data) ~= "table" then
-    return nil, "failed to parse issue JSON"
+  local number = tonumber(stdout:match("/issues/(%d+)"))
+  if not number then
+    return nil, "failed to parse issue number from: " .. stdout
   end
-  return (data as {string:any}).number as integer
+  return number as integer
 end
 
 local function transition_to_doing(issue_url: string)


### PR DESCRIPTION
gh issue create does not support the --json flag (it's only available
on list/view commands). Parse the issue number from the URL that gh
outputs to stdout instead.

https://claude.ai/code/session_01S61b8eXR2HkHFAj6nzWR7y