### PR TITLE
fix: ensure required labels exist before using them

### DIFF
--- a/lib/ah/test_work_labels.tl
+++ b/lib/ah/test_work_labels.tl
@@ -1,0 +1,37 @@
+#!/usr/bin/env cosmic
+-- test_work_labels.tl: tests for work label management
+
+local record Work
+  required_labels: {string}
+  ensure_labels: function(string): boolean, string
+end
+
+local work = require("ah.work") as Work
+
+-- Test that required_labels exists and contains expected labels
+local function test_required_labels()
+  assert(work.required_labels ~= nil, "required_labels should be exported")
+  local expected = {"todo", "doing", "done", "failed"}
+  local found: {string:boolean} = {}
+  for _, label in ipairs(work.required_labels) do
+    found[label] = true
+  end
+
+  for _, label in ipairs(expected) do
+    assert(found[label], "required_labels should contain '" .. label .. "'")
+  end
+
+  assert(#work.required_labels == #expected,
+    "required_labels should have exactly " .. #expected .. " labels, got " .. #work.required_labels)
+  print("✓ required_labels contains all expected labels")
+end
+test_required_labels()
+
+-- Test that ensure_labels is exported as a function
+local function test_ensure_labels_exported()
+  assert(type(work.ensure_labels) == "function", "ensure_labels should be exported as a function")
+  print("✓ ensure_labels is exported")
+end
+test_ensure_labels_exported()
+
+print("\nAll work-labels tests passed!")

--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -244,6 +244,16 @@ local function slice(t: {string}, from: integer): {string}
   return result
 end
 
+-- Labels used throughout the PDCA workflow
+local required_labels: {string} = {"todo", "doing", "done", "failed"}
+
+local function ensure_labels(repo: string): boolean, string
+  for _, label in ipairs(required_labels) do
+    run({"gh", "label", "create", label, "--repo", repo, "--force"})
+  end
+  return true
+end
+
 -- Issue selection
 
 local function get_priority(labels: {Label}): integer
@@ -803,6 +813,9 @@ local function main(args: {string}): integer
     return 1
   end
 
+  -- Ensure required labels exist in the repository
+  ensure_labels(repo)
+
   -- Create issue from prompt template if specified
   if prompt_name then
     if issue_number then
@@ -868,4 +881,6 @@ return {
   validate_branch = validate_branch,
   execute_action = execute_action,
   slice = slice,
+  required_labels = required_labels,
+  ensure_labels = ensure_labels,
 }


### PR DESCRIPTION
gh issue create --label todo fails when the label doesn't exist in the
repo. Add ensure_labels() that runs gh label create --force for each
required label (todo, doing, done, failed) before the PDCA workflow
starts. Includes test for the exported labels list and function.

https://claude.ai/code/session_01Kb9vgeSVTSUWyijy1exJtz