### PR TITLE
work: inject repo_root (cwd) into phase prompts

### DIFF
--- a/lib/ah/work/init.tl
+++ b/lib/ah/work/init.tl
@@ -104,10 +104,11 @@ local record PromptMod
   read_prompt_template: function(string): string
   interpolate_prompt: function(string, {string:string}): string
   plan_diagnostic: function(string): string
-  build_do_prompt: function(string, string, string, string): string
+  build_do_prompt: function(string, string, string, string, string): string
   build_check_prompt: function(string, string, string): string
-  build_fix_prompt: function(string, string, string, string, string): string
+  build_fix_prompt: function(string, string, string, string, string, string): string
   build_friction_prompt: function(string, string): string
+  build_plan_prompt: function(string, string, string, string): string
   make_friction_prompt: function(string): string
 end
 
@@ -202,6 +203,7 @@ local function phase_plan(no_sandbox: boolean, repo: string, issue_number: integ
     title = issue.title,
     body = issue.body or "",
     issue_number = tostring(issue.number),
+    repo_root = unix.getcwd() or ".",
   })
 
   util.log("plan prompt interpolated (" .. #tpl .. " bytes) for issue #" .. tostring(issue.number))
@@ -253,7 +255,7 @@ local function phase_do(no_sandbox: boolean, title: string, number: string, mode
 
   local branch = util.extract_branch(plan_contents, number)
 
-  tpl = prompt.build_do_prompt(tpl, title, plan_contents, branch)
+  tpl = prompt.build_do_prompt(tpl, title, plan_contents, branch, unix.getcwd() or ".")
 
   local friction = prompt.make_friction_prompt("o/work/do")
   local ok = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/do/session.db", {"o/work/plan"}, friction, sandbox.do_limits, model)
@@ -404,7 +406,7 @@ local function phase_fix(no_sandbox: boolean, title: string, number: string, mod
 
   local branch = util.extract_branch(plan_contents, number)
 
-  tpl = prompt.build_fix_prompt(tpl, title, plan_contents, check_contents, branch)
+  tpl = prompt.build_fix_prompt(tpl, title, plan_contents, check_contents, branch, unix.getcwd() or ".")
 
   local friction = prompt.make_friction_prompt("o/work/fix")
   local ok = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/fix/session.db", {"o/work/plan", "o/work/do"}, friction, sandbox.fix_limits, model)

--- a/lib/ah/work/prompt.tl
+++ b/lib/ah/work/prompt.tl
@@ -63,11 +63,12 @@ end
 -- Prompt building for do/check/fix phases
 -- Extracted for testability.
 
-local function build_do_prompt(template: string, title: string, plan_contents: string, branch: string): string
+local function build_do_prompt(template: string, title: string, plan_contents: string, branch: string, repo_root: string): string
   return interpolate_prompt(template, {
     title = title,
     ["plan.md contents"] = plan_contents,
     branch = branch,
+    repo_root = repo_root or ".",
   })
 end
 
@@ -78,18 +79,27 @@ local function build_check_prompt(template: string, plan_contents: string, do_co
   })
 end
 
-local function build_fix_prompt(template: string, title: string, plan_contents: string, check_contents: string, branch: string): string
+local function build_fix_prompt(template: string, title: string, plan_contents: string, check_contents: string, branch: string, repo_root: string): string
   return interpolate_prompt(template, {
     title = title,
     ["plan.md contents"] = plan_contents,
     ["check.md contents"] = check_contents,
     branch = branch,
+    repo_root = repo_root or ".",
   })
 end
 
 local function build_friction_prompt(template: string, friction_path: string): string
   return interpolate_prompt(template, {
     friction_path = friction_path,
+  })
+end
+
+local function build_plan_prompt(template: string, title: string, body: string, repo_root: string): string
+  return interpolate_prompt(template, {
+    title = title,
+    body = body,
+    repo_root = repo_root or ".",
   })
 end
 
@@ -109,5 +119,6 @@ return {
   build_check_prompt = build_check_prompt,
   build_fix_prompt = build_fix_prompt,
   build_friction_prompt = build_friction_prompt,
+  build_plan_prompt = build_plan_prompt,
   make_friction_prompt = make_friction_prompt,
 }

--- a/lib/ah/work/test_prompt.tl
+++ b/lib/ah/work/test_prompt.tl
@@ -4,10 +4,11 @@
 local record WorkPrompt
   interpolate_prompt: function(string, {string:string}): string
   plan_diagnostic: function(string): string
-  build_do_prompt: function(string, string, string, string): string
+  build_do_prompt: function(string, string, string, string, string): string
   build_check_prompt: function(string, string, string): string
-  build_fix_prompt: function(string, string, string, string, string): string
+  build_fix_prompt: function(string, string, string, string, string, string): string
   build_friction_prompt: function(string, string): string
+  build_plan_prompt: function(string, string, string, string): string
 end
 
 local prompt = require("ah.work.prompt") as WorkPrompt
@@ -139,7 +140,7 @@ test_diagnostic_with_update()
 local function test_do_prompt_percent_in_plan()
   local template = "Title: {title}\nPlan:\n{plan.md contents}\nBranch: {branch}"
   local plan = "increase test coverage to 100%"
-  local ok, result = pcall(prompt.build_do_prompt, template, "fix tests", plan, "work/42")
+  local ok, result = pcall(prompt.build_do_prompt, template, "fix tests", plan, "work/42", ".")
   assert(ok, "build_do_prompt should not crash with % in plan, got error: " .. tostring(result))
   assert(result == "Title: fix tests\nPlan:\nincrease test coverage to 100%\nBranch: work/42",
     "wrong result: " .. tostring(result))
@@ -150,7 +151,7 @@ test_do_prompt_percent_in_plan()
 -- Test build_do_prompt handles %1 capture ref in title
 local function test_do_prompt_capture_ref_in_title()
   local template = "Title: {title}\nPlan:\n{plan.md contents}\nBranch: {branch}"
-  local ok, result = pcall(prompt.build_do_prompt, template, "fix %1 regex", "plan text", "work/42")
+  local ok, result = pcall(prompt.build_do_prompt, template, "fix %1 regex", "plan text", "work/42", ".")
   assert(ok, "build_do_prompt should not crash with %1 in title, got error: " .. tostring(result))
   assert(result == "Title: fix %1 regex\nPlan:\nplan text\nBranch: work/42",
     "wrong result: " .. tostring(result))
@@ -173,7 +174,7 @@ test_check_prompt_percent_in_do()
 -- Test build_fix_prompt interpolates all variables
 local function test_build_fix_prompt_basic()
   local template = "Title: {title}\nPlan:\n{plan.md contents}\nFeedback:\n{check.md contents}\nBranch: {branch}"
-  local result = prompt.build_fix_prompt(template, "fix docs", "the plan", "model name is wrong", "work/79")
+  local result = prompt.build_fix_prompt(template, "fix docs", "the plan", "model name is wrong", "work/79", ".")
   assert(result == "Title: fix docs\nPlan:\nthe plan\nFeedback:\nmodel name is wrong\nBranch: work/79",
     "should interpolate all vars, got: " .. tostring(result))
   print("✓ build_fix_prompt interpolates all variables")
@@ -184,7 +185,7 @@ test_build_fix_prompt_basic()
 local function test_build_fix_prompt_percent()
   local template = "Plan:\n{plan.md contents}\nFeedback:\n{check.md contents}"
   local check = "coverage dropped from 100% to 50%"
-  local ok, result = pcall(prompt.build_fix_prompt, template, "t", "p", check, "work/1")
+  local ok, result = pcall(prompt.build_fix_prompt, template, "t", "p", check, "work/1", ".")
   assert(ok, "should not crash with % in check feedback, got: " .. tostring(result))
   print("✓ build_fix_prompt handles % in check feedback")
 end
@@ -241,5 +242,73 @@ local function test_fix_prompt_uses_fix_directory()
   print("✓ fix.md prompt writes to o/work/fix/ directory")
 end
 test_fix_prompt_uses_fix_directory()
+
+-- Test build_do_prompt includes repo_root
+local function test_do_prompt_includes_repo_root()
+  local template = "Root: {repo_root}\nTitle: {title}\nPlan:\n{plan.md contents}\nBranch: {branch}"
+  local result = prompt.build_do_prompt(template, "fix thing", "the plan", "work/42", "/home/runner/work/ah/ah")
+  assert(result:find("/home/runner/work/ah/ah", 1, true),
+    "build_do_prompt should interpolate repo_root, got: " .. result)
+  print("✓ build_do_prompt interpolates repo_root")
+end
+test_do_prompt_includes_repo_root()
+
+-- Test build_fix_prompt includes repo_root
+local function test_fix_prompt_includes_repo_root()
+  local template = "Root: {repo_root}\nTitle: {title}\nPlan:\n{plan.md contents}\nFeedback:\n{check.md contents}\nBranch: {branch}"
+  local result = prompt.build_fix_prompt(template, "fix docs", "the plan", "model name is wrong", "work/79", "/srv/repo")
+  assert(result:find("/srv/repo", 1, true),
+    "build_fix_prompt should interpolate repo_root, got: " .. result)
+  print("✓ build_fix_prompt interpolates repo_root")
+end
+test_fix_prompt_includes_repo_root()
+
+-- Test build_plan_prompt exists and interpolates repo_root
+local function test_plan_prompt_includes_repo_root()
+  local template = "Root: {repo_root}\nIssue: {title}\n\n{body}"
+  local result = prompt.build_plan_prompt(template, "fix bug", "details here", "/workspace")
+  assert(result:find("/workspace", 1, true),
+    "build_plan_prompt should interpolate repo_root, got: " .. result)
+  assert(result:find("fix bug", 1, true),
+    "build_plan_prompt should interpolate title, got: " .. result)
+  print("✓ build_plan_prompt interpolates repo_root, title, body")
+end
+test_plan_prompt_includes_repo_root()
+
+-- Test do.md skill prompt contains {repo_root} placeholder
+local function test_do_skill_has_repo_root()
+  local f = io.open("sys/skills/do.md", "r")
+  assert(f, "should be able to read sys/skills/do.md")
+  local content = f:read("*a")
+  f:close()
+  assert(content:find("{repo_root}", 1, true),
+    "do.md should contain {repo_root} placeholder")
+  print("✓ do.md skill prompt contains {repo_root} placeholder")
+end
+test_do_skill_has_repo_root()
+
+-- Test plan.md skill prompt contains {repo_root} placeholder
+local function test_plan_skill_has_repo_root()
+  local f = io.open("sys/skills/plan.md", "r")
+  assert(f, "should be able to read sys/skills/plan.md")
+  local content = f:read("*a")
+  f:close()
+  assert(content:find("{repo_root}", 1, true),
+    "plan.md should contain {repo_root} placeholder")
+  print("✓ plan.md skill prompt contains {repo_root} placeholder")
+end
+test_plan_skill_has_repo_root()
+
+-- Test fix.md skill prompt contains {repo_root} placeholder
+local function test_fix_skill_has_repo_root()
+  local f = io.open("sys/skills/fix.md", "r")
+  assert(f, "should be able to read sys/skills/fix.md")
+  local content = f:read("*a")
+  f:close()
+  assert(content:find("{repo_root}", 1, true),
+    "fix.md should contain {repo_root} placeholder")
+  print("✓ fix.md skill prompt contains {repo_root} placeholder")
+end
+test_fix_skill_has_repo_root()
 
 print("\nAll work-prompt tests passed!")

--- a/sys/skills/do.md
+++ b/sys/skills/do.md
@@ -7,6 +7,10 @@ description: Execute a work plan. Create branch, make changes, run validation, c
 
 You are executing a work item. Follow the plan below.
 
+## Environment
+
+- Working directory: `{repo_root}`
+
 ## Plan
 
 {plan.md contents}

--- a/sys/skills/fix.md
+++ b/sys/skills/fix.md
@@ -7,6 +7,10 @@ description: Fix issues found during review. Address check feedback, re-validate
 
 You are fixing issues found during review. Follow the plan and address the feedback below.
 
+## Environment
+
+- Working directory: `{repo_root}`
+
 ## Plan
 
 {plan.md contents}

--- a/sys/skills/plan.md
+++ b/sys/skills/plan.md
@@ -7,6 +7,11 @@ description: Plan a work item. Research the codebase, identify goals and entry p
 
 You are planning a work item. Research the codebase and write a plan.
 
+## Environment
+
+- Working directory: `{repo_root}`
+- Only paths under the working directory are accessible.
+
 ## Issue
 
 **{title}**


### PR DESCRIPTION
## Problem

Agents in sandbox phases (plan, do, fix) guess the working directory, wasting tool calls on wrong paths. In run [22007300813](https://github.com/whilp/ah/actions/runs/22007300813/job/63593819983):

- **do agent** tried `cd /home/ah` 3 times before discovering the actual path `/home/runner/work/ah/ah` via `pwd`
- **plan agent** tried `ls /zip/...` and `ls /` — 3 wasted calls due to sandbox filesystem restrictions

## Fix

- Add `{repo_root}` placeholder to `plan.md`, `do.md`, `fix.md` skill prompts
- Add `repo_root` param to `build_do_prompt`, `build_fix_prompt`, new `build_plan_prompt`  
- Inject `unix.getcwd()` in `phase_plan`, `phase_do`, `phase_fix`
- `plan.md` also notes that only paths under cwd are accessible

## Testing

- 6 new tests for repo_root interpolation and skill prompt placeholders
- All 28 tests pass, all 48 type checks pass (`make ci`)
- Red-green TDD: tests written first, verified failing, then made green

## Evidence from run

```
do/session.db errors:
  cd /home/ah && git checkout -b work/97-remove-friction-md origin/main → exit code 1
  cd /home/ah && git branch -a → exit code 1  
  cd /home/ah && git branch -a 2>&1 → exit code 1

plan/session.db errors:
  ls -la /zip/embed/sys/skills/ → exit code 2
  ls -la / → exit code 2
  ls / → exit code 2
```

closes #135, closes #166, closes #167