### PR TITLE
fix: coerce string integers to integers in tool input

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -746,4 +746,35 @@ local function test_abort_kills_process()
 end
 test_abort_kills_process()
 
+-- Test that string integers are coerced to integers before validation
+-- Regression: Claude models sometimes serialize integers as strings
+local function test_string_integer_coercion()
+  -- Read tool with string limit/offset (Claude often sends these as strings)
+  local test_file = fs.join(TEST_TMPDIR, "test_coerce.txt")
+  cio.barf(test_file, "line1\nline2\nline3\nline4\nline5\n")
+
+  local result, is_error = tools.execute_tool("read", {
+    path = test_file,
+    limit = "2",  -- string instead of integer
+    offset = "2"  -- string instead of integer
+  })
+  assert(not is_error, "read with string integers should succeed: " .. result)
+  assert(result:match("2\tline2"), "should start at offset 2: " .. result)
+  assert(not result:match("4\tline4"), "should respect limit of 2: " .. result)
+  print("✓ read tool coerces string integers to integers")
+end
+test_string_integer_coercion()
+
+local function test_bash_timeout_string_coercion()
+  -- Bash tool with string timeout
+  local result, is_error = tools.execute_tool("bash", {
+    command = "echo hello",
+    timeout = "5000"  -- string instead of integer
+  })
+  assert(not is_error, "bash with string timeout should succeed: " .. result)
+  assert(result:match("hello"), "should execute command")
+  print("✓ bash tool coerces string timeout to integer")
+end
+test_bash_timeout_string_coercion()
+
 print("\nAll tools tests passed!")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -743,11 +743,35 @@ local function abort_running_tools()
   end
 end
 
+-- Coerce string values to integers where schema expects integer
+-- Claude models sometimes serialize integers as strings in JSON tool calls
+local function coerce_integer_params(schema: {string:any}, input: {string:any})
+  local properties = schema.properties as {string:{string:any}}
+  if not properties then return end
+
+  for prop, prop_schema in pairs(properties) do
+    local expected_type = prop_schema.type as string
+    if expected_type == "integer" or expected_type == "number" then
+      local value = input[prop]
+      if type(value) == "string" then
+        local num = tonumber(value)
+        if num then
+          input[prop] = num
+        end
+      end
+    end
+  end
+end
+
 local function execute_tool(name: string, input: {string:any}): string, boolean, ToolDetails
   local tool = get_tool(name)
   if not tool then
     return "error: unknown tool: " .. name, true, nil
   end
+
+  -- Coerce string integers to integers before validation
+  -- Claude models sometimes serialize integers as strings
+  coerce_integer_params(tool.input_schema, input or {})
 
   -- Validate input against schema before execution
   local validation_err = validate_input(tool.input_schema, input or {})


### PR DESCRIPTION
Claude models sometimes serialize integer parameters as strings in JSON tool calls (e.g., `{"limit": "100"}` instead of `{"limit": 100}`).

This adds `coerce_integer_params()` that converts string values to numbers for properties with `type="integer"` or `type="number"` before validation runs. This prevents validation errors like:

```
property 'limit': expected integer, got string
```

Fixes #93