### PR TITLE
fix: set GIT_CONFIG_GLOBAL=/dev/null to avoid safe.directory errors

### DIFF
--- a/lib/ah/work/test_util.tl
+++ b/lib/ah/work/test_util.tl
@@ -66,6 +66,24 @@ local function test_setup_git_env_defaults()
 end
 test_setup_git_env_defaults()
 
+-- Test setup_git_env sets GIT_CONFIG_GLOBAL to /dev/null when not present
+local function test_setup_git_env_config_global()
+  local e: {string} = {}
+  util.setup_git_env(e)
+  assert(util.env_get(e, "GIT_CONFIG_GLOBAL") == "/dev/null", "should set GIT_CONFIG_GLOBAL=/dev/null, got: " .. tostring(util.env_get(e, "GIT_CONFIG_GLOBAL")))
+  print("✓ setup_git_env sets GIT_CONFIG_GLOBAL")
+end
+test_setup_git_env_config_global()
+
+-- Test setup_git_env preserves existing GIT_CONFIG_GLOBAL
+local function test_setup_git_env_preserves_config_global()
+  local e: {string} = {"GIT_CONFIG_GLOBAL=/custom/gitconfig"}
+  util.setup_git_env(e)
+  assert(util.env_get(e, "GIT_CONFIG_GLOBAL") == "/custom/gitconfig", "should preserve existing GIT_CONFIG_GLOBAL")
+  print("✓ setup_git_env preserves existing GIT_CONFIG_GLOBAL")
+end
+test_setup_git_env_preserves_config_global()
+
 -- Test setup_git_env uses GITHUB_ACTOR when available
 local function test_setup_git_env_github_actor()
   local e: {string} = {"GITHUB_ACTOR=octocat"}

--- a/lib/ah/work/util.tl
+++ b/lib/ah/work/util.tl
@@ -54,6 +54,8 @@ end
 -- env.all() returns {string} as "KEY=value" entries.
 -- Uses GITHUB_ACTOR when available (GitHub Actions), otherwise falls back
 -- to defaults. Does not overwrite values that are already set.
+-- Also sets GIT_CONFIG_GLOBAL=/dev/null to disable global config (avoids
+-- safe.directory issues in sandboxed environments).
 local function setup_git_env(run_env: {string})
   local actor = env_get(run_env, "GITHUB_ACTOR")
   local name = actor or "ah-agent"
@@ -63,6 +65,8 @@ local function setup_git_env(run_env: {string})
   if not env_get(run_env, "GIT_AUTHOR_EMAIL") then env_set(run_env, "GIT_AUTHOR_EMAIL", email) end
   if not env_get(run_env, "GIT_COMMITTER_NAME") then env_set(run_env, "GIT_COMMITTER_NAME", name) end
   if not env_get(run_env, "GIT_COMMITTER_EMAIL") then env_set(run_env, "GIT_COMMITTER_EMAIL", email) end
+  -- Disable global config to avoid safe.directory errors in sandbox
+  if not env_get(run_env, "GIT_CONFIG_GLOBAL") then env_set(run_env, "GIT_CONFIG_GLOBAL", "/dev/null") end
 end
 
 -- Format error from a failed command, preferring stderr over stdout.


### PR DESCRIPTION
When running in GitHub Actions sandbox, git commands fail with exit code 128 because safe.directory is not configured. Setting GIT_CONFIG_GLOBAL=/dev/null bypasses the global gitconfig check entirely.

Fixes: #122