### PR TITLE
plan skill: add turn budget guidance to prevent research exhaustion

### DIFF
--- a/sys/skills/plan.md
+++ b/sys/skills/plan.md
@@ -19,6 +19,10 @@ You are planning a work item. Research the codebase and write a plan.
 2. Identify what needs to change and where
 3. Validate that you have a clear goal and entry point
 
+You have a limited turn budget. Spend at most 5 turns researching, then
+write your output files. If you find yourself on turn 6+, stop researching
+and write plan.md with what you know.
+
 ## Bail conditions
 
 If you cannot identify BOTH a clear goal AND an entry point, write ONLY


### PR DESCRIPTION
The plan agent on issue #135 spent all 10 turns reading files and never wrote plan.md, causing the entire work run to fail with `plan_failed`.

Add explicit turn budgeting guidance: spend at most 5 turns researching, then write output with what you know.

Fixes the behavioral issue where the plan agent exhausts its turn budget on research without producing output.