### PR TITLE
debug: fix plan generation and add diagnostic logging

### DIFF
--- a/lib/ah/test_work_plan.tl
+++ b/lib/ah/test_work_plan.tl
@@ -1,0 +1,121 @@
+#!/usr/bin/env cosmic
+-- test_work_plan.tl: tests for plan phase prompt interpolation and diagnostics
+
+local record Work
+  interpolate_prompt: function(string, {string:string}): string
+  plan_diagnostic: function(string): string
+end
+
+local work = require("ah.work") as Work
+
+-- Test basic interpolation
+local function test_interpolate_basic()
+  local template = "Plan for {title}\n\n{body}\n\nBranch: work/{issue_number}"
+  local result = work.interpolate_prompt(template, {
+    title = "fix bug",
+    body = "the bug is bad",
+    issue_number = "42",
+  })
+  assert(result == "Plan for fix bug\n\nthe bug is bad\n\nBranch: work/42",
+    "basic interpolation failed, got: " .. result)
+  print("✓ interpolate_prompt handles basic substitution")
+end
+test_interpolate_basic()
+
+-- Test interpolation with % in values (this is the gsub bug)
+local function test_interpolate_percent()
+  local template = "Title: {title}\nBody: {body}"
+  local result = work.interpolate_prompt(template, {
+    title = "fix 100% of bugs",
+    body = "increase coverage from %50 to %100",
+  })
+  assert(result == "Title: fix 100% of bugs\nBody: increase coverage from %50 to %100",
+    "percent interpolation failed, got: " .. result)
+  print("✓ interpolate_prompt handles % in values")
+end
+test_interpolate_percent()
+
+-- Test interpolation with %1 capture reference in values (would crash old gsub)
+local function test_interpolate_percent_digit()
+  local template = "{title}: {body}"
+  local result = work.interpolate_prompt(template, {
+    title = "test %1 %2 refs",
+    body = "body with %0 and %9",
+  })
+  assert(result == "test %1 %2 refs: body with %0 and %9",
+    "percent-digit interpolation failed, got: " .. result)
+  print("✓ interpolate_prompt handles %N capture references in values")
+end
+test_interpolate_percent_digit()
+
+-- Test interpolation with missing placeholder (no change)
+local function test_interpolate_missing_key()
+  local template = "{title} and {missing}"
+  local result = work.interpolate_prompt(template, {
+    title = "hello",
+  })
+  assert(result == "hello and {missing}",
+    "missing key should leave placeholder, got: " .. result)
+  print("✓ interpolate_prompt leaves unknown placeholders unchanged")
+end
+test_interpolate_missing_key()
+
+-- Test interpolation with empty value
+local function test_interpolate_empty_value()
+  local template = "Title: {title}\nBody: {body}"
+  local result = work.interpolate_prompt(template, {
+    title = "something",
+    body = "",
+  })
+  assert(result == "Title: something\nBody: ",
+    "empty value interpolation failed, got: " .. result)
+  print("✓ interpolate_prompt handles empty values")
+end
+test_interpolate_empty_value()
+
+-- Test interpolation with value containing braces
+local function test_interpolate_braces_in_value()
+  local template = "{title}: {body}"
+  local result = work.interpolate_prompt(template, {
+    title = "fix {thing}",
+    body = "body text",
+  })
+  assert(result == "fix {thing}: body text",
+    "braces in value failed, got: " .. result)
+  print("✓ interpolate_prompt handles braces in values")
+end
+test_interpolate_braces_in_value()
+
+-- Test plan_diagnostic when no files exist
+local function test_diagnostic_no_files()
+  local msg = work.plan_diagnostic("/nonexistent/path/that/does/not/exist")
+  assert(msg:find("plan.md not found") or msg:find("not found"),
+    "diagnostic should mention plan.md not found, got: " .. msg)
+  print("✓ plan_diagnostic reports when no files found")
+end
+test_diagnostic_no_files()
+
+-- Test plan_diagnostic with update.md (bail condition)
+local function test_diagnostic_with_update()
+  local tmpdir = os.getenv("TEST_TMPDIR")
+  if not tmpdir then
+    print("✓ plan_diagnostic bail test skipped (no TEST_TMPDIR)")
+    return
+  end
+
+  local plan_dir = tmpdir .. "/plan"
+  os.execute("mkdir -p " .. plan_dir)
+
+  -- Write update.md (bail condition)
+  local f = io.open(plan_dir .. "/update.md", "w")
+  f:write("Could not identify entry point for this issue.\n")
+  f:close()
+
+  local msg = work.plan_diagnostic(plan_dir)
+  assert(msg:find("update.md"), "diagnostic should mention update.md, got: " .. msg)
+  assert(msg:find("Could not identify"), "diagnostic should include update.md content, got: " .. msg)
+  print("✓ plan_diagnostic reports bail condition from update.md")
+end
+test_diagnostic_with_update()
+
+print("\nAll work-plan tests passed!")

--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -75,6 +75,43 @@ local function read_prompt_template(name: string): string
       or cio.slurp("sys/work/prompts/" .. name .. ".md")
 end
 
