### PR TITLE
fix: parenthesize json.encode in io.write calls

### DIFF
--- a/lib/work/issue.tl
+++ b/lib/work/issue.tl
@@ -76,4 +76,4 @@ local issue = {
    branch = "work/" .. tostring(selected.number) .. "-" .. suffix,
 }
 
-io.write(json.encode(issue))
+io.write((json.encode(issue)))

--- a/lib/work/issues.tl
+++ b/lib/work/issues.tl
@@ -35,4 +35,4 @@ if not issues then
    os.exit(1)
 end
 
-io.write(json.encode(issues))
+io.write((json.encode(issues)))


### PR DESCRIPTION
## Problem

The work workflow fails at the `Run work` step with:

```
o/bin/cosmic: lib/work/issues.tl:38: bad argument #2 to 'write' (string expected, got nil)
```

## Root cause

`json.encode()` (via cosmopolitan's `EncodeJson`) returns two values: `(result, err)`. When the call is passed directly to `io.write()`, both return values are forwarded as arguments. `io.write` is strict and rejects `nil` as any argument, so `io.write(string, nil)` fails.

## Fix

Wrap `json.encode()` in parentheses to truncate to one return value:

```lua
-- before (passes two args to io.write)
io.write(json.encode(issues))

-- after (passes one arg)
io.write((json.encode(issues)))
```

Applied to both `lib/work/issues.tl:38` and `lib/work/issue.tl:79`.

## Validation

- Reproduced locally: `WORK_REPO=whilp/ah o/bin/cosmic lib/work/issues.tl` exits 1 before, exits 0 after
- `make test`: 27/27 pass