### PR TITLE
feat: add --sandbox, --timeout, --allow-host, --unveil CLI flags

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -237,6 +237,10 @@ options:
   --steer MSG         send steering message to running session
   --followup MSG      queue followup message for after session completes
   --max-tokens N      stop when cumulative tokens exceed N
+  --sandbox           run inside network sandbox (proxy + unveil + pledge)
+  --timeout N         wall-clock timeout in seconds
+  --allow-host H:P    allow egress to host:port (repeatable, default: api.anthropic.com:443)
+  --unveil PATH:PERM  set filesystem visibility (repeatable, perms: r/w/x/c)
 
 models:
 ]])
@@ -781,12 +785,19 @@ local record ParsedArgs
   steer_msg: string
   followup_msg: string
   max_tokens: integer
+  sandbox: boolean
+  timeout: integer
+  allow_hosts: {string}
+  unveil_dirs: {string}
   remaining: {string}
 end
 
 local function parse_args(args: {string}): ParsedArgs, string
   local result: ParsedArgs = {
     new_session = false,
+    sandbox = false,
+    allow_hosts = {},
+    unveil_dirs = {},
     remaining = {},
   }
 
@@ -800,6 +811,10 @@ local function parse_args(args: {string}): ParsedArgs, string
     {name = "steer", has_arg = "required"},
     {name = "followup", has_arg = "required"},
     {name = "max-tokens", has_arg = "required"},
+    {name = "sandbox", has_arg = "none"},
+    {name = "timeout", has_arg = "required"},
+    {name = "allow-host", has_arg = "required"},
+    {name = "unveil", has_arg = "required"},
   }
 
   -- Use + prefix for POSIX mode: stop parsing options at first non-option arg.
@@ -829,6 +844,14 @@ local function parse_args(args: {string}): ParsedArgs, string
       result.followup_msg = optarg
     elseif opt == "max-tokens" then
       result.max_tokens = tonumber(optarg) as integer
+    elseif opt == "sandbox" then
+      result.sandbox = true
+    elseif opt == "timeout" then
+      result.timeout = tonumber(optarg) as integer
+    elseif opt == "allow-host" then
+      table.insert(result.allow_hosts, optarg)
+    elseif opt == "unveil" then
+      table.insert(result.unveil_dirs, optarg)
     elseif opt == "?" then
       return nil, "unknown"
     end
@@ -849,13 +872,64 @@ local function parse_protect_dirs(value: string): {string}
   return dirs
 end
 
+-- Parse an --unveil entry: "path:perms" or just "path" (defaults to "r").
+-- Returns path, perms.
+local function parse_unveil_entry(entry: string): string, string
+  local path, perms = entry:match("^(.+):([rwxc]+)$")
+  if path and perms then
+    return path, perms
+  end
+  -- No perms suffix, default to read-only
+  return entry, "r"
+end
+
+-- Record types for sandbox supervisor mode (lazy-loaded modules)
+local record SandboxCtx
+  enabled: boolean
+  socket_path: string
+  proxy_pid: number
+  tmpdir: string
+end
+
+local record WorkSandboxMod
+  start_sandbox: function(): SandboxCtx, string
+  stop_sandbox: function(SandboxCtx)
+end
+
+local record WorkUtilMod
+  ah_exe: function(): string
+  setup_git_env: function({string})
+  env_set: function({string}, string, string)
+end
+
+local record EnvMod
+  all: function(): {string}
+end
+
+local record FetchMod
+  unix_proxy: function(string): string, string
+end
+
+local record ChildMod
+  spawn: function({string}, {string:any}): ChildHandle, string
+end
+
+local record ChildHandle
+  stderr: StderrHandle
+  read: function(ChildHandle): boolean, string, string
+end
+
+local record StderrHandle
+  read: function(StderrHandle): string
+end
+
 local function main(args: {string}): integer, string
   -- Enable core dumps for crash debugging
   -- RLIMIT_CORE = 4 on Linux, RLIM_INFINITY = -1
   unix.setrlimit(4, -1, -1)
 
   -- Sandbox mode: when AH_SANDBOX=1, restrict capabilities