+-- Interpolate template variables safely.
+-- Uses function replacement to avoid gsub interpreting % in values as capture references.
+local function interpolate_prompt(template: string, vars: {string:string}): string
+  for key, value in pairs(vars) do
+    template = template:gsub("{" .. key .. "}", function(): string return value end)
+  end
+  return template
+end
+
+-- Diagnostic: inspect plan directory and report what was (or wasn't) created.
+-- Returns a human-readable message explaining why plan.md may be missing.
+local function plan_diagnostic(plan_dir: string): string
+  local parts: {string} = {}
+
+  local plan = read_file(plan_dir .. "/plan.md")
+  if plan then
+    table.insert(parts, "plan.md found (" .. #plan .. " bytes)")
+    return table.concat(parts, "; ")
+  end
+
+  table.insert(parts, "plan.md not found")
+
+  local update = read_file(plan_dir .. "/update.md")
+  if update then
+    table.insert(parts, "update.md found (bail condition): " .. update:sub(1, 200))
+  end
+
+  local issue = read_file(plan_dir .. "/issue.json")
+  if issue then
+    table.insert(parts, "issue.json present")
+  else
+    table.insert(parts, "issue.json missing")
+  end
+
+  return table.concat(parts, "; ")
+end
+
 local function ah_exe(): string
   return arg and arg[-1] or "ah"
 end
@@ -205,6 +242,7 @@ local function sandboxed_agent(no_sandbox: boolean, prompt: string, db: string):
     run_env.AH_SANDBOX = "1"
   end
 
+  log("spawning agent: db=" .. db .. " prompt_len=" .. #prompt)
   local handle, spawn_err = spawn.spawn(
     {ah_exe(), "-n", "--db", db, prompt},
     {env = run_env as {string}}
@@ -216,12 +254,29 @@ local function sandboxed_agent(no_sandbox: boolean, prompt: string, db: string):
     end
     return false, spawn_err as string, -1
   end
+  local stderr_out = handle.stderr:read()
   local ok, stdout, exit_str = handle:read()
   local exit_code = (tonumber(exit_str) or 0) as integer
 
   if ctx then
     io.stderr:write("[sandbox] stopping proxy\n")
     stop_sandbox(ctx)
+  end
+
+  -- Log agent subprocess results for debugging
+  log("agent exited: ok=" .. tostring(ok) .. " exit_code=" .. tostring(exit_code))
+  if stderr_out and stderr_out ~= "" then
+    -- Log last 2000 chars of stderr to avoid flooding
+    local stderr_tail = stderr_out
+    if #stderr_tail > 2000 then
+      stderr_tail = "...(" .. #stderr_out .. " bytes total)\n" .. stderr_out:sub(-2000)
+    end
+    log("agent stderr:\n" .. stderr_tail)
+  end
+  if stdout and stdout ~= "" then
+    local stdout_preview = stdout:sub(1, 500)
+    if #stdout > 500 then stdout_preview = stdout_preview .. "..." end
+    log("agent stdout: " .. stdout_preview)
   end
 
   return ok and exit_code == 0, stdout, exit_code
@@ -463,19 +518,27 @@ local function phase_plan(no_sandbox: boolean, repo: string, issue_number: integ
     return 1
   end
 
-  prompt = prompt:gsub("{title}", issue.title)
-  prompt = prompt:gsub("{body}", issue.body or "")
-  prompt = prompt:gsub("{issue_number}", tostring(issue.number))
+  prompt = interpolate_prompt(prompt, {
+    title = issue.title,
+    body = issue.body or "",
+    issue_number = tostring(issue.number),
+  })
+
+  log("plan prompt interpolated (" .. #prompt .. " bytes) for issue #" .. tostring(issue.number))
 
   local ok = sandboxed_agent(no_sandbox, prompt, "o/work/plan/session.db")
 
   if not ok then
     io.stderr:write("error: plan agent failed\n")
+    local diag = plan_diagnostic("o/work/plan")
+    log("plan diagnostic: " .. diag)
     return 1
   end
 
   if not read_file("o/work/plan/plan.md") then
+    local diag = plan_diagnostic("o/work/plan")
     io.stderr:write("error: plan.md not created\n")
+    log("plan diagnostic: " .. diag)
     return 1
   end
 
@@ -883,4 +946,6 @@ return {
   slice = slice,
   required_labels = required_labels,
   ensure_labels = ensure_labels,
+  interpolate_prompt = interpolate_prompt,
+  plan_diagnostic = plan_diagnostic,
 }


### PR DESCRIPTION
Three changes to improve plan phase reliability and debuggability:

1. Fix prompt interpolation: replace raw gsub with interpolate_prompt()
   that uses function replacement, preventing crashes when issue
   title/body contains % characters (gsub interprets %N as capture refs)

2. Add stderr capture to sandboxed_agent: the agent subprocess stderr
   was silently discarded, making it impossible to diagnose API errors,
   credential failures, or other agent issues from CI logs

3. Add plan_diagnostic(): when plan.md is not created, log what IS
   present in the plan directory (update.md bail condition, issue.json)
   so we can distinguish "agent bailed" from "agent failed silently"

Tests: test_work_plan.tl covers interpolation edge cases (%N refs,
empty values, missing keys) and diagnostic output for bail conditions.

https://claude.ai/code/session_01Q3C3jZLvASyKusW8PaTqBY