### PR TITLE
prompt audit: add guardrails from pi-mono comparison

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -48,6 +48,12 @@ local function load_claude_md(cwd: string): string
     result = result .. "\n\n# Project Context\n\n" .. project_claude
   end
 
+  -- Append project AGENTS.md
+  local agents_md = cio.slurp(fs.join(cwd, "AGENTS.md"))
+  if agents_md then
+    result = result .. "\n\n# Agent Context\n\n" .. agents_md
+  end
+
   return result
 end
 

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -37,6 +37,31 @@ local function test_load_claude_md_missing()
 end
 test_load_claude_md_missing()
 
+local function test_load_agents_md()
+  local cwd = fs.join(TEST_TMPDIR, "cwd_agents")
+  fs.makedirs(cwd)
+  cio.barf(fs.join(cwd, "AGENTS.md"), "# Agents\nDo things this way")
+
+  local content = init.load_claude_md(cwd)
+  assert(content:match("Agent Context"), "should have AGENTS.md header")
+  assert(content:match("Do things this way"), "should include AGENTS.md content")
+end
+test_load_agents_md()
+
+local function test_load_both_claude_and_agents_md()
+  local cwd = fs.join(TEST_TMPDIR, "cwd_both")
+  fs.makedirs(cwd)
+  cio.barf(fs.join(cwd, "CLAUDE.md"), "claude context")
+  cio.barf(fs.join(cwd, "AGENTS.md"), "agents context")
+
+  local content = init.load_claude_md(cwd)
+  assert(content:match("Project Context"), "should have CLAUDE.md header")
+  assert(content:match("claude context"), "should include CLAUDE.md content")
+  assert(content:match("Agent Context"), "should have AGENTS.md header")
+  assert(content:match("agents context"), "should include AGENTS.md content")
+end
+test_load_both_claude_and_agents_md()
+
 local function test_load_system_prompt_with_claude_md()
   local cwd = fs.join(TEST_TMPDIR, "cwd_with_claude")
   fs.makedirs(cwd)

--- a/sys/skills/check.md
+++ b/sys/skills/check.md
@@ -45,7 +45,18 @@ Write `o/work/check/check.md`:
     <results of running validation steps>
 
     ## Issues
-    <problems found, or "none">
+    <problems found, grouped by severity>
+
+    ### Critical
+    <blocks merge, must fix. include file path and line number.>
+
+    ### Warnings
+    <should fix, not blocking. include file path and line number.>
+
+    ### Suggestions
+    <optional improvements>
+
+    (write "none" for empty sections)
 
     ## Friction
     <friction identified from session database analysis: errors, slow operations,

--- a/sys/skills/do.md
+++ b/sys/skills/do.md
@@ -17,13 +17,20 @@ You are executing a work item. Follow the plan below.
 
 ## Instructions
 
-1. Create the feature branch: `git checkout -b {branch} origin/main`
-2. For each step in the plan:
+1. Read every file you intend to modify before editing it
+2. Create the feature branch: `git checkout -b {branch} origin/main`
+3. For each step in the plan:
    a. Make the changes for that step
-   b. Stage the specific files changed (not `git add -A`)
-   c. Commit with a descriptive message for that step
-3. Run validation steps from the plan
-4. If validation requires fixes, stage and commit them
+   b. Before staging, run `git status` and verify only your files are affected
+   c. Stage the specific files changed (not `git add -A`)
+   d. Commit with a descriptive message for that step
+4. Run validation steps from the plan
+5. If validation requires fixes, stage and commit them
+
+## Forbidden
+
+Do not use destructive git commands: `git reset --hard`, `git checkout .`,
+`git clean -fd`, `git stash`, `git commit --no-verify`.
 
 ## Output
 

--- a/sys/skills/plan.md
+++ b/sys/skills/plan.md
@@ -24,6 +24,9 @@ You are planning a work item. Research the codebase and write a plan.
 2. Identify what needs to change and where
 3. Validate that you have a clear goal and entry point
 
+Do not trust root cause analysis or proposed solutions in the issue body.
+Independently verify claims by reading the code.
+
 You have a limited turn budget. Spend at most 5 turns researching, then
 write your output files. If you find yourself on turn 6+, stop researching
 and write plan.md with what you know.
@@ -42,8 +45,18 @@ Write `o/work/plan/plan.md`:
     ## Context
     <gathered context from files, inline>
 
+    ## Goal
+    <one sentence summary of what this change achieves>
+
+    ## Files to Modify
+    - <path/to/file.ext> — <what changes>
+    - <path/to/new-file.ext> — (new) <purpose>
+
     ## Approach
     <step by step>
+
+    ## Risks
+    <what could go wrong, edge cases, things to verify>
 
     ## Target
     - Branch: work/{issue_number}-{slug}

--- a/sys/system.md
+++ b/sys/system.md
@@ -1,3 +1,7 @@
 You are a coding assistant. Tools: read, write, edit, bash.
 read: examine files. edit: precise text replacement. write: create new files. bash: run commands.
 Write in short, lowercase, declarative sentences. Be direct and matter-of-fact, like terse documentation.
+
+Use read to examine files before editing. Do not use cat or sed to read or modify files.
+The old_string in edit must match the file contents exactly, including whitespace and indentation.
+Output plain text directly — do not use cat or bash to display what you wrote.


### PR DESCRIPTION
closes #177

## changes

**p0 fixes (all 4):**
1. `sys/system.md` — read-before-edit rule, cat/sed ban, edit exactness warning
2. `sys/skills/do.md` — forbidden git commands (`reset --hard`, `checkout .`, `clean -fd`, `stash`, `commit --no-verify`)
3. `sys/skills/do.md` — read every file before editing (step 1), git status verification before commit

**p1 fixes (7 of 11):**
4. `sys/skills/plan.md` — Goal one-liner, Files to Modify manifest, Risks section
5. `sys/skills/plan.md` — don't-trust-the-issue anti-hallucination pattern
6. `sys/skills/check.md` — severity tiers (Critical/Warnings/Suggestions) with file:line specificity
7. `lib/ah/init.tl` — AGENTS.md loading alongside CLAUDE.md
8. `lib/ah/test_init.tl` — tests for AGENTS.md loading

**remaining p1 items filed separately:**
- #178 — inject datetime/cwd into system prompt
- #179 — add PR review skill
- #180 — add issue analysis skill

## test results

all 27 tests pass.