### PR TITLE
fix: set GIT_CONFIG_NOSYSTEM=1 in sandbox environment

### DIFF
--- a/lib/ah/work/test_util.tl
+++ b/lib/ah/work/test_util.tl
@@ -223,3 +223,13 @@ end
 test_format_error_both_nil()
 
 print("\nAll work-util tests passed!")
+
+-- Test setup_git_env sets GIT_CONFIG_NOSYSTEM
+local function test_setup_git_env_nosystem()
+  local run_env: {string} = {}
+  util.setup_git_env(run_env)
+  local val = util.env_get(run_env, "GIT_CONFIG_NOSYSTEM")
+  assert(val == "1", "GIT_CONFIG_NOSYSTEM should be '1', got: " .. (val or "nil"))
+  print("✓ setup_git_env sets GIT_CONFIG_NOSYSTEM=1")
+end
+test_setup_git_env_nosystem()

--- a/lib/ah/work/util.tl
+++ b/lib/ah/work/util.tl
@@ -55,7 +55,8 @@ end
 -- Uses GITHUB_ACTOR when available (GitHub Actions), otherwise falls back
 -- to defaults. Does not overwrite values that are already set.
 -- Also sets GIT_CONFIG_GLOBAL=/dev/null to disable global config (avoids
--- safe.directory issues in sandboxed environments).
+-- safe.directory issues in sandboxed environments) and GIT_CONFIG_NOSYSTEM=1
+-- to disable system config (avoids /etc/gitconfig permission errors).
 local function setup_git_env(run_env: {string})
   local actor = env_get(run_env, "GITHUB_ACTOR")
   local name = actor or "ah-agent"
@@ -67,6 +68,8 @@ local function setup_git_env(run_env: {string})
   if not env_get(run_env, "GIT_COMMITTER_EMAIL") then env_set(run_env, "GIT_COMMITTER_EMAIL", email) end
   -- Disable global config to avoid safe.directory errors in sandbox
   if not env_get(run_env, "GIT_CONFIG_GLOBAL") then env_set(run_env, "GIT_CONFIG_GLOBAL", "/dev/null") end
+  -- Disable system config to avoid /etc/gitconfig permission errors in sandbox
+  if not env_get(run_env, "GIT_CONFIG_NOSYSTEM") then env_set(run_env, "GIT_CONFIG_NOSYSTEM", "1") end
 end
 
 -- Format error from a failed command, preferring stderr over stdout.


### PR DESCRIPTION
Fixes permission denied errors when git tries to read /etc/gitconfig in sandboxed environments. The agent was discovering this workaround through trial and error, causing 6 retries before succeeding.

## Changes
- Set `GIT_CONFIG_NOSYSTEM=1` in `setup_git_env()` to disable system-level git config
- Added test to verify the env var is set

## Evidence
From work run 21974064830, the do phase had 6 git errors:
```
warning: unable to access '/etc/gitconfig': Permission denied
fatal: unknown error occurred while reading the configuration files
exit code: 128
```

The agent had to discover the workaround through trial and error.

Closes #131