### PR TITLE
fix: atomic binary writes and bump cosmic to 2026-02-14-bbc4d7b

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ TMP ?= /tmp
 export TMPDIR := $(TMP)
 
 # cosmic dependency
-cosmic_version := 2026-02-13-5f7b857
+cosmic_version := 2026-02-14-bbc4d7b
 cosmic_url := https://github.com/whilp/cosmic/releases/download/$(cosmic_version)/cosmic-lua
-cosmic_sha := 2ef4e697c34f6ce9ed81ce98d9ab8df4407955922c08bd0cc994bdfd171c398c
+cosmic_sha := beef0b672272de763d620c2d333f0690c883bb7dd464cdde6d55bae8a7ccbdab
 cosmic := $(o)/bin/cosmic
 
 .PHONY: cosmic
@@ -31,7 +31,7 @@ $(cosmic):
 
 # cosmic-debug dependency (with debug symbols)
 cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/$(cosmic_version)/cosmic-lua-debug
-cosmic_debug_sha := d722747849d4409cfd613ab96ffccb1f62086c17b95d092c8ffafd8d9692dfc5
+cosmic_debug_sha := bf76b446a87116d874b02fde3a6ccfc9e32f353989c051b1d4cc7803a3a321cd
 cosmic_debug := $(o)/bin/cosmic-debug
 
 .PHONY: cosmic-debug
@@ -119,7 +119,7 @@ ah_sys := $(patsubst sys/%,$(o)/embed/embed/sys/%,$(ah_sys_files))
 
 $(o)/bin/ah: $(o)/embed/main.lua $(ah_lib_lua) $(ah_dep_lua) $(ah_sys) $(cosmic)
 	@echo "==> embedding ah"
-	@$(cosmic) --embed $(o)/embed --output $@
+	@$(cosmic) --embed $(o)/embed --output $@.tmp && mv $@.tmp $@
 
 .PHONY: ah
 ## Build ah executable archive
@@ -127,7 +127,7 @@ ah: $(o)/bin/ah
 
 $(o)/bin/ah-debug: $(o)/embed/main.lua $(ah_lib_lua) $(ah_dep_lua) $(ah_sys) $(cosmic_debug)
 	@echo "==> embedding ah-debug"
-	@$(cosmic_debug) --embed $(o)/embed --output $@
+	@$(cosmic_debug) --embed $(o)/embed --output $@.tmp && mv $@.tmp $@
 
 .PHONY: ah-debug
 ## Build ah executable archive with debug symbols


### PR DESCRIPTION
## Problem

The APE loader mmaps code pages from the executable file using `MAP_PRIVATE`. When the agent rebuilds itself (`make ah-debug` while running), the embed command overwrites the file in place, corrupting the mmapped pages and causing SIGSEGV (signal 11). This was observed as a core dump with ~20,000 recursive stack frames — the corrupted code pages turned the Lua VM's threaded dispatch into an infinite loop that exhausted the 8MB stack.

## Fix

Two layers:

1. **Bump cosmic to `2026-02-14-bbc4d7b`** — includes [whilp/cosmic#221](https://github.com/whilp/cosmic/pull/221) which makes `--embed --output` use `mkstemp` + `rename` internally, so the output is always written atomically.

2. **Makefile defense-in-depth** — embed rules write to `$@.tmp` then `mv $@.tmp $@`, so even with an older cosmic binary the running process keeps its old inode.

`rename()` on the same filesystem is atomic — the old inode (with the running process's pages) stays valid until the process exits.

## Validation

- `make test`: 27/27 pass
- `make check-types`: 47/47 pass
- `make ah ah-debug`: builds successfully with new cosmic