### PR TITLE
Add contents:write permission to prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,6 +10,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The prerelease workflow was failing with HTTP 403 "Resource not
accessible by integration" because it lacked the permissions block
needed for gh release create/delete. Add contents:write to grant
the GITHUB_TOKEN access to create releases and upload assets.

https://claude.ai/code/session_01AyrXqyS6po6JgpxnEBRSeE