### PR TITLE
fix: sanitize auth tokens to prevent invalid HTTP header encoding

### DIFF
--- a/lib/ah/auth.tl
+++ b/lib/ah/auth.tl
@@ -24,22 +24,33 @@ local function parse_env_file(path: string): {string:string}
   return env
 end
 
+-- Strip leading/trailing whitespace and control characters from a token.
+-- Tokens from environment variables or .env files may contain trailing
+-- newlines or carriage returns that are invalid in HTTP header values.
+local function sanitize_token(token: string): string
+  if not token then return nil end
+  return (token:match("^%s*(.-)%s*$"))
+end
+
 local function load_credentials(): Credentials, string
   -- Priority: CLAUDE_CODE_OAUTH_TOKEN (OAuth tokens for Claude Max)
-  local oauth_token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  if oauth_token then
+  local oauth_token = sanitize_token(os.getenv("CLAUDE_CODE_OAUTH_TOKEN"))
+  if oauth_token and oauth_token ~= "" then
     return {access_token = oauth_token, is_oauth = true}
   end
 
   -- Fall back to ANTHROPIC_API_KEY (regular API key)
-  local api_key = os.getenv("ANTHROPIC_API_KEY")
-  if api_key then
+  local api_key = sanitize_token(os.getenv("ANTHROPIC_API_KEY"))
+  if api_key and api_key ~= "" then
     return {access_token = api_key, is_oauth = false}
   end
 
   local env = parse_env_file(".env")
   if env and env.ANTHROPIC_API_KEY then
-    return {access_token = env.ANTHROPIC_API_KEY, is_oauth = false}
+    local key = sanitize_token(env.ANTHROPIC_API_KEY)
+    if key and key ~= "" then
+      return {access_token = key, is_oauth = false}
+    end
   end
 
   return nil, "no credentials found (set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN)"

--- a/lib/ah/test_auth.tl
+++ b/lib/ah/test_auth.tl
@@ -96,4 +96,96 @@ local function test_oauth_headers()
 end
 test_oauth_headers()
 
+-- Token sanitization: tokens from env vars may contain trailing
+-- whitespace or control characters that are invalid in HTTP headers.
+-- cosmic.fetch rejects header values containing bytes in 0x00-0x08,
+-- 0x0A-0x1F, 0x7F, or 0x80-0x9F (Latin-1 C1 controls).
+
+local function test_oauth_token_trailing_newline()
+  local orig_key = os.getenv("ANTHROPIC_API_KEY")
+  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
+
+  if orig_key then unix.unsetenv("ANTHROPIC_API_KEY") end
+  -- Token with trailing newline (common copy/paste artifact)
+  unix.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-test-token\n")
+
+  local creds = auth.load_credentials()
+  assert(creds, "should load credentials")
+  assert(creds.access_token == "sk-ant-oat-test-token",
+    "should trim trailing newline, got: [" .. creds.access_token .. "]")
+
+  if orig_key then unix.setenv("ANTHROPIC_API_KEY", orig_key) end
+  if orig_oauth then unix.setenv("CLAUDE_CODE_OAUTH_TOKEN", orig_oauth)
+  else unix.unsetenv("CLAUDE_CODE_OAUTH_TOKEN") end
+end
+test_oauth_token_trailing_newline()
+
+local function test_api_key_trailing_whitespace()
+  local orig_key = os.getenv("ANTHROPIC_API_KEY")
+  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
+
+  if orig_oauth then unix.unsetenv("CLAUDE_CODE_OAUTH_TOKEN") end
+  -- Token with trailing spaces and newline
+  unix.setenv("ANTHROPIC_API_KEY", "  sk-test-key-456  \n")
+
+  local creds = auth.load_credentials()
+  assert(creds, "should load credentials")
+  assert(creds.access_token == "sk-test-key-456",
+    "should trim whitespace, got: [" .. creds.access_token .. "]")
+
+  if orig_key then unix.setenv("ANTHROPIC_API_KEY", orig_key)
+  else unix.unsetenv("ANTHROPIC_API_KEY") end
+  if orig_oauth then unix.setenv("CLAUDE_CODE_OAUTH_TOKEN", orig_oauth) end
+end
+test_api_key_trailing_whitespace()
+
+local function test_oauth_token_crlf()
+  local orig_key = os.getenv("ANTHROPIC_API_KEY")
+  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
+
+  if orig_key then unix.unsetenv("ANTHROPIC_API_KEY") end
+  unix.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-test\r\n")
+
+  local creds = auth.load_credentials()
+  assert(creds, "should load credentials")
+  assert(creds.access_token == "sk-ant-oat-test",
+    "should trim CRLF, got: [" .. creds.access_token .. "]")
+
+  if orig_key then unix.setenv("ANTHROPIC_API_KEY", orig_key) end
+  if orig_oauth then unix.setenv("CLAUDE_CODE_OAUTH_TOKEN", orig_oauth)
+  else unix.unsetenv("CLAUDE_CODE_OAUTH_TOKEN") end
+end
+test_oauth_token_crlf()
+
+local function test_whitespace_only_token_rejected()
+  local orig_key = os.getenv("ANTHROPIC_API_KEY")
+  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
+
+  if orig_key then unix.unsetenv("ANTHROPIC_API_KEY") end
+  unix.setenv("CLAUDE_CODE_OAUTH_TOKEN", "  \n\r  ")
+
+  local creds, err = auth.load_credentials()
+  assert(creds == nil, "whitespace-only token should be rejected")
+  assert(err, "should return error message")
+
+  if orig_key then unix.setenv("ANTHROPIC_API_KEY", orig_key) end
+  if orig_oauth then unix.setenv("CLAUDE_CODE_OAUTH_TOKEN", orig_oauth)
+  else unix.unsetenv("CLAUDE_CODE_OAUTH_TOKEN") end
+end
+test_whitespace_only_token_rejected()
+
+local function test_oauth_header_value_no_control_chars()
+  -- Ensure the authorization header value contains no control characters
+  local creds: auth.Credentials = {access_token = "sk-ant-oat-test", is_oauth = true}
+  local headers = auth.get_auth_headers(creds)
+  local auth_val = headers["authorization"]
+  for i = 1, #auth_val do
+    local b = auth_val:byte(i)
+    -- Valid: TAB(0x09), SP-TILDE(0x20-0x7E), obs-text(0xA0-0xFF)
+    local valid = b == 0x09 or (b >= 0x20 and b <= 0x7E) or (b >= 0xA0)
+    assert(valid, string.format("auth header contains invalid byte 0x%02X at position %d", b, i))
+  end
+end
+test_oauth_header_value_no_control_chars()
+
 print("all auth tests passed")


### PR DESCRIPTION
cosmic.fetch validates header values as Latin-1 and rejects control
characters (0x00-0x08, 0x0A-0x1F, 0x7F, 0x80-0x9F). Tokens from
environment variables or .env files may contain trailing newlines or
whitespace (common copy/paste artifact in CI secrets), causing
"invalid header authorization value encoding" errors.

Strip leading/trailing whitespace from tokens at load time and reject
whitespace-only tokens as empty credentials.

https://claude.ai/code/session_01Bs1BHUdroRFvfd1Qxrmmzx