### PR TITLE
fix: remove o/bin from LUA_PATH to prevent stack overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(o)/%.lua: %.tl $(cosmic)
 # tests
 all_tested := $(patsubst %,$(o)/%.test.ok,$(ah_tests))
 
-export LUA_PATH := $(CURDIR)/o/bin/?.lua;$(CURDIR)/o/lib/?.lua;$(CURDIR)/o/lib/?/init.lua;$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;
+export LUA_PATH := $(CURDIR)/o/lib/?.lua;$(CURDIR)/o/lib/?/init.lua;$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;
 
 $(o)/%.tl.test.ok: $(o)/%.lua $(ah_lua) $(cosmic)
 	@mkdir -p $(@D)


### PR DESCRIPTION
## Problem

The work workflow fails at the `plan` step with:

```
o/bin/ah: error loading module 'ah' from file '.../o/bin/ah.lua':
    C stack overflow
```

(Run 22024523246)

## Root cause

`Makefile:67` exports `LUA_PATH` with `o/bin/?.lua` as the **first** search path. When the embedded `o/bin/ah` binary runs, it inherits this `LUA_PATH`. Its entry point calls `require('ah')`, which resolves to `o/bin/ah.lua` (the entry script itself) instead of `o/lib/ah/init.lua` (the actual module). This creates infinite recursion.

## Fix

Remove `o/bin/?.lua` from `LUA_PATH`. It was unnecessary — `require('ah')` already resolves correctly via the `o/lib/?/init.lua` pattern.

## Validation

- `LUA_PATH=...(with o/bin)... o/bin/ah --help` → stack overflow (before)
- `LUA_PATH=...(without o/bin)... o/bin/ah --help` → works (after)
- `cosmic o/bin/ah.lua --help` → still works
- `make test`: 27/27 pass