### PR TITLE
refactor: use ah --sandbox CLI flags in work workflow

### DIFF
--- a/lib/ah/work/init.tl
+++ b/lib/ah/work/init.tl
@@ -100,14 +100,24 @@ local record PromptMod
   build_plan_prompt: function(string, string, string, string): string
 end
 
+local record PhaseOpts
+  sandbox: boolean
+  timeout: integer
+  unveil_dirs: {string}
+  db: string
+  prompt: string
+  max_tokens: integer
+  model: string
+end
+
 local record SandboxMod
   overall_timeout_sec: number
   plan_limits: AgentLimits
   do_limits: AgentLimits
   check_limits: AgentLimits
   fix_limits: AgentLimits
-  sandboxed_agent: function(boolean, string, string, {string}, string, AgentLimits, string): boolean, string, integer
-  build_agent_args: function(string, string, string, boolean, AgentLimits, string): {string}
+  run_phase: function(PhaseOpts): boolean, string, integer
+  build_phase_args: function(string, PhaseOpts): {string}
 end
 
 local util = require("ah.work.util") as Util
@@ -165,7 +175,14 @@ local function phase_plan(no_sandbox: boolean, repo: string, issue_number: integ
 
   util.log("plan prompt interpolated (" .. #tpl .. " bytes) for issue #" .. tostring(issue.number))
 
-  local ok = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/plan/session.db", nil, nil, sandbox.plan_limits, model)
+  local ok = sandbox.run_phase({
+    sandbox = not no_sandbox,
+    timeout = sandbox.plan_limits.timeout_sec,
+    db = "o/work/plan/session.db",
+    prompt = tpl,
+    max_tokens = sandbox.plan_limits.max_tokens,
+    model = model,
+  })
 
   -- Check if plan.md was created, regardless of agent exit status.
   -- The agent may have written plan.md in its final tool call but been
@@ -213,7 +230,15 @@ local function phase_do(no_sandbox: boolean, title: string, number: string, mode
 
   tpl = prompt.build_do_prompt(tpl, title, plan_contents, branch, unix.getcwd() or ".")
 
-  local ok = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/do/session.db", {"o/work/plan"}, nil, sandbox.do_limits, model)
+  local ok = sandbox.run_phase({
+    sandbox = not no_sandbox,
+    timeout = sandbox.do_limits.timeout_sec,
+    unveil_dirs = {"o/work/plan"},
+    db = "o/work/do/session.db",
+    prompt = tpl,
+    max_tokens = sandbox.do_limits.max_tokens,
+    model = model,
+  })
 
   -- Always write branch.txt so push phase can find the branch
   util.write_file("o/work/do/branch.txt", branch .. "\n")
@@ -312,7 +337,15 @@ local function phase_check(no_sandbox: boolean, model: string, do_dir: string): 
   -- Retry on crash signals (SIGSEGV, SIGBUS, etc.) up to 2 times
   local max_crash_retries = 2
   for attempt = 1, max_crash_retries + 1 do
-    local ok, _, exit_code = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/check/session.db", protect_dirs, nil, sandbox.check_limits, model)
+    local ok, _, exit_code = sandbox.run_phase({
+      sandbox = not no_sandbox,
+      timeout = sandbox.check_limits.timeout_sec,
+      unveil_dirs = protect_dirs,
+      db = "o/work/check/session.db",
+      prompt = tpl,
+      max_tokens = sandbox.check_limits.max_tokens,
+      model = model,
+    })
 
     if ok then
       return 0
@@ -512,7 +545,15 @@ local function phase_fix(no_sandbox: boolean, title: string, number: string, mod
 
   tpl = prompt.build_fix_prompt(tpl, title, plan_contents, check_contents, branch, unix.getcwd() or ".")
 
-  local ok = sandbox.sandboxed_agent(no_sandbox, tpl, "o/work/fix/session.db", {"o/work/plan", "o/work/do"}, nil, sandbox.fix_limits, model)
+  local ok = sandbox.run_phase({
+    sandbox = not no_sandbox,
+    timeout = sandbox.fix_limits.timeout_sec,
+    unveil_dirs = {"o/work/plan", "o/work/do"},
+    db = "o/work/fix/session.db",
+    prompt = tpl,
+    max_tokens = sandbox.fix_limits.max_tokens,
+    model = model,
+  })
 
   if not ok then
     io.stderr:write("error: fix agent failed\n")
@@ -965,6 +1006,6 @@ return {
   format_run_error = util.format_run_error,
   format_protect_dirs = util.format_protect_dirs,
   build_fix_prompt = prompt.build_fix_prompt,
-  build_agent_args = sandbox.build_agent_args,
+  build_phase_args = sandbox.build_phase_args,
   setup_git_env = util.setup_git_env,
 }

--- a/lib/ah/work/sandbox.tl
+++ b/lib/ah/work/sandbox.tl
@@ -1,9 +1,30 @@
--- ah/work/sandbox.tl: sandbox management, agent spawning, and limits
+-- ah/work/sandbox.tl: sandbox management, phase runner, and limits
 local spawn = require("cosmic.child")
 local env = require("cosmic.env")
-local fetch = require("cosmic.fetch")
 local unix = require("cosmo.unix")
 local util = require("ah.work.util")
+
+-- Type declarations for cosmic.child handles
+local record StdinHandle
+  write: function(StdinHandle, string)
+  close: function(StdinHandle)
+end
+
+local record StderrHandle
+  read: function(StderrHandle): string
+end
+
+local record ChildHandle
+  stdin: StdinHandle
+  stderr: StderrHandle
+  read: function(ChildHandle): boolean, string, string
+end
+
+local record ChildMod
+  spawn: function({string}, {string:any}): ChildHandle, string
+end
+
+local child = spawn as ChildMod
 
 -- Sandbox context for network isolation
 local record SandboxCtx
@@ -16,6 +37,17 @@ end
 local record AgentLimits
   max_tokens: integer   -- token budget passed via --max-tokens
   timeout_sec: integer  -- wall-clock timeout via timeout(1) wrapper
+end
+
+-- Phase options for run_phase()
+local record PhaseOpts
+  sandbox: boolean       -- pass --sandbox to ah
+  timeout: integer       -- wall-clock timeout in seconds
+  unveil_dirs: {string}  -- directories to --unveil as read-only
+  db: string             -- session database path
+  prompt: string         -- prompt text (piped via stdin)
+  max_tokens: integer    -- token budget
+  model: string          -- model alias
 end
 
 -- Overall deadline for unified work run (seconds)
@@ -100,147 +132,108 @@ local function stop_sandbox(ctx: SandboxCtx)
   end
 end
 
--- Build the argv for an agent subprocess.
+-- Build the argv for a phase subprocess.
+-- The prompt is NOT included in argv; it is piped via stdin.
 -- Exported for testing.
-local function build_agent_args(exe: string, db: string, prompt: string, new_session: boolean, limits: AgentLimits, model: string): {string}
+local function build_phase_args(exe: string, opts: PhaseOpts): {string}
   local args: {string} = {}
 
   -- Wall-clock timeout wrapper
-  if limits and limits.timeout_sec and limits.timeout_sec > 0 then
+  if opts.timeout and opts.timeout > 0 then
     table.insert(args, "timeout")
-    table.insert(args, tostring(limits.timeout_sec))
+    table.insert(args, tostring(opts.timeout))
   end
 
   table.insert(args, exe)
 
-  if new_session then
-    table.insert(args, "-n")
+  -- Always new session for phase runs
+  table.insert(args, "-n")
+
+  -- Sandbox flag
+  if opts.sandbox then
+    table.insert(args, "--sandbox")
   end
 
   -- Model selection
-  if model then
+  if opts.model then
     table.insert(args, "-m")
-    table.insert(args, model)
+    table.insert(args, opts.model)
   end
 
   -- Token budget
-  if limits and limits.max_tokens and limits.max_tokens > 0 then
+  if opts.max_tokens and opts.max_tokens > 0 then
     table.insert(args, "--max-tokens")
-    table.insert(args, tostring(limits.max_tokens))
+    table.insert(args, tostring(opts.max_tokens))
+  end
+
+  -- Unveil dirs (read-only)
+  if opts.unveil_dirs then
+    for _, dir in ipairs(opts.unveil_dirs) do
+      table.insert(args, "--unveil")
+      table.insert(args, dir .. ":r")
+    end
   end
 
   table.insert(args, "--db")
-  table.insert(args, db)
-  table.insert(args, prompt)
+  table.insert(args, opts.db)
+
+  -- No prompt arg; prompt comes on stdin
 
   return args
 end
 
--- Spawn an ah agent subprocess and wait for completion.
--- When new_session is true, passes -n to start a fresh session.
--- When false, continues the most recent session in the db.
-local function spawn_agent(run_env: {string}, db: string, prompt: string, new_session: boolean, limits: AgentLimits, model: string): boolean, string, integer
-  local args = build_agent_args(util.ah_exe(), db, prompt, new_session, limits, model)
+-- Run a work phase as a standalone ah subprocess.
+-- Builds `ah --sandbox --timeout T --unveil DIR:r ... --db DB` and pipes
+-- the prompt via stdin. Returns (ok, stdout, exit_code).
+local function run_phase(opts: PhaseOpts): boolean, string, integer
+  local args = build_phase_args(util.ah_exe(), opts)
 
-  util.log("spawning agent: db=" .. db .. " prompt_len=" .. #prompt .. " new=" .. tostring(new_session))
-  local handle, spawn_err = spawn.spawn(args, {env = run_env})
-  if not handle then
-    return false, spawn_err as string, -1
-  end
-  local stderr_out = handle.stderr:read()
-  local ok, stdout, exit_str = handle:read()
-  local exit_code = (tonumber(exit_str) or 0) as integer
-
-  -- Detect timeout(1) exit code
-  if exit_code == 124 then
-    util.log("agent timed out (wall-clock limit)")
-  end
-
-  -- Log agent subprocess results for debugging
-  util.log("agent exited: ok=" .. tostring(ok) .. " exit_code=" .. tostring(exit_code))
-  if stderr_out and stderr_out ~= "" then
-    local stderr_tail = stderr_out
-    if #stderr_tail > 2000 then
-      stderr_tail = "...(" .. #stderr_out .. " bytes total)\n" .. stderr_out:sub(-2000)
-    end
-    util.log("agent stderr:\n" .. stderr_tail)
-  end
-  if stdout and stdout ~= "" then
-    local stdout_preview = stdout:sub(1, 500)
-    if #stdout > 500 then stdout_preview = stdout_preview .. "..." end
-    util.log("agent stdout: " .. stdout_preview)
-  end
-
-  return ok and exit_code == 0, stdout, exit_code
-end
-
--- Run an ah agent subprocess inside the network sandbox.
--- Only api.anthropic.com is reachable; filesystem is restricted via pledge/unveil.
--- The sandbox is started and stopped around each agent invocation so that
--- only agent actions run inside the sandbox; all other (deterministic) work
--- executes without network isolation overhead.
--- If friction_prompt is provided, it is sent as a follow-up message in the
--- same session after the main prompt completes.
-local function sandboxed_agent(no_sandbox: boolean, prompt: string, db: string, protect_dirs?: {string}, friction_prompt?: string, limits?: AgentLimits, model?: string): boolean, string, integer
-  local ctx: SandboxCtx = nil
-  if not no_sandbox then
-    local sctx, err = start_sandbox()
-    if not sctx then
-      io.stderr:write("error: sandbox failed to start: " .. (err or "unknown") .. "\n")
-      return false, "sandbox failed to start: " .. (err or "unknown"), 1
-    end
-    ctx = sctx
-    io.stderr:write("[sandbox] proxy started on " .. ctx.socket_path .. "\n")
-  end
+  util.log("run_phase: " .. table.concat(args, " ") .. " (prompt_len=" .. #opts.prompt .. ")")
 
   local run_env: {string} = env.all() as {string}
   util.setup_git_env(run_env)
 
-  -- Set TMPDIR to sandbox tmpdir or a local writable location.
+  -- Set TMPDIR to a local writable location if not already set.
   -- APE binaries (cosmic) need to extract to $TMPDIR/.ape-* on first run;
   -- in restricted environments (GitHub Actions), /tmp may not be writable.
-  if ctx and ctx.tmpdir then
-    util.env_set(run_env, "TMPDIR", ctx.tmpdir)
-  elseif not util.env_get(run_env, "TMPDIR") then
-    -- Fallback: use o/tmp relative to cwd
+  if not util.env_get(run_env, "TMPDIR") then
     local cwd = unix.getcwd() or "."
     local local_tmp = cwd .. "/o/tmp"
     unix.mkdir(local_tmp, tonumber("755", 8))
     util.env_set(run_env, "TMPDIR", local_tmp)
   end
 
-  if ctx and ctx.enabled then
-    local proxy_url, proxy_err = fetch.unix_proxy(ctx.socket_path)
-    if not proxy_url then
-      io.stderr:write("[sandbox] invalid proxy path: " .. (proxy_err or "unknown") .. "\n")
-      stop_sandbox(ctx)
-      return false, "invalid proxy path: " .. (proxy_err or "unknown"), 1
-    end
-    util.env_set(run_env, "http_proxy", proxy_url)
-    util.env_set(run_env, "HTTP_PROXY", proxy_url)
-    util.env_set(run_env, "https_proxy", proxy_url)
-    util.env_set(run_env, "HTTPS_PROXY", proxy_url)
-    util.env_set(run_env, "AH_SANDBOX", "1")
-    local protect = util.format_protect_dirs(protect_dirs)
-    if protect then
-      util.env_set(run_env, "AH_PROTECT_DIRS", protect)
-    end
+  local handle, spawn_err = child.spawn(args, {env = run_env})
+  if not handle then
+    return false, spawn_err as string, -1
   end
 
-  -- Main prompt: new session
-  local ok, stdout, exit_code = spawn_agent(run_env, db, prompt, true, limits, model)
+  -- Pipe prompt via stdin
+  handle.stdin:write(opts.prompt)
+  handle.stdin:close()
 
-  if not ok then
-    if ctx then
-      io.stderr:write("[sandbox] stopping proxy\n")
-      stop_sandbox(ctx)
-    end
-    return false, stdout, exit_code
+  local stderr_out = handle.stderr:read()
+  local ok, stdout, exit_str = handle:read()
+  local exit_code = (tonumber(exit_str) or 0) as integer
+
+  -- Detect timeout(1) exit code
+  if exit_code == 124 then
+    util.log("phase timed out (wall-clock limit)")
   end
 
-  if ctx then
-    io.stderr:write("[sandbox] stopping proxy\n")
-    stop_sandbox(ctx)
+  -- Log subprocess results for debugging
+  util.log("phase exited: ok=" .. tostring(ok) .. " exit_code=" .. tostring(exit_code))
+  if stderr_out and stderr_out ~= "" then
+    local stderr_tail = stderr_out
+    if #stderr_tail > 2000 then
+      stderr_tail = "...(" .. #stderr_out .. " bytes total)\n" .. stderr_out:sub(-2000)
+    end
+    util.log("phase stderr:\n" .. stderr_tail)
+  end
+  if stdout and stdout ~= "" then
+    local stdout_preview = stdout:sub(1, 500)
+    if #stdout > 500 then stdout_preview = stdout_preview .. "..." end
+    util.log("phase stdout: " .. stdout_preview)
   end
 
   return ok and exit_code == 0, stdout, exit_code
@@ -252,8 +245,8 @@ return {
   do_limits = do_limits,
   check_limits = check_limits,
   fix_limits = fix_limits,
-  sandboxed_agent = sandboxed_agent,
-  build_agent_args = build_agent_args,
+  run_phase = run_phase,
+  build_phase_args = build_phase_args,
   start_sandbox = start_sandbox,
   stop_sandbox = stop_sandbox,
 }

--- a/lib/ah/work/test_sandbox.tl
+++ b/lib/ah/work/test_sandbox.tl
@@ -6,108 +6,175 @@ local record AgentLimits
   timeout_sec: integer
 end
 
+local record PhaseOpts
+  sandbox: boolean
+  timeout: integer
+  unveil_dirs: {string}
+  db: string
+  prompt: string
+  max_tokens: integer
+  model: string
+end
+
 local record WorkSandbox
-  build_agent_args: function(string, string, string, boolean, AgentLimits, string): {string}
+  build_phase_args: function(string, PhaseOpts): {string}
 end
 
 local sandbox = require("ah.work.sandbox") as WorkSandbox
 
--- Test: build_agent_args with new session, no limits
-local function test_agent_args_basic()
-  local args = sandbox.build_agent_args("ah", "test.db", "hello", true, nil, nil)
+-- Helper: join args for assertion messages
+local function joined(args: {string}): string
+  return table.concat(args, " ")
+end
+
+-- Test: build_phase_args basic (no sandbox, no limits)
+local function test_phase_args_basic()
+  local args = sandbox.build_phase_args("ah", {
+    db = "test.db",
+    prompt = "hello",
+  })
   assert(args[1] == "ah", "exe should be ah, got: " .. args[1])
   assert(args[2] == "-n", "should have -n for new session, got: " .. args[2])
   assert(args[3] == "--db", "should have --db, got: " .. args[3])
   assert(args[4] == "test.db", "should have db path, got: " .. args[4])
-  assert(args[5] == "hello", "should have prompt, got: " .. args[5])
-  assert(#args == 5, "should have 5 args, got: " .. #args)
-  print("✓ build_agent_args basic new session")
+  assert(#args == 4, "should have 4 args (no prompt in argv), got: " .. #args)
+  print("✓ build_phase_args basic")
 end
-test_agent_args_basic()
+test_phase_args_basic()
 
--- Test: build_agent_args continue session (no -n)
-local function test_agent_args_continue()
-  local args = sandbox.build_agent_args("ah", "test.db", "hello", false, nil, nil)
-  assert(args[1] == "ah", "exe should be ah")
-  assert(args[2] == "--db", "should have --db without -n, got: " .. args[2])
-  assert(args[3] == "test.db")
-  assert(args[4] == "hello")
-  assert(#args == 4, "should have 4 args, got: " .. #args)
-  print("✓ build_agent_args continue session")
+-- Test: build_phase_args with sandbox flag
+local function test_phase_args_sandbox()
+  local args = sandbox.build_phase_args("ah", {
+    sandbox = true,
+    db = "test.db",
+    prompt = "hello",
+  })
+  local j = joined(args)
+  assert(j:find("--sandbox"), "should have --sandbox, got: " .. j)
+  print("✓ build_phase_args with sandbox")
 end
-test_agent_args_continue()
+test_phase_args_sandbox()
 
--- Test: build_agent_args with max_tokens
-local function test_agent_args_max_tokens()
-  local limits: AgentLimits = {max_tokens = 50000, timeout_sec = 0}
-  local args = sandbox.build_agent_args("ah", "test.db", "hello", true, limits, nil)
-  -- Should be: ah -n --max-tokens 50000 --db test.db hello
-  local joined = table.concat(args, " ")
-  assert(joined:find("--max%-tokens 50000"), "should have --max-tokens 50000, got: " .. joined)
-  assert(args[1] == "ah")
-  assert(args[#args] == "hello", "prompt should be last arg, got: " .. args[#args])
-  print("✓ build_agent_args with max_tokens")
+-- Test: build_phase_args with max_tokens
+local function test_phase_args_max_tokens()
+  local args = sandbox.build_phase_args("ah", {
+    db = "test.db",
+    prompt = "hello",
+    max_tokens = 50000,
+  })
+  local j = joined(args)
+  assert(j:find("--max%-tokens 50000"), "should have --max-tokens 50000, got: " .. j)
+  -- prompt should NOT be in argv
+  assert(args[#args] ~= "hello", "prompt should not be in argv, got: " .. args[#args])
+  print("✓ build_phase_args with max_tokens")
 end
-test_agent_args_max_tokens()
+test_phase_args_max_tokens()
 
--- Test: build_agent_args with timeout wraps in timeout command
-local function test_agent_args_timeout()
-  local limits: AgentLimits = {max_tokens = 0, timeout_sec = 300}
-  local args = sandbox.build_agent_args("ah", "test.db", "hello", true, limits, nil)
-  -- Should be: timeout 300 ah -n --db test.db hello
+-- Test: build_phase_args with timeout wraps in timeout command
+local function test_phase_args_timeout()
+  local args = sandbox.build_phase_args("ah", {
+    db = "test.db",
+    prompt = "hello",
+    timeout = 300,
+  })
   assert(args[1] == "timeout", "should start with timeout, got: " .. args[1])
   assert(args[2] == "300", "should have timeout seconds, got: " .. args[2])
   assert(args[3] == "ah", "exe should follow timeout, got: " .. args[3])
-  assert(args[#args] == "hello", "prompt should be last, got: " .. args[#args])
-  print("✓ build_agent_args with timeout")
+  print("✓ build_phase_args with timeout")
 end
-test_agent_args_timeout()
+test_phase_args_timeout()
 
--- Test: build_agent_args with both limits
-local function test_agent_args_both_limits()
-  local limits: AgentLimits = {max_tokens = 100000, timeout_sec = 300}
-  local args = sandbox.build_agent_args("ah", "test.db", "hello", true, limits, nil)
-  local joined = table.concat(args, " ")
+-- Test: build_phase_args with both limits
+local function test_phase_args_both_limits()
+  local args = sandbox.build_phase_args("ah", {
+    sandbox = true,
+    db = "test.db",
+    prompt = "hello",
+    max_tokens = 100000,
+    timeout = 300,
+  })
+  local j = joined(args)
   assert(args[1] == "timeout", "should start with timeout, got: " .. args[1])
   assert(args[2] == "300", "timeout value, got: " .. args[2])
-  assert(joined:find("--max%-tokens 100000"), "should have --max-tokens, got: " .. joined)
-  assert(args[#args] == "hello", "prompt last, got: " .. args[#args])
-  print("✓ build_agent_args with both limits")
+  assert(j:find("--max%-tokens 100000"), "should have --max-tokens, got: " .. j)
+  assert(j:find("--sandbox"), "should have --sandbox, got: " .. j)
+  print("✓ build_phase_args with both limits")
 end
-test_agent_args_both_limits()
+test_phase_args_both_limits()
 
--- Test: build_agent_args with model
-local function test_agent_args_model()
-  local args = sandbox.build_agent_args("ah", "test.db", "hello", true, nil, "opus")
-  local joined = table.concat(args, " ")
-  assert(joined:find("-m opus"), "should have -m opus, got: " .. joined)
+-- Test: build_phase_args with model
+local function test_phase_args_model()
+  local args = sandbox.build_phase_args("ah", {
+    db = "test.db",
+    prompt = "hello",
+    model = "opus",
+  })
+  local j = joined(args)
+  assert(j:find("-m opus"), "should have -m opus, got: " .. j)
   assert(args[1] == "ah")
-  assert(args[#args] == "hello", "prompt should be last arg, got: " .. args[#args])
-  print("✓ build_agent_args with model")
+  print("✓ build_phase_args with model")
 end
-test_agent_args_model()
+test_phase_args_model()
 
--- Test: build_agent_args with model and limits
-local function test_agent_args_model_and_limits()
-  local limits: AgentLimits = {max_tokens = 50000, timeout_sec = 180}
-  local args = sandbox.build_agent_args("ah", "test.db", "hello", true, limits, "haiku")
-  local joined = table.concat(args, " ")
+-- Test: build_phase_args with model and limits
+local function test_phase_args_model_and_limits()
+  local args = sandbox.build_phase_args("ah", {
+    sandbox = true,
+    db = "test.db",
+    prompt = "hello",
+    max_tokens = 50000,
+    timeout = 180,
+    model = "haiku",
+  })
+  local j = joined(args)
   assert(args[1] == "timeout", "should start with timeout, got: " .. args[1])
   assert(args[2] == "180", "timeout value, got: " .. args[2])
-  assert(joined:find("-m haiku"), "should have -m haiku, got: " .. joined)
-  assert(joined:find("--max%-tokens 50000"), "should have --max-tokens, got: " .. joined)
-  assert(args[#args] == "hello", "prompt last, got: " .. args[#args])
-  print("✓ build_agent_args with model and limits")
+  assert(j:find("-m haiku"), "should have -m haiku, got: " .. j)
+  assert(j:find("--max%-tokens 50000"), "should have --max-tokens, got: " .. j)
+  print("✓ build_phase_args with model and limits")
 end
-test_agent_args_model_and_limits()
+test_phase_args_model_and_limits()
 
--- Test: build_agent_args without model (nil) doesn't add -m
-local function test_agent_args_no_model()
-  local args = sandbox.build_agent_args("ah", "test.db", "hello", true, nil, nil)
-  local joined = table.concat(args, " ")
-  assert(not joined:find("-m "), "should not have -m when model is nil, got: " .. joined)
-  print("✓ build_agent_args without model omits -m")
+-- Test: build_phase_args without model (nil) doesn't add -m
+local function test_phase_args_no_model()
+  local args = sandbox.build_phase_args("ah", {
+    db = "test.db",
+    prompt = "hello",
+  })
+  local j = joined(args)
+  assert(not j:find("-m "), "should not have -m when model is nil, got: " .. j)
+  print("✓ build_phase_args without model omits -m")
 end
-test_agent_args_no_model()
+test_phase_args_no_model()
+
+-- Test: build_phase_args with unveil_dirs
+local function test_phase_args_unveil()
+  local args = sandbox.build_phase_args("ah", {
+    sandbox = true,
+    db = "test.db",
+    prompt = "hello",
+    unveil_dirs = {"o/work/plan", "o/work/do"},
+  })
+  local j = joined(args)
+  assert(j:find("--unveil o/work/plan:r"), "should have --unveil o/work/plan:r, got: " .. j)
+  assert(j:find("--unveil o/work/do:r"), "should have --unveil o/work/do:r, got: " .. j)
+  print("✓ build_phase_args with unveil_dirs")
+end
+test_phase_args_unveil()
+
+-- Test: prompt is NOT included in argv (piped via stdin instead)
+local function test_phase_args_no_prompt_in_argv()
+  local long_prompt = string.rep("x", 10000)
+  local args = sandbox.build_phase_args("ah", {
+    db = "test.db",
+    prompt = long_prompt,
+    timeout = 180,
+  })
+  for _, a in ipairs(args) do
+    assert(a ~= long_prompt, "prompt should not appear in argv")
+  end
+  print("✓ build_phase_args excludes prompt from argv")
+end
+test_phase_args_no_prompt_in_argv()
 
 print("\nAll work-sandbox tests passed!")


### PR DESCRIPTION
Replace sandboxed_agent() subprocess management with run_phase() which
invokes ah --sandbox with explicit --timeout and --unveil flags. Prompts
are piped via stdin instead of passed as argv to avoid OS argument limits.

Each work phase now runs as a standalone ah command with CLI-level sandbox
flags, eliminating duplicated sandbox lifecycle code (proxy start/stop,
env var wiring, protect_dirs handling).

Key changes:
- sandbox.tl: add run_phase() and build_phase_args(), remove
  sandboxed_agent/spawn_agent and their env/proxy plumbing
- init.tl: phase runners use sandbox.run_phase() with PhaseOpts
- test_sandbox.tl: test build_phase_args() including --unveil and
  stdin-based prompt passing

Follows from PR #211 which exposed sandbox proxy as CLI-level flags.
