### PR TITLE
fix: return non-zero exit code when agent loop ends with error

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -1242,7 +1242,7 @@ local function main(args: {string}): integer, string
   if max_tokens then
     agent_opts.max_tokens = max_tokens
   end
-  loop.run_agent(d, qdb, effective_system, effective_model, prompt, parent_id, on_event, agent_opts)
+  local stop_reason = loop.run_agent(d, qdb, effective_system, effective_model, prompt, parent_id, on_event, agent_opts)
 
   -- Mark session as closed before exit
   db.set_session_state(d, "closed")
@@ -1251,6 +1251,12 @@ local function main(args: {string}): integer, string
   queue.release_lock(qdb)
   queue.close(qdb)
   db.close(d)
+
+  -- Return non-zero exit code for error stop reasons
+  if stop_reason == "error" then
+    return 1
+  end
+
   return 0
 end
 

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -137,7 +137,7 @@ end
 -- When provided, the loop emits events instead of writing directly to stderr/stdout.
 -- When nil, the loop still functions but produces no output.
 -- opts: optional agent options (e.g. token budget)
-local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, model: string, prompt: string, parent_id: string, on_event: events.EventCallback, opts: AgentOpts)
+local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, model: string, prompt: string, parent_id: string, on_event: events.EventCallback, opts: AgentOpts): string
   opts = opts or {}
   local max_tokens = opts.max_tokens
 
@@ -145,7 +145,7 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
   local creds, creds_err = auth.load_credentials()
   if not creds then
     emit(on_event, events.error_event("credentials: " .. creds_err))
-    return
+    return "error"
   end
   local is_oauth = creds.is_oauth or false
 
@@ -738,6 +738,8 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
   -- Log agent_end event to DB
   db.log_event(d, "agent_end", nil, events.to_json(events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens)))
+
+  return final_stop_reason
 end
 
 return {

--- a/lib/ah/test_loop.tl
+++ b/lib/ah/test_loop.tl
@@ -242,3 +242,13 @@ end
 test_thresholds()
 
 print("all loop tests passed")
+
+-- Test that run_agent returns a stop_reason string
+local function test_run_agent_signature()
+  -- Verify run_agent is exported and callable
+  assert(type(loop.run_agent) == "function", "run_agent should be a function")
+  -- The function should return a string (stop_reason)
+  -- We can't easily test without mocking the API, but we document the contract
+  print("✓ run_agent is exported as a function")
+end
+test_run_agent_signature()


### PR DESCRIPTION
## Problem

The agent process was returning exit code 0 even when the loop ended with `stop_reason='error'` (e.g., API transport failures). This caused the work harness to think the agent succeeded when it hadn't written required outputs.

Evidence from run 21954523635:
- Agent encountered `fetch failed: transport error` at 16:14:24
- Agent ended with `stop_reason: error` at 16:15:24
- But agent process exited with code 0
- Harness reported misleading "error: plan.md not created" instead of detecting the agent failure

## Root Cause

`loop.run_agent()` returned no value, and `init.main()` unconditionally returned 0 regardless of how the agent loop terminated.

## Fix

1. `loop.run_agent()` now returns the `final_stop_reason` string
2. `init.main()` checks if `stop_reason == "error"` and returns exit code 1

## Changes

- `lib/ah/loop.tl`: Added return type `: string`, returns `"error"` on credential failure, returns `final_stop_reason` at end
- `lib/ah/init.tl`: Captures return value from `run_agent`, returns 1 if stop_reason is "error"
- `lib/ah/test_loop.tl`: Added test documenting the contract

## Result

When an API error occurs, the agent now exits with code 1, causing the harness to correctly detect the failure and report "error: plan agent failed" instead of the misleading "error: plan.md not created".

Fixes part of #102