### PR TITLE
do phase: commit incrementally and recover partial progress

### DIFF
--- a/lib/ah/work/init.tl
+++ b/lib/ah/work/init.tl
@@ -260,12 +260,21 @@ local function phase_do(no_sandbox: boolean, title: string, number: string, mode
   local friction = prompt.make_friction_prompt("o/work/do")
   local ok = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/do/session.db", {"o/work/plan"}, friction, sandbox.do_limits, model)
 
+  -- Always write branch.txt so push phase can find the branch
+  util.write_file("o/work/do/branch.txt", branch .. "\n")
+
+  -- Check for partial progress even if agent failed.
+  -- With incremental commits, the branch may have useful commits
+  -- even when the agent hits a transport error or timeout.
   if not ok then
+    local has_commits = util.run({"git", "log", "--oneline", "origin/main..HEAD", "--max-count=1"})
+    if has_commits then
+      util.log("do agent exited non-zero but branch has commits ahead of main, treating as partial success")
+      return 0
+    end
     io.stderr:write("error: do agent failed\n")
     return 1
   end
-
-  util.write_file("o/work/do/branch.txt", branch .. "\n")
 
   return 0
 end

--- a/sys/skills/do.md
+++ b/sys/skills/do.md
@@ -18,10 +18,12 @@ You are executing a work item. Follow the plan below.
 ## Instructions
 
 1. Create the feature branch: `git checkout -b {branch} origin/main`
-2. Make the changes described in the plan
+2. For each step in the plan:
+   a. Make the changes for that step
+   b. Stage the specific files changed (not `git add -A`)
+   c. Commit with a descriptive message for that step
 3. Run validation steps from the plan
-4. Stage specific files (not `git add -A`)
-5. Commit with the message from the plan
+4. If validation requires fixes, stage and commit them
 
 ## Output
 


### PR DESCRIPTION
## Problem

When the do agent hits a transport error mid-execution, all progress is lost. The agent exits with code 1 and `phase_do` returns failure — even if substantial work was completed via tool calls.

## Changes

Two changes to survive transport errors during the do phase:

### 1. Incremental commits in do.md skill

Changed the agent instructions from a single final commit to incremental commits per plan step:

```
1. Create the feature branch
2. For each step in the plan:
   a. Make the changes for that step
   b. Stage the specific files changed (not git add -A)
   c. Commit with a descriptive message for that step
3. Run validation steps from the plan
4. If validation requires fixes, stage and commit them
```

This ensures partial work survives if the agent dies mid-execution.

### 2. Partial progress recovery in phase_do

`phase_do` now mirrors the existing `phase_plan` recovery pattern:
- Always writes `branch.txt` before checking agent exit status (so push phase can find the branch)
- If the agent exits non-zero but the branch has commits ahead of main, treats it as partial success instead of total failure

## Validation

All 28 tests pass.

Closes #169