-  -- Used by work.tl to run ah with limited network access
+  -- Used by work.tl and --sandbox flag to run ah with limited network access
   if os.getenv("AH_SANDBOX") then
     -- Unveil: restrict filesystem visibility
     local cwd_for_unveil = fs.getcwd()
@@ -864,6 +938,18 @@ local function main(args: {string}): integer, string
     local protect = parse_protect_dirs(os.getenv("AH_PROTECT_DIRS"))
     for _, dir in ipairs(protect) do
       sandbox.unveil(cwd_for_unveil .. "/" .. dir, "r")
+    end
+    -- Custom unveil entries from AH_UNVEIL (comma-separated path:perms)
+    local unveil_env = os.getenv("AH_UNVEIL")
+    if unveil_env then
+      for entry in unveil_env:gmatch("[^,]+") do
+        local u_path, u_perms = parse_unveil_entry(entry)
+        if u_path:sub(1, 1) == "/" then
+          sandbox.unveil(u_path, u_perms)
+        else
+          sandbox.unveil(cwd_for_unveil .. "/" .. u_path, u_perms)
+        end
+      end
     end
     sandbox.unveil("/tmp", "rwxc")           -- proxy socket, temp files, APE binaries
     sandbox.unveil("/usr", "rx")             -- system binaries
@@ -916,6 +1002,112 @@ local function main(args: {string}): integer, string
   local followup_msg = parsed.followup_msg
   local max_tokens = parsed.max_tokens
   local remaining = parsed.remaining
+
+  -- Supervisor mode: --sandbox starts proxy, re-execs as sandboxed child
+  if parsed.sandbox then
+    local work_sandbox = require("ah.work.sandbox") as WorkSandboxMod
+    local work_util = require("ah.work.util") as WorkUtilMod
+    local env_mod = require("cosmic.env") as EnvMod
+    local fetch = require("cosmic.fetch") as FetchMod
+
+    local ctx, sbox_err = work_sandbox.start_sandbox()
+    if not ctx then
+      io.stderr:write("error: sandbox failed to start: " .. (sbox_err or "unknown") .. "\n")
+      return 1
+    end
+    io.stderr:write("[sandbox] proxy started on " .. ctx.socket_path .. "\n")
+
+    -- Build child environment
+    local run_env: {string} = env_mod.all() as {string}
+    work_util.setup_git_env(run_env)
+
+    -- Set TMPDIR for APE binary extraction
+    work_util.env_set(run_env, "TMPDIR", ctx.tmpdir)
+
+    -- Proxy env vars
+    local proxy_url, proxy_err = fetch.unix_proxy(ctx.socket_path)
+    if not proxy_url then
+      io.stderr:write("[sandbox] invalid proxy path: " .. (proxy_err or "unknown") .. "\n")
+      work_sandbox.stop_sandbox(ctx)
+      return 1
+    end
+    work_util.env_set(run_env, "http_proxy", proxy_url)
+    work_util.env_set(run_env, "HTTP_PROXY", proxy_url)
+    work_util.env_set(run_env, "https_proxy", proxy_url)
+    work_util.env_set(run_env, "HTTPS_PROXY", proxy_url)
+    work_util.env_set(run_env, "AH_SANDBOX", "1")
+
+    -- Pass allow-host entries to proxy via env
+    if #parsed.allow_hosts > 0 then
+      work_util.env_set(run_env, "AH_ALLOW_HOSTS", table.concat(parsed.allow_hosts, ","))
+    end
+
+    -- Pass unveil entries to child via env
+    if #parsed.unveil_dirs > 0 then
+      work_util.env_set(run_env, "AH_UNVEIL", table.concat(parsed.unveil_dirs, ","))
+    end
+
+    -- Build child argv: strip sandbox-related flags, keep everything else
+    local child_args: {string} = {}
+    local exe = work_util.ah_exe()
+
+    -- Add timeout wrapper if specified
+    if parsed.timeout and parsed.timeout > 0 then
+      table.insert(child_args, "timeout")
+      table.insert(child_args, tostring(parsed.timeout))
+    end
+
+    table.insert(child_args, exe)
+
+    -- Rebuild args without --sandbox, --timeout, --allow-host, --unveil
+    local i = 1
+    while i <= #args do
+      local a = args[i]
+      if a == "--sandbox" then
+        -- skip
+      elseif a == "--timeout" then
+        i = i + 1  -- skip value too
+      elseif a == "--allow-host" then
+        i = i + 1  -- skip value too
+      elseif a == "--unveil" then
+        i = i + 1  -- skip value too
+      else
+        table.insert(child_args, a)
+      end
+      i = i + 1
+    end
+
+    -- Spawn child and wait
+    local child_mod = require("cosmic.child") as ChildMod
+    io.stderr:write("[sandbox] spawning child: " .. table.concat(child_args, " ") .. "\n")
+    local handle, spawn_err = child_mod.spawn(child_args, {env = run_env})
+    if not handle then
+      io.stderr:write("error: failed to spawn sandboxed child: " .. (spawn_err or "unknown") .. "\n")
+      work_sandbox.stop_sandbox(ctx)
+      return 1
+    end
+
+    local stderr_out = handle.stderr:read()
+    local ok, stdout, exit_str = handle:read()
+    local exit_code = (tonumber(exit_str) or 0) as integer
+
+    -- Forward child output
+    if stdout and stdout ~= "" then
+      io.write(stdout)
+    end
+    if stderr_out and stderr_out ~= "" then
+      io.stderr:write(stderr_out)
+    end
+
+    -- Cleanup
+    io.stderr:write("[sandbox] stopping proxy\n")
+    work_sandbox.stop_sandbox(ctx)
+
+    if not ok or exit_code ~= 0 then
+      return exit_code ~= 0 and exit_code or 1
+    end
+    return 0
+  end
 
   -- Handle commands that don't need db
   local cmd = remaining[1]
