### PR TITLE
Fix git identity configuration and bash command execution

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -681,6 +681,29 @@ local function test_unknown_tool_no_details()
 end
 test_unknown_tool_no_details()
 
+-- Test that bash tool preserves literal newlines in command strings.
+-- Regression: old code used sh -c %q double-wrapping which turned
+-- newlines into line-continuations, mangling multi-line commands
+-- (e.g. git commit messages with heredocs).
+local function test_bash_newline_in_command()
+  local cmd = "echo first\necho second"
+  local result, is_error = tools.execute_tool("bash", {command = cmd})
+  assert(not is_error, "multiline command should succeed: " .. result)
+  assert(result:match("first\nsecond"), "should run both echo commands: " .. result)
+  print("✓ bash tool preserves literal newlines in commands")
+end
+test_bash_newline_in_command()
+
+-- Test that bash tool supports bash-specific syntax (brace expansion).
+-- Regression: old code used sh which lacks brace expansion.
+local function test_bash_brace_expansion()
+  local result, is_error = tools.execute_tool("bash", {command = "echo {a,b,c}"})
+  assert(not is_error, "bash should succeed")
+  assert(result:match("a b c"), "brace expansion should work (bash feature): " .. result)
+  print("✓ bash tool supports bash features (brace expansion)")
+end
+test_bash_brace_expansion()
+
 -- Test abort_running_tools with no running processes (should be a no-op)
 local function test_abort_no_processes()
   -- Should not error when nothing is running

--- a/lib/ah/test_work.tl
+++ b/lib/ah/test_work.tl
@@ -4,6 +4,7 @@
 local record Work
   main: function({string}): integer
   slice: function({string}, integer): {string}
+  setup_git_env: function({string:string})
 end
 
 local work = require("ah.work") as Work
@@ -100,5 +101,44 @@ local function test_act_no_args()
   print("✓ act without --issue-url returns 1")
 end
 test_act_no_args()
+
+-- Test setup_git_env sets defaults when no GITHUB_ACTOR
+local function test_setup_git_env_defaults()
+  local e: {string:string} = {}
+  work.setup_git_env(e)
+  assert(e.GIT_AUTHOR_NAME == "ah-agent", "should default author name, got: " .. tostring(e.GIT_AUTHOR_NAME))
+  assert(e.GIT_AUTHOR_EMAIL == "ah-agent@localhost", "should default author email, got: " .. tostring(e.GIT_AUTHOR_EMAIL))
+  assert(e.GIT_COMMITTER_NAME == "ah-agent", "should default committer name, got: " .. tostring(e.GIT_COMMITTER_NAME))
+  assert(e.GIT_COMMITTER_EMAIL == "ah-agent@localhost", "should default committer email, got: " .. tostring(e.GIT_COMMITTER_EMAIL))
+  print("✓ setup_git_env sets defaults")
+end
+test_setup_git_env_defaults()
+
+-- Test setup_git_env uses GITHUB_ACTOR when available
+local function test_setup_git_env_github_actor()
+  local e: {string:string} = {GITHUB_ACTOR = "octocat"}
+  work.setup_git_env(e)
+  assert(e.GIT_AUTHOR_NAME == "octocat", "should use GITHUB_ACTOR for name, got: " .. tostring(e.GIT_AUTHOR_NAME))
+  assert(e.GIT_AUTHOR_EMAIL == "octocat@users.noreply.github.com", "should derive email, got: " .. tostring(e.GIT_AUTHOR_EMAIL))
+  assert(e.GIT_COMMITTER_NAME == "octocat", "should use GITHUB_ACTOR for committer, got: " .. tostring(e.GIT_COMMITTER_NAME))
+  assert(e.GIT_COMMITTER_EMAIL == "octocat@users.noreply.github.com", "should derive committer email, got: " .. tostring(e.GIT_COMMITTER_EMAIL))
+  print("✓ setup_git_env uses GITHUB_ACTOR")
+end
+test_setup_git_env_github_actor()
+
+-- Test setup_git_env does not overwrite already-set values
+local function test_setup_git_env_no_overwrite()
+  local e: {string:string} = {
+    GIT_AUTHOR_NAME = "custom",
+    GIT_AUTHOR_EMAIL = "custom@example.com",
+    GIT_COMMITTER_NAME = "custom",
+    GIT_COMMITTER_EMAIL = "custom@example.com",
+  }
+  work.setup_git_env(e)
+  assert(e.GIT_AUTHOR_NAME == "custom", "should not overwrite existing name")
+  assert(e.GIT_AUTHOR_EMAIL == "custom@example.com", "should not overwrite existing email")
+  print("✓ setup_git_env preserves existing values")
+end
+test_setup_git_env_no_overwrite()
 
 print("\nAll work tests passed!")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -288,12 +288,14 @@ local bash_tool: Tool = {
     local timeout_ms = (input.timeout as integer) or 120000
     local timeout_sec = math.ceil(timeout_ms / 1000)
 
-    -- Wrap command with timeout
-    local wrapped = string.format("timeout %d sh -c %q", timeout_sec, command)
-
-    -- Pass current environment to the child process
-    -- env.all() returns an array of "key=value" strings
-    local handle, err = child.spawn({"sh", "-c", wrapped}, {env = env.all() as {string}})
+    -- Spawn directly: timeout -> shell -> command
+    -- No double-wrapping (old: sh -c "timeout N sh -c %q") which corrupted
+    -- newlines via %q escaping (backslash-newline becomes line continuation).
+    local shell = os.getenv("AH_SHELL") or "bash"
+    local handle, err = child.spawn(
+      {"timeout", tostring(timeout_sec), shell, "-c", command},
+      {env = env.all() as {string}}
+    )
     if not handle then
       return "error: failed to spawn: " .. tostring(err), true, nil
     end

--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -64,6 +64,20 @@ local function format_protect_dirs(dirs: {string}): string
   return table.concat(dirs, ":")
 end
 
+-- Configure git identity env vars in the given environment table.
+-- Uses GITHUB_ACTOR when available (GitHub Actions), otherwise falls back
+-- to defaults. Does not overwrite values that are already set.
+local function setup_git_env(run_env: {string:string})
+  local actor = run_env.GITHUB_ACTOR
+  local name = actor or "ah-agent"
+  local email = actor and (actor .. "@users.noreply.github.com") or "ah-agent@localhost"
+
+  if not run_env.GIT_AUTHOR_NAME then run_env.GIT_AUTHOR_NAME = name end
+  if not run_env.GIT_AUTHOR_EMAIL then run_env.GIT_AUTHOR_EMAIL = email end
+  if not run_env.GIT_COMMITTER_NAME then run_env.GIT_COMMITTER_NAME = name end
+  if not run_env.GIT_COMMITTER_EMAIL then run_env.GIT_COMMITTER_EMAIL = email end
+end
+
 local function write_file(path: string, content: string): boolean
   local f = io.open(path, "w")
   if not f then return false end
@@ -325,6 +339,7 @@ local function sandboxed_agent(no_sandbox: boolean, prompt: string, db: string, 
   end
 
   local run_env = env.all()
+  setup_git_env(run_env)
   if ctx and ctx.enabled then
     local proxy_url, proxy_err = fetch.unix_proxy(ctx.socket_path)
     if not proxy_url then
@@ -1182,4 +1197,5 @@ return {
   build_fix_prompt = build_fix_prompt,
   build_friction_prompt = build_friction_prompt,
   build_agent_args = build_agent_args,
+  setup_git_env = setup_git_env,
 }


### PR DESCRIPTION
## Summary
This PR fixes two critical issues: (1) git operations now use proper identity configuration that respects GitHub Actions context, and (2) bash commands with literal newlines are now executed correctly without corruption.

## Key Changes

- **Add `setup_git_env()` function** to configure git identity environment variables
  - Uses `GITHUB_ACTOR` when available (GitHub Actions environment)
  - Falls back to sensible defaults (`ah-agent`) when not in GitHub Actions
  - Respects pre-existing git configuration (does not overwrite)
  - Automatically derives GitHub-style email addresses from actor names

- **Fix bash command execution** to preserve literal newlines
  - Removed double-wrapping of commands (`sh -c "timeout N sh -c %q"`)
  - Changed to direct spawning: `timeout -> shell -> command`
  - The old `%q` escaping was converting newlines to line continuations, breaking multi-line commands (e.g., git commits with heredocs)
  - Now respects `AH_SHELL` environment variable (defaults to `bash`)

- **Add comprehensive test coverage**
  - Tests for `setup_git_env()` with defaults, GitHub Actions context, and existing values
  - Regression tests for bash newline preservation and bash-specific features (brace expansion)

## Implementation Details

The `setup_git_env()` function is called during agent initialization to ensure git operations have proper identity configuration. This is particularly important in CI/CD environments where git commits need to be attributed correctly.

The bash execution fix eliminates the problematic double-wrapping pattern that was corrupting command strings. Commands are now passed directly to the shell without intermediate escaping that would mangle whitespace.

https://claude.ai/code/session_01AirMHCtY666nz3nb1s7Pif