### PR TITLE
triage skill: add issue refinement step

### DIFF
--- a/sys/skills/triage-issues.md
+++ b/sys/skills/triage-issues.md
@@ -1,11 +1,12 @@
 ---
 name: triage-issues
-description: Triage open GitHub issues. Assess priority, deduplicate, label, and close stale issues.
+description: Triage open GitHub issues. Assess priority, deduplicate, label, close stale issues, and refine underspecified issues.
 ---
 
 # triage-issues
 
-Triage open issues in the repo. Assess priority, deduplicate, and apply labels.
+Triage open issues in the repo. Assess priority, deduplicate, apply labels,
+and refine underspecified issues.
 
 ## Usage
 
@@ -34,6 +35,8 @@ Triage open issues in the repo. Assess priority, deduplicate, and apply labels.
    - **duplicates**: does it overlap with another open issue?
    - **staleness**: is it outdated or already resolved by recent changes?
    - **labels**: which labels should be added or removed?
+   - **specificity**: is the body detailed enough to act on? does it identify
+     files, functions, root causes, and a concrete approach?
 
 4. **Check for duplicates** by reading bodies of related issues:
    ```bash
@@ -55,6 +58,24 @@ Triage open issues in the repo. Assess priority, deduplicate, and apply labels.
    gh issue edit <number> --add-label "needs-investigation"
    ```
 
+6. **Refine one underspecified issue** — pick the thinnest issue (shortest
+   body, fewest details) that is still open and actionable. Research the
+   codebase to fill in specifics, then update it:
+
+   - read the source files referenced or implied by the issue
+   - identify the current state: what exists, what code paths are involved,
+     exact file paths and line numbers
+   - write a concrete proposed approach with files to modify
+   - add constraints, edge cases, and relationships to other issues
+   - update the issue body:
+     ```bash
+     gh issue edit <number> --body "<refined body>"
+     ```
+   - add appropriate labels if missing
+
+   Do only one issue per triage run. Prefer issues that are labeled `todo`
+   (the work loop will pick them up) but have bodies too vague to act on.
+
 ## Priority criteria
 
 - **p0**: blocks the work workflow, causes data loss, or breaks core functionality
@@ -73,9 +94,11 @@ Print a triage summary table:
 |---|-------|--------|--------|
 | 97 | friction: remove per-phase friction.md | keep p0 | blocks workflow improvement |
 | 140 | friction: sandbox blocks bash | close duplicate | same root cause as #135 |
+| 55 | support session name aliases | refine | body lacks file paths and approach |
 ```
 
-Then list all actions taken (labels applied, issues closed, comments added).
+Then list all actions taken (labels applied, issues closed, comments added,
+issues refined).
 
 ## Rules
 


### PR DESCRIPTION
After triaging, the skill now picks the thinnest underspecified issue and refines it with codebase research — one per run.

Changes to `sys/skills/triage-issues.md`:
- **step 3**: added specificity assessment criterion
- **step 6** (new): refine one underspecified issue per triage run — research codebase, fill in file paths/line numbers/approach, update the issue body
- **output**: added `refine` action type to summary table

Scoped to one issue per run to keep triage bounded.