### PR TITLE
fix(work): retry check phase on crash signals

### DIFF
--- a/lib/ah/work/init.tl
+++ b/lib/ah/work/init.tl
@@ -298,6 +298,17 @@ local function phase_push(work_dir: string): integer
   return 0
 end
 
+-- Check if exit code indicates a crash signal (SIGSEGV, SIGBUS, etc.)
+-- Exit codes 128+N indicate the process was killed by signal N
+local function is_crash_signal(exit_code: integer): boolean
+  if exit_code > 128 and exit_code <= 159 then
+    local signal = exit_code - 128
+    -- SIGSEGV=11, SIGBUS=7, SIGFPE=8, SIGILL=4, SIGABRT=6
+    return signal == 11 or signal == 7 or signal == 8 or signal == 4 or signal == 6
+  end
+  return false
+end
+
 local function phase_check(no_sandbox: boolean, model: string, do_dir: string): integer
   do_dir = do_dir or "o/work/do"
   local dir_ok, dir_err = ensure_dir("o/work/check")
@@ -333,14 +344,29 @@ local function phase_check(no_sandbox: boolean, model: string, do_dir: string): 
   end
 
   local friction = prompt.make_friction_prompt("o/work/check")
-  local ok = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/check/session.db", protect_dirs, friction, sandbox.check_limits, model)
 
-  if not ok then
-    io.stderr:write("error: check agent failed\n")
-    return 1
+  -- Retry on crash signals (SIGSEGV, SIGBUS, etc.) up to 2 times
+  local max_crash_retries = 2
+  for attempt = 1, max_crash_retries + 1 do
+    local ok, _, exit_code = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/check/session.db", protect_dirs, friction, sandbox.check_limits, model)
+
+    if ok then
+      return 0
+    end
+
+    -- Check if it was a crash signal
+    if is_crash_signal(exit_code) and attempt <= max_crash_retries then
+      io.stderr:write("[work] check agent crashed (signal " .. tostring(exit_code - 128) .. "), retrying (" .. tostring(attempt) .. "/" .. tostring(max_crash_retries) .. ")...\n")
+      -- Clear the check directory for retry
+      os.execute("rm -rf o/work/check/*")
+      ensure_dir("o/work/check")
+    else
+      io.stderr:write("error: check agent failed (exit code " .. tostring(exit_code) .. ")\n")
+      return 1
+    end
   end
 
-  return 0
+  return 1
 end
 
 local function read_check_verdict(): string
@@ -925,6 +951,8 @@ end
 
 return {
   main = main,
+  -- internal functions exported for testing
+  is_crash_signal = is_crash_signal,
   -- re-exported from submodules for backward compatibility
   get_priority = issue_mod.get_priority,
   sort_issues = issue_mod.sort_issues,

--- a/lib/ah/work/test_init.tl
+++ b/lib/ah/work/test_init.tl
@@ -3,9 +3,37 @@
 
 local record Work
   main: function({string}): integer
+  is_crash_signal: function(integer): boolean
 end
 
 local work = require("ah.work") as Work
+
+-- Test is_crash_signal
+local function test_is_crash_signal()
+  -- SIGSEGV = 11, exit code 139
+  assert(work.is_crash_signal(139) == true, "139 (SIGSEGV) should be crash signal")
+  -- SIGBUS = 7, exit code 135
+  assert(work.is_crash_signal(135) == true, "135 (SIGBUS) should be crash signal")
+  -- SIGFPE = 8, exit code 136
+  assert(work.is_crash_signal(136) == true, "136 (SIGFPE) should be crash signal")
+  -- SIGILL = 4, exit code 132
+  assert(work.is_crash_signal(132) == true, "132 (SIGILL) should be crash signal")
+  -- SIGABRT = 6, exit code 134
+  assert(work.is_crash_signal(134) == true, "134 (SIGABRT) should be crash signal")
+  
+  -- Non-crash signals
+  assert(work.is_crash_signal(0) == false, "0 should not be crash signal")
+  assert(work.is_crash_signal(1) == false, "1 should not be crash signal")
+  assert(work.is_crash_signal(124) == false, "124 (timeout) should not be crash signal")
+  assert(work.is_crash_signal(128) == false, "128 should not be crash signal")
+  -- SIGTERM = 15, exit code 143
+  assert(work.is_crash_signal(143) == false, "143 (SIGTERM) should not be crash signal")
+  -- SIGKILL = 9, exit code 137
+  assert(work.is_crash_signal(137) == false, "137 (SIGKILL) should not be crash signal")
+  
+  print("✓ is_crash_signal works correctly")
+end
+test_is_crash_signal()
 
 -- Test that help returns 0
 local function test_help()


### PR DESCRIPTION
Add retry logic (up to 2 retries) when the check phase agent crashes with a signal like SIGSEGV (exit code 139), SIGBUS (135), etc.

## Problem

The work workflow intermittently crashes with SIGSEGV during the check phase (see #148). This is likely a transient memory issue in the cosmic runtime.

## Solution

- Add `is_crash_signal()` function to detect exit codes indicating crash signals (128+N where N is SIGSEGV=11, SIGBUS=7, etc.)
- Retry the check phase up to 2 times on crash signals
- Clear the check directory before retry

## Testing

- Added unit tests for `is_crash_signal()`
- `make check-types` passes
- `make test` passes

Fixes #148