@@ -1375,4 +1567,5 @@ return {
   cmd_branch_rm = cmd_branch_rm,
   cmd_diff = cmd_diff,
   parse_protect_dirs = parse_protect_dirs,
+  parse_unveil_entry = parse_unveil_entry,
 }

--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -10,11 +10,35 @@ local record M
   parse_connect: function(string): string, string
   resolvehost: function(string): string
   is_allowed: function(string): boolean
+  parse_allow_hosts: function(string): {string:boolean}
 end
 
 local ALLOWLIST: {string:boolean} = {
   ["api.anthropic.com:443"] = true,
 }
+
+-- Parse AH_ALLOW_HOSTS env var: comma-separated host:port entries.
+-- Returns a table of host:port -> true. Trims whitespace.
+local function parse_allow_hosts(value: string): {string:boolean}
+  local hosts: {string:boolean} = {}
+  if not value or value == "" then return hosts end
+  for entry in value:gmatch("[^,]+") do
+    local trimmed = entry:match("^%s*(.-)%s*$")
+    if trimmed and #trimmed > 0 then
+      hosts[trimmed] = true
+    end
+  end
+  return hosts
+end
+
+-- Merge AH_ALLOW_HOSTS into the allowlist at load time
+local allow_hosts_env = os.getenv("AH_ALLOW_HOSTS")
+if allow_hosts_env then
+  local extra = parse_allow_hosts(allow_hosts_env)
+  for host, _ in pairs(extra) do
+    ALLOWLIST[host] = true
+  end
+end
 
 -- DNS: hardcoded for known allowlist entries.
 -- TODO: resolve dynamically via net.getaddrinfo once cosmic exposes it,
@@ -194,5 +218,6 @@ M.resolvehost = resolvehost
 M.is_allowed = function(dest: string): boolean
   return ALLOWLIST[dest] or false
 end
+M.parse_allow_hosts = parse_allow_hosts
 
 return M

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -297,4 +297,143 @@ local function test_parse_protect_dirs_empty()
 end
 test_parse_protect_dirs_empty()
 
