### PR TITLE
fix: treat plan phase as successful if plan.md exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(o)/%.tl.test.ok: $(o)/%.lua $(ah_lua) $(cosmic)
 	@mkdir -p $(@D)
 	@d=$$(mktemp -d); TEST_TMPDIR=$$d $(cosmic) $< >$$d/out 2>&1 \
 		&& echo "pass:" > $@ || echo "fail:" > $@; \
-	cat $$d/out >> $@; rm -rf $$d
+	if [ -f $$d/out ]; then cat $$d/out >> $@; fi; rm -rf $$d
 
 # targets
 .PHONY: help

--- a/lib/ah/work/init.tl
+++ b/lib/ah/work/init.tl
@@ -191,21 +191,27 @@ local function phase_plan(no_sandbox: boolean, repo: string, issue_number: integ
   local friction = prompt.make_friction_prompt("o/work/plan")
   local ok = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/plan/session.db", nil, friction, sandbox.plan_limits, model)
 
+  -- Check if plan.md was created, regardless of agent exit status.
+  -- The agent may have written plan.md in its final tool call but been
+  -- terminated before completing (stop_reason: tool_use instead of end_turn).
+  local plan_content = util.read_file("o/work/plan/plan.md")
+  if plan_content and #plan_content > 0 then
+    -- Plan exists with content - consider successful even if agent didn't exit cleanly
+    if not ok then
+      util.log("plan agent exited non-zero but plan.md exists, treating as success")
+    end
+    return 0, issue
+  end
+
+  -- No plan.md or empty - this is a failure
   if not ok then
     io.stderr:write("error: plan agent failed\n")
-    local diag = prompt.plan_diagnostic("o/work/plan")
-    util.log("plan diagnostic: " .. diag)
-    return 1
-  end
-
-  if not util.read_file("o/work/plan/plan.md") then
-    local diag = prompt.plan_diagnostic("o/work/plan")
+  else
     io.stderr:write("error: plan.md not created\n")
-    util.log("plan diagnostic: " .. diag)
-    return 1
   end
-
-  return 0, issue
+  local diag = prompt.plan_diagnostic("o/work/plan")
+  util.log("plan diagnostic: " .. diag)
+  return 1
 end
 
 local function phase_do(no_sandbox: boolean, title: string, number: string, model: string): integer

--- a/lib/ah/work/test_plan_success.tl
+++ b/lib/ah/work/test_plan_success.tl
@@ -1,0 +1,56 @@
+-- Test plan phase success logic
+-- The plan phase should succeed if plan.md exists, even if the agent
+-- subprocess didn't exit cleanly.
+
+local fs = require("cosmic.fs")
+local unix = require("cosmo.unix")
+local util = require("ah.work.util")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp/test_plan_success"
+unix.rmrf(tmpdir)
+fs.makedirs(tmpdir)
+
+-- Helper: check if plan output is valid
+-- This mirrors the logic we want in phase_plan
+local function is_plan_valid(plan_dir: string): boolean
+  local content = util.read_file(plan_dir .. "/plan.md")
+  if not content then return false end
+  if #content == 0 then return false end
+  return true
+end
+
+-- Test case 1: plan.md exists and has content -> valid
+print("Test 1: plan.md exists with content")
+local plan_dir = tmpdir .. "/plan"
+fs.makedirs(plan_dir)
+local f = io.open(plan_dir .. "/plan.md", "w")
+if f then
+  f:write("# Plan\n\nThis is a complete plan.\n")
+  f:close()
+end
+assert(is_plan_valid(plan_dir), "plan with content should be valid")
+print("  ✓ plan with content is valid")
+
+-- Test case 2: plan.md doesn't exist -> invalid
+print("Test 2: plan.md doesn't exist")
+local empty_dir = tmpdir .. "/empty"
+fs.makedirs(empty_dir)
+assert(not is_plan_valid(empty_dir), "missing plan should be invalid")
+print("  ✓ missing plan.md is invalid")
+
+-- Test case 3: plan.md is empty -> invalid
+print("Test 3: plan.md is empty")
+local empty_plan_dir = tmpdir .. "/empty_plan"
+fs.makedirs(empty_plan_dir)
+f = io.open(empty_plan_dir .. "/plan.md", "w")
+if f then
+  f:write("")
+  f:close()
+end
+assert(not is_plan_valid(empty_plan_dir), "empty plan should be invalid")
+print("  ✓ empty plan.md is invalid")
+
+-- Cleanup
+unix.rmrf(tmpdir)
+
+print("\nAll tests passed!")


### PR DESCRIPTION
The plan agent may write plan.md in its final tool call but be terminated before completing (stop_reason: tool_use instead of end_turn). Previously this marked the phase as failed even though the work was completed.

Now check if plan.md exists with content before failing the phase. If plan.md is valid, treat the phase as successful regardless of the agent's exit status.

Fixes #127

## Changes
- Check for plan.md existence and content after agent runs
- Treat phase as success if plan.md exists with content, even if agent exited non-zero
- Add test for plan validity logic