### PR TITLE
enable work workflow schedule every 6 hours

### DIFF
--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -1,8 +1,8 @@
 name: work
 
 on:
-  # schedule:
-  #   - cron: '0 0 * * *'
+  schedule:
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       issue:


### PR DESCRIPTION
enables scheduled runs of the work workflow every 6 hours (cron: `0 */6 * * *`).

confirmed the existing behavior:
- issues are already filtered by `todo` label
- only issue title and body are passed to the flow (no comments)