### PR TITLE
skills: add feedback loop between check and do

### DIFF
--- a/sys/skills/check.md
+++ b/sys/skills/check.md
@@ -81,4 +81,8 @@ Action rules:
 
 Write `o/work/check/update.md`: 2-4 line summary.
 
+If verdict is "needs-fixes", copy the critical and warning issues into
+`o/work/do/feedback.md` so the do phase can address them on re-run.
+If verdict is "pass" or "fail", write an empty `o/work/do/feedback.md`.
+
 Do NOT modify any source files.

--- a/sys/skills/do.md
+++ b/sys/skills/do.md
@@ -16,18 +16,22 @@ You are executing a work item. Follow the plan.
 
 Read `o/work/plan/plan.md` for the full plan.
 
+Read `o/work/do/feedback.md` — if non-empty, it contains review feedback from a
+previous check. Address those issues first, then continue with any remaining plan steps.
+
 The issue JSON follows this prompt with fields: `number`, `title`, `body`, `url`, `branch`.
 
 ## Instructions
 
 1. Read the plan and every file you intend to modify before editing
-2. For each step in the plan:
+2. If feedback.md is non-empty, fix those issues first
+3. For each remaining step in the plan:
    a. Make the changes for that step
    b. Before staging, run `git status` and verify only your files are affected
    c. Stage the specific files changed (not `git add -A`)
    d. Commit with a descriptive message for that step
-3. Run validation steps from the plan
-4. If validation requires fixes, stage and commit them
+4. Run validation steps from the plan
+5. If validation requires fixes, stage and commit them
 
 ## Forbidden
 


### PR DESCRIPTION
## Summary

Adds feedback.md as the communication channel between check and do phases in the convergence loop.

### Changes

- **check.md**: when verdict is "needs-fixes", write critical and warning issues to `o/work/do/feedback.md`. Write empty feedback.md on pass/fail.
- **do.md**: read `o/work/do/feedback.md` on startup. If non-empty, address those issues first before continuing with the plan.

### How it works

`work.mk` runs `make check` up to 3 times. On each run:
1. check evaluates the diff and writes a verdict
2. if needs-fixes, check writes feedback.md (newer than do_done)
3. next `make check` sees do_done is stale → reruns do → push → check
4. do reads feedback.md and fixes the issues
5. once check passes, feedback.md is empty, do_done stays fresh, make is a no-op

### Validation

`make ci`: 47/47 pass