### PR TITLE
fix(loop): log API errors to DB and include in agent_end

### DIFF
--- a/lib/ah/events.tl
+++ b/lib/ah/events.tl
@@ -92,11 +92,14 @@ local function agent_start(model: string, prompt: string, parent_id: string): Ev
   return e
 end
 
-local function agent_end(stop_reason: string, total_input_tokens: integer, total_output_tokens: integer): EventData
+local function agent_end(stop_reason: string, total_input_tokens: integer, total_output_tokens: integer, error_message: string): EventData
   local e = make_event("agent_end")
   e.stop_reason = stop_reason
   e.total_input_tokens = total_input_tokens
   e.total_output_tokens = total_output_tokens
+  if error_message then
+    e.error = error_message
+  end
   return e
 end
 

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -218,6 +218,9 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
   -- Track final stop reason for agent_end event
   local final_stop_reason = "unknown"
 
+  -- Track last error message for agent_end
+  local last_error: string = nil
+
   -- Turn signature history for loop detection
   local turn_history: {string} = {}
 
@@ -289,6 +292,7 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       else
         -- Compaction failed - continue without it
         emit(on_event, events.error_event(compact_err))
+        db.log_event(d, "error", nil, events.to_json(events.error_event(compact_err)))
         last_input_tokens = 0  -- Don't keep retrying
       end
     end
@@ -337,12 +341,16 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
     if err then
       emit(on_event, events.error_event(err))
+      db.log_event(d, "error", nil, events.to_json(events.error_event(err)))
+      last_error = err
       final_stop_reason = "error"
       break
     end
 
     if not response then
       emit(on_event, events.error_event("no response"))
+      db.log_event(d, "error", nil, events.to_json(events.error_event("no response")))
+      last_error = "no response"
       final_stop_reason = "error"
       break
     end
@@ -734,10 +742,10 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
   local totals = db.get_session_token_totals(d)
 
   -- Emit agent_end with token totals
-  emit(on_event, events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens))
+  emit(on_event, events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens, last_error))
 
   -- Log agent_end event to DB
-  db.log_event(d, "agent_end", nil, events.to_json(events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens)))
+  db.log_event(d, "agent_end", nil, events.to_json(events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens, last_error)))
 
   return final_stop_reason
 end

--- a/lib/ah/test_events.tl
+++ b/lib/ah/test_events.tl
@@ -24,23 +24,34 @@ test_agent_start()
 
 -- Test agent_end constructor
 local function test_agent_end()
-  local e = events.agent_end("end_turn", 1000, 500)
+  local e = events.agent_end("end_turn", 1000, 500, nil)
   assert(e.event_type == "agent_end", "event_type should be agent_end")
   assert(e.stop_reason == "end_turn", "stop_reason mismatch")
   assert(e.total_input_tokens == 1000, "total_input_tokens mismatch")
   assert(e.total_output_tokens == 500, "total_output_tokens mismatch")
+  assert(e.error == nil, "error should be nil for normal end")
 end
 test_agent_end()
 
 -- Test agent_end without token totals (nil)
 local function test_agent_end_no_tokens()
-  local e = events.agent_end("interrupted", nil, nil)
+  local e = events.agent_end("interrupted", nil, nil, nil)
   assert(e.event_type == "agent_end", "event_type should be agent_end")
   assert(e.stop_reason == "interrupted", "stop_reason mismatch")
   assert(e.total_input_tokens == nil, "total_input_tokens should be nil")
   assert(e.total_output_tokens == nil, "total_output_tokens should be nil")
 end
 test_agent_end_no_tokens()
+
+-- Test agent_end with error message
+local function test_agent_end_with_error()
+  local e = events.agent_end("error", 500, 100, "API error 401: unauthorized")
+  assert(e.event_type == "agent_end", "event_type should be agent_end")
+  assert(e.stop_reason == "error", "stop_reason should be error")
+  assert(e.error == "API error 401: unauthorized", "error mismatch")
+  assert(e.total_input_tokens == 500, "total_input_tokens mismatch")
+end
+test_agent_end_with_error()
 
 -- Test api_call_start constructor
 local function test_api_call_start()
@@ -171,7 +182,7 @@ local function test_event_callback()
 
   cb(events.agent_start("model", "prompt", nil))
   cb(events.text_delta("hello"))
-  cb(events.agent_end("end_turn", nil, nil))
+  cb(events.agent_end("end_turn", nil, nil, nil))
 
   assert(#received == 3, "should receive 3 events")
   assert(received[1].event_type == "agent_start", "first should be agent_start")


### PR DESCRIPTION
Log API errors to the session database and include error messages in the agent_end event.

## Changes

- **events.tl**: Add optional `error_message` parameter to `agent_end()`
- **loop.tl**: Track `last_error` and log errors to DB with `db.log_event()`
- **test_events.tl**: Add test coverage for error parameter

## Context

This was generated by the work workflow (run 21993938858) for issue #133. The check phase crashed with SIGSEGV before a PR could be created.

Closes #133