### PR TITLE
Separate fix phase artifacts into o/work/fix directory

### DIFF
--- a/lib/ah/test_work_fix.tl
+++ b/lib/ah/test_work_fix.tl
@@ -81,6 +81,36 @@ local function test_build_friction_prompt_phases()
 end
 test_build_friction_prompt_phases()
 
+-- Test: fix.md prompt writes artifacts to o/work/fix/, not o/work/do/
+local function test_fix_prompt_uses_fix_directory()
+  local f = io.open("sys/work/fix.md", "r")
+  assert(f, "should be able to read sys/work/fix.md")
+  local content = f:read("*a")
+  f:close()
+  -- fix prompt must write to o/work/fix/ so it doesn't overwrite do phase artifacts
+  assert(content:find("o/work/fix/do.md", 1, true),
+    "fix prompt should write to o/work/fix/do.md")
+  assert(content:find("o/work/fix/update.md", 1, true),
+    "fix prompt should write to o/work/fix/update.md")
+  -- must not reference o/work/do/ for output paths
+  assert(not content:find("o/work/do/do.md", 1, true),
+    "fix prompt must not write to o/work/do/do.md (would overwrite do phase artifacts)")
+  assert(not content:find("o/work/do/update.md", 1, true),
+    "fix prompt must not write to o/work/do/update.md (would overwrite do phase artifacts)")
+  print("ok fix.md prompt writes to o/work/fix/ directory")
+end
+test_fix_prompt_uses_fix_directory()
+
+-- Test: build_friction_prompt works for fix phase path
+local function test_build_friction_prompt_fix_phase()
+  local template = "Write `{friction_path}`"
+  local result = work.build_friction_prompt(template, "o/work/fix/friction.md")
+  assert(result == "Write `o/work/fix/friction.md`",
+    "should interpolate o/work/fix/friction.md, got: " .. tostring(result))
+  print("ok build_friction_prompt works for fix phase path")
+end
+test_build_friction_prompt_fix_phase()
+
 -- Test: build_agent_args with new session, no limits
 local function test_agent_args_basic()
   local args = work.build_agent_args("ah", "test.db", "hello", true, nil, nil)

