### PR TITLE
workflow: use ah-debug and capture coredumps

### DIFF
--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -76,10 +76,12 @@ jobs:
             ${prompt:+--prompt "$prompt"} \
             ${model:+--model "$model"}
 
+      - name: Collect coredump
+        if: always()
+        run: mv core* o/ 2>/dev/null || true
+
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: work
-          path: |
-            o/
-            core*
+          path: o/


### PR DESCRIPTION
Changes:
- Build ah-debug instead of ah
- Enable coredumps with unlimited size and simple naming
- Include core* files in upload artifact for debugging crashes