+-- Sandbox CLI flag parsing tests
+
+local function test_parse_args_sandbox()
+  local parsed = init.parse_args({"--sandbox", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.sandbox == true, "sandbox should be true")
+  assert(parsed.remaining[1] == "hello", "prompt should be in remaining")
+  print("✓ parse_args: --sandbox flag")
+end
+test_parse_args_sandbox()
+
+local function test_parse_args_timeout()
+  local parsed = init.parse_args({"--timeout", "300", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.timeout == 300, "timeout should be 300, got: " .. tostring(parsed.timeout))
+  assert(parsed.remaining[1] == "hello", "prompt should be in remaining")
+  print("✓ parse_args: --timeout flag")
+end
+test_parse_args_timeout()
+
+local function test_parse_args_allow_host_single()
+  local parsed = init.parse_args({"--allow-host", "api.example.com:443", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.allow_hosts, "allow_hosts should be set")
+  assert(#parsed.allow_hosts == 1, "should have 1 host, got: " .. #parsed.allow_hosts)
+  assert(parsed.allow_hosts[1] == "api.example.com:443", "host mismatch, got: " .. parsed.allow_hosts[1])
+  print("✓ parse_args: --allow-host single")
+end
+test_parse_args_allow_host_single()
+
+local function test_parse_args_allow_host_multiple()
+  local parsed = init.parse_args({"--allow-host", "api.example.com:443", "--allow-host", "hooks.slack.com:443", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(#parsed.allow_hosts == 2, "should have 2 hosts, got: " .. #parsed.allow_hosts)
+  assert(parsed.allow_hosts[1] == "api.example.com:443", "first host")
+  assert(parsed.allow_hosts[2] == "hooks.slack.com:443", "second host")
+  print("✓ parse_args: --allow-host multiple")
+end
+test_parse_args_allow_host_multiple()
+
+local function test_parse_args_unveil_single()
+  local parsed = init.parse_args({"--unveil", "o/work/plan:r", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.unveil_dirs, "unveil_dirs should be set")
+  assert(#parsed.unveil_dirs == 1, "should have 1 unveil, got: " .. #parsed.unveil_dirs)
+  assert(parsed.unveil_dirs[1] == "o/work/plan:r", "unveil mismatch, got: " .. parsed.unveil_dirs[1])
+  print("✓ parse_args: --unveil single")
+end
+test_parse_args_unveil_single()
+
+local function test_parse_args_unveil_multiple()
+  local parsed = init.parse_args({"--unveil", "o/work/plan:r", "--unveil", "o/work/do:rw", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(#parsed.unveil_dirs == 2, "should have 2 unveils, got: " .. #parsed.unveil_dirs)
+  assert(parsed.unveil_dirs[1] == "o/work/plan:r", "first unveil")
+  assert(parsed.unveil_dirs[2] == "o/work/do:rw", "second unveil")
+  print("✓ parse_args: --unveil multiple")
+end
+test_parse_args_unveil_multiple()
+
+local function test_parse_args_sandbox_combined()
+  local parsed = init.parse_args({
+    "--sandbox", "--timeout", "180",
+    "--allow-host", "hooks.slack.com:443",
+    "--unveil", "o/work/plan:r",
+    "-m", "opus", "--db", "test.db",
+    "do the thing"
+  })
+  assert(parsed, "should parse successfully")
+  assert(parsed.sandbox == true, "sandbox should be true")
+  assert(parsed.timeout == 180, "timeout should be 180")
+  assert(#parsed.allow_hosts == 1, "should have 1 allow-host")
+  assert(parsed.allow_hosts[1] == "hooks.slack.com:443", "allow-host value")
+  assert(#parsed.unveil_dirs == 1, "should have 1 unveil")
+  assert(parsed.unveil_dirs[1] == "o/work/plan:r", "unveil value")
+  assert(parsed.model == "opus", "model should be opus")
+  assert(parsed.db_path == "test.db", "db should be test.db")
+  assert(parsed.remaining[1] == "do the thing", "prompt in remaining")
+  print("✓ parse_args: --sandbox combined with all flags")
+end
+test_parse_args_sandbox_combined()
+
+local function test_parse_args_sandbox_with_work()
+  -- --sandbox before work subcommand shouldn't interfere
+  local parsed = init.parse_args({"--sandbox", "work", "--repo", "owner/repo"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.sandbox == true, "sandbox should be true")
+  assert(parsed.remaining[1] == "work", "work in remaining")
+  assert(parsed.remaining[2] == "--repo", "--repo in remaining")
+  assert(parsed.remaining[3] == "owner/repo", "repo value in remaining")
+  print("✓ parse_args: --sandbox with work subcommand")
+end
+test_parse_args_sandbox_with_work()
+
+local function test_parse_args_no_sandbox_defaults()
+  local parsed = init.parse_args({"hello"})
+  assert(parsed, "should parse successfully")
+  assert(not parsed.sandbox, "sandbox should be nil/false by default")
+  assert(not parsed.timeout, "timeout should be nil by default")
+  assert(not parsed.allow_hosts or #parsed.allow_hosts == 0, "allow_hosts should be empty by default")
+  assert(not parsed.unveil_dirs or #parsed.unveil_dirs == 0, "unveil_dirs should be empty by default")
+  print("✓ parse_args: sandbox flags absent by default")
+end
+test_parse_args_no_sandbox_defaults()
+
+-- parse_unveil helper tests
+
+local function test_parse_unveil_entry()
+  local path, perms = init.parse_unveil_entry("o/work/plan:r")
+  assert(path == "o/work/plan", "path should be o/work/plan, got: " .. tostring(path))
+  assert(perms == "r", "perms should be r, got: " .. tostring(perms))
+  print("✓ parse_unveil_entry: basic")
+end
+test_parse_unveil_entry()
+
+local function test_parse_unveil_entry_rw()
+  local path, perms = init.parse_unveil_entry("src:rwc")
+  assert(path == "src", "path should be src")
+  assert(perms == "rwc", "perms should be rwc, got: " .. tostring(perms))
+  print("✓ parse_unveil_entry: rwc perms")
+end
+test_parse_unveil_entry_rw()
+
+local function test_parse_unveil_entry_absolute()
+  local path, perms = init.parse_unveil_entry("/tmp:rwxc")
+  assert(path == "/tmp", "path should be /tmp")
+  assert(perms == "rwxc", "perms should be rwxc")
+  print("✓ parse_unveil_entry: absolute path")
+end
+test_parse_unveil_entry_absolute()
+
+local function test_parse_unveil_entry_no_perms()
+  local path, perms = init.parse_unveil_entry("o/work/plan")
+  assert(path == "o/work/plan", "path should be o/work/plan")
+  assert(perms == "r", "perms should default to r, got: " .. tostring(perms))
+  print("✓ parse_unveil_entry: defaults to r when no perms")
+end
+test_parse_unveil_entry_no_perms()
+
 print("all init tests passed")

--- a/lib/ah/test_proxy.tl
+++ b/lib/ah/test_proxy.tl
@@ -6,6 +6,7 @@ local record Proxy
   parse_connect: function(string): string, string
   resolvehost: function(string): string
   is_allowed: function(string): boolean
+  parse_allow_hosts: function(string): {string:boolean}
 end
 
 local proxy = require("ah.proxy") as Proxy
@@ -151,5 +152,46 @@ local function test_is_allowed_ip_literal()
   print("✓ is_allowed: blocks IP literal")
 end
 test_is_allowed_ip_literal()
+
+-- AH_ALLOW_HOSTS env var tests
+
+-- Test: parse_allow_hosts parses comma-separated host:port entries
+local function test_parse_allow_hosts_single()
+  local hosts = proxy.parse_allow_hosts("example.com:443")
+  assert(hosts["example.com:443"] == true, "should allow example.com:443")
+  print("✓ parse_allow_hosts: single host")
+end
+test_parse_allow_hosts_single()
+
+local function test_parse_allow_hosts_multiple()
+  local hosts = proxy.parse_allow_hosts("example.com:443,hooks.slack.com:443")
+  assert(hosts["example.com:443"] == true, "should allow example.com:443")
+  assert(hosts["hooks.slack.com:443"] == true, "should allow hooks.slack.com:443")
+  print("✓ parse_allow_hosts: multiple hosts")
+end
+test_parse_allow_hosts_multiple()
+
+local function test_parse_allow_hosts_empty()
+  local hosts = proxy.parse_allow_hosts("")
+  -- Should be empty (or nil-safe)
+  assert(not hosts["anything:443"], "empty string should produce no hosts")
+  print("✓ parse_allow_hosts: empty string")
+end
+test_parse_allow_hosts_empty()
+
+local function test_parse_allow_hosts_nil()
+  local hosts = proxy.parse_allow_hosts(nil)
+  assert(not hosts["anything:443"], "nil should produce no hosts")
+  print("✓ parse_allow_hosts: nil")
+end
+test_parse_allow_hosts_nil()
+
+local function test_parse_allow_hosts_whitespace()
+  local hosts = proxy.parse_allow_hosts(" example.com:443 , hooks.slack.com:443 ")
+  assert(hosts["example.com:443"] == true, "should trim whitespace")
+  assert(hosts["hooks.slack.com:443"] == true, "should trim whitespace on second entry")
+  print("✓ parse_allow_hosts: trims whitespace")
+end
+test_parse_allow_hosts_whitespace()
 
 print("\nall proxy tests passed")

--- a/lib/ah/work/sandbox.tl
+++ b/lib/ah/work/sandbox.tl
@@ -254,4 +254,6 @@ return {
   fix_limits = fix_limits,
   sandboxed_agent = sandboxed_agent,
   build_agent_args = build_agent_args,
+  start_sandbox = start_sandbox,
+  stop_sandbox = stop_sandbox,
 }


### PR DESCRIPTION
## Summary

Expose sandbox proxy as CLI-level flags so any `ah` invocation can run with the same network isolation and filesystem restrictions that `ah work` provides. This makes the PDCA workflow expressible as a sequence of standalone `ah` commands in a shell script.

## New flags

| Flag | Description |
|------|-------------|
| `--sandbox` | Start proxy, re-exec as sandboxed child, tear down on exit |
| `--timeout N` | Wall-clock timeout in seconds (wraps child in `timeout(1)`) |
| `--allow-host host:port` | Allow egress to additional hosts (repeatable; `api.anthropic.com:443` always allowed) |
| `--unveil path:perms` | Set filesystem visibility (repeatable; perms: `r`/`w`/`x`/`c`) |

## How it works

`--sandbox` makes the current `ah` process a **supervisor**:
1. Starts the proxy (reuses `work.sandbox.start_sandbox()`)
2. Builds a child env with `AH_SANDBOX=1`, proxy URLs, `AH_ALLOW_HOSTS`, `AH_UNVEIL`
3. Strips sandbox flags from child argv, prepends `timeout` if `--timeout` set
4. Spawns child `ah`, forwards output, stops proxy on exit

The child process hits the existing `AH_SANDBOX` code path (unveil/pledge).

## Enables composable workflows

```bash
ah --sandbox --timeout 180 --db plan.db /skill:plan
ah --sandbox --timeout 300 --unveil o/work/plan:r --db do.db /skill:do
ah --sandbox --timeout 180 --unveil o/work/plan:r --unveil o/work/do:r --db check.db /skill:check
```

## Changes

- `lib/ah/init.tl` — arg parsing, supervisor mode, `AH_UNVEIL` support, `parse_unveil_entry()`
- `lib/ah/proxy.tl` — `parse_allow_hosts()`, `AH_ALLOW_HOSTS` env var
- `lib/ah/work/sandbox.tl` — export `start_sandbox`/`stop_sandbox`
- `lib/ah/test_init.tl` — 13 new tests
- `lib/ah/test_proxy.tl` — 5 new tests

## Validation

`make ci` — all 47 checks pass (27 test + 20 teal type checks).