### PR TITLE
inject datetime, cwd, and git context into system prompt

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -57,6 +57,38 @@ local function load_claude_md(cwd: string): string
   return result
 end
 
+local child = require("cosmic.child")
+
+-- Run a git command in cwd with a 2s timeout. Returns trimmed stdout or nil.
+-- Never throws. Any failure (not a repo, git missing, timeout, bad exit) returns nil.
+local function git_cmd(cwd: string, ...: string): string
+  local argv: {string} = {"timeout", "2", "git"}
+  for i = 1, select("#", ...) do
+    argv[#argv + 1] = select(i, ...) as string
+  end
+  local ok, result = pcall(function(): string
+    local h, err = child.spawn(argv, {cwd = cwd})
+    if not h then return nil end
+    local success, stdout, _ = h:read()
+    if not success then return nil end
+    local out = (stdout as string) or ""
+    if out == "" then return nil end
+    return (out:gsub("%s+$", ""))
+  end)
+  if not ok then return nil end
+  return result
+end
+
+-- Gather git context for the working directory. Each value is nil
+-- when the command fails (not a git repo, git not installed, timeout).
+local function git_context(cwd: string): {string:string}
+  return {
+    branch  = git_cmd(cwd, "rev-parse", "--abbrev-ref", "HEAD"),
+    commit  = git_cmd(cwd, "rev-parse", "--short", "HEAD"),
+    remote  = git_cmd(cwd, "remote", "get-url", "origin"),
+  }
+end
+
 -- Load system prompt with precedence:
 -- 1. /zip/embed/system.md (user override)
 -- 2. /zip/embed/sys/system.md (ah default)
@@ -78,9 +110,20 @@ local function load_system_prompt(cwd: string): string
     end
   end
 
-  -- Append runtime context (datetime and working directory)
+  -- Append runtime context (datetime, working directory, git info)
   local date_str = os.date("!%Y-%m-%dT%H:%M:%SZ") as string
   base = base .. "\n\nCurrent date: " .. date_str .. "\nWorking directory: " .. cwd
+
+  local git = git_context(cwd)
+  if git.branch then
+    base = base .. "\nGit branch: " .. git.branch
+  end
+  if git.commit then
+    base = base .. "\nGit commit: " .. git.commit
+  end
+  if git.remote then
+    base = base .. "\nGit remote: " .. git.remote
+  end
 
   return base
 end

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -9,12 +9,14 @@ local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
 
 local function test_load_system_prompt_default()
   -- No files exist, should still contain runtime context (datetime and cwd)
+  -- but no git info (not a git repo)
   local empty_dir = fs.join(TEST_TMPDIR, "empty")
   fs.makedirs(empty_dir)
 
   local prompt = init.load_system_prompt(empty_dir)
   assert(prompt:match("Current date: %d%d%d%d%-%d%d%-%d%d"), "should contain current date")
   assert(prompt:match("Working directory: "), "should contain working directory")
+  assert(not prompt:match("Git branch:"), "should not contain git branch in non-repo dir")
 end
 test_load_system_prompt_default()
 


### PR DESCRIPTION
Appends runtime context to the end of the system prompt:

```
Current date: 2025-07-14T19:32:00Z
Working directory: /home/user/project
Git branch: main
Git commit: abc1234
Git remote: https://github.com/owner/repo
```

- datetime helps with time-sensitive tasks (log filtering, recency checks)
- cwd grounds file path reasoning
- git branch/commit/remote saves tool calls and prevents branch confusion

git commands use `child.spawn` with `timeout 2`, wrapped in `pcall`. any failure (not a repo, git missing, timeout, bad exit) silently omits that field. no shell quoting needed since `child.spawn` takes an argv array with `cwd` option.

Closes #178