--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -738,10 +738,12 @@ local function phase_do(no_sandbox: boolean, title: string, number: string, mode
   return 0
 end
 
-local function phase_push(): integer
-  local branch_content = read_file("o/work/do/branch.txt")
+local function phase_push(work_dir: string): integer
+  work_dir = work_dir or "o/work/do"
+  local branch_file = work_dir .. "/branch.txt"
+  local branch_content = read_file(branch_file)
   if not branch_content then
-    io.stderr:write("error: could not read o/work/do/branch.txt\n")
+    io.stderr:write("error: could not read " .. branch_file .. "\n")
     return 1
   end
 
@@ -766,7 +768,8 @@ local function phase_push(): integer
   return 0
 end
 
-local function phase_check(no_sandbox: boolean, model: string): integer
+local function phase_check(no_sandbox: boolean, model: string, do_dir: string): integer
+  do_dir = do_dir or "o/work/do"
   fs.makedirs("o/work/check")
 
   local plan_contents = read_file("o/work/plan/plan.md")
@@ -775,9 +778,10 @@ local function phase_check(no_sandbox: boolean, model: string): integer
     return 1
   end
 
-  local do_contents = read_file("o/work/do/do.md")
+  local do_md = do_dir .. "/do.md"
+  local do_contents = read_file(do_md)
   if not do_contents then
-    io.stderr:write("error: could not read o/work/do/do.md\n")
+    io.stderr:write("error: could not read " .. do_md .. "\n")
     return 1
   end
 
@@ -789,8 +793,13 @@ local function phase_check(no_sandbox: boolean, model: string): integer
 
   prompt = build_check_prompt(prompt, plan_contents, do_contents)
 
+  local protect_dirs: {string} = {"o/work/plan", "o/work/do"}
+  if do_dir ~= "o/work/do" then
+    table.insert(protect_dirs, do_dir)
+  end
+
   local friction = make_friction_prompt("o/work/check")
-  local ok = sandboxed_agent(no_sandbox, prompt, "o/work/check/session.db", {"o/work/plan", "o/work/do"}, friction, check_limits, model)
+  local ok = sandboxed_agent(no_sandbox, prompt, "o/work/check/session.db", protect_dirs, friction, check_limits, model)
 
   if not ok then
     io.stderr:write("error: check agent failed\n")
@@ -809,7 +818,7 @@ local function read_check_verdict(): string
 end
 
 local function phase_fix(no_sandbox: boolean, title: string, number: string, model: string): integer
-  fs.makedirs("o/work/do")
+  fs.makedirs("o/work/fix")
 
   local plan_contents = read_file("o/work/plan/plan.md")
   if not plan_contents then
@@ -833,15 +842,15 @@ local function phase_fix(no_sandbox: boolean, title: string, number: string, mod
 
   prompt = build_fix_prompt(prompt, title, plan_contents, check_contents, branch)
 
-  local friction = make_friction_prompt("o/work/do")
-  local ok = sandboxed_agent(no_sandbox, prompt, "o/work/do/session.db", {"o/work/plan"}, friction, fix_limits, model)
+  local friction = make_friction_prompt("o/work/fix")
+  local ok = sandboxed_agent(no_sandbox, prompt, "o/work/fix/session.db", {"o/work/plan", "o/work/do"}, friction, fix_limits, model)
 
   if not ok then
     io.stderr:write("error: fix agent failed\n")
     return 1
   end
 
-  write_file("o/work/do/branch.txt", branch .. "\n")
+  write_file("o/work/fix/branch.txt", branch .. "\n")
 
   return 0
 end
@@ -1050,11 +1059,11 @@ local function main(args: {string}): integer
   elseif subcmd == "do" then
     return cmd_do(no_sandbox, slice(filtered_args, 2), model)
   elseif subcmd == "check" then
-    return phase_check(no_sandbox, model)
+    return phase_check(no_sandbox, model, "o/work/do")
   elseif subcmd == "act" then
     return cmd_act(slice(filtered_args, 2))
   elseif subcmd == "push" then
-    return phase_push()
+    return phase_push("o/work/do")
   end
 
   -- Unified mode: parse options, run all phases
@@ -1154,13 +1163,13 @@ local function main(args: {string}): integer
   -- Phase 3: Push (deterministic — unsandboxed)
   if not check_deadline("push") then return 1 end
   io.stderr:write("==> push\n")
-  rc = phase_push()
+  rc = phase_push("o/work/do")
   if rc ~= 0 then return rc end
 
   -- Phase 4: Check (agent — sandboxed)
   if not check_deadline("check") then return 1 end
   io.stderr:write("==> check\n")
-  rc = phase_check(no_sandbox, model)
+  rc = phase_check(no_sandbox, model, "o/work/do")
   if rc ~= 0 then return rc end
 
   -- Retry loop: if check returns needs-fixes, run fix/push/check
@@ -1175,12 +1184,12 @@ local function main(args: {string}): integer
 
     if not check_deadline("push") then break end
     io.stderr:write("==> push\n")
-    rc = phase_push()
+    rc = phase_push("o/work/fix")
     if rc ~= 0 then break end
 
     if not check_deadline("check") then break end
     io.stderr:write("==> check\n")
-    rc = phase_check(no_sandbox, model)
+    rc = phase_check(no_sandbox, model, "o/work/fix")
     if rc ~= 0 then break end
   end
 

--- a/sys/work/fix.md
+++ b/sys/work/fix.md
@@ -20,7 +20,7 @@ You are fixing issues found during review. Follow the plan and address the feedb
 
 ## Output
 
-Write `o/work/do/do.md`:
+Write `o/work/fix/do.md`:
 
     # Fix: {title}
 
@@ -36,6 +36,6 @@ Write `o/work/do/do.md`:
     ## Notes
     <issues encountered>
 
-Write `o/work/do/update.md`: 2-4 line summary.
+Write `o/work/fix/update.md`: 2-4 line summary.
 
 Fix only the issues identified in the review. Do not add unrequested changes.


### PR DESCRIPTION
## Summary
This change separates the fix phase workflow into its own directory (`o/work/fix`) to prevent artifacts from overwriting the do phase outputs. Previously, both phases wrote to `o/work/do`, which could cause data loss during the retry loop when fixes are applied.

## Key Changes

- **phase_push()**: Added `work_dir` parameter (defaults to `"o/work/do"`) to make the branch file path configurable
- **phase_check()**: Added `do_dir` parameter (defaults to `"o/work/do"`) to read do.md from a configurable location; dynamically builds protected directories list to include custom do_dir when specified
- **phase_fix()**: Changed all artifact paths from `o/work/do/` to `o/work/fix/` (session.db, branch.txt, friction prompt); now protects both `o/work/plan` and `o/work/do` directories during sandboxed execution
- **sys/work/fix.md**: Updated prompt template to write outputs to `o/work/fix/do.md` and `o/work/fix/update.md` instead of `o/work/do/`
- **main()**: Updated all phase_push() and phase_check() calls to pass appropriate work directory paths (`"o/work/do"` for initial phases, `"o/work/fix"` for retry loop)
- **Tests**: Added test cases to verify fix.md prompt writes to correct directory and build_friction_prompt works with fix phase paths

## Implementation Details

The fix phase now operates in complete isolation from the do phase, with its own session database and output files. During the retry loop, phase_push() reads from `o/work/fix/branch.txt` and phase_check() reads from `o/work/fix/do.md`, ensuring the workflow can iterate without data loss. The sandboxed agent protects both the original do phase artifacts and the plan directory from modification.

https://claude.ai/code/session_019a1f7bGqQL8yGKwpGcYYwT