### PR TITLE
fix: resolve proxy DNS dynamically via cosmic.ip.lookup

### DIFF
--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -16,6 +16,15 @@ local record Socket
   connect: function(self: Socket, ip: number, port: number): boolean, string
 end
 
+local record IpAddr
+  int: function(IpAddr): integer
+  format: function(IpAddr): string
+end
+
+local record IpMod
+  lookup: function(string): IpAddr, string
+end
+
 local record NetMod
   socket: function(number, number, number): Socket, string
   listen_unix: function(string, number): Socket, string
@@ -32,12 +41,13 @@ local record NetMod
 end
 
 local net = require("cosmic.net") as NetMod
+local ip_mod = require("cosmic.ip") as IpMod
 
 local record M
   serve: function(string): integer
   -- exported for testing
   parse_connect: function(string): string, string
-  resolvehost: function(string): string
+  resolvehost: function(string): IpAddr, string
   is_allowed: function(string): boolean
   parse_allow_hosts: function(string): {string:boolean}
 end
@@ -69,15 +79,18 @@ if allow_hosts_env then
   end
 end
 
--- DNS: hardcoded for known allowlist entries.
--- TODO: resolve dynamically via net.getaddrinfo once cosmic exposes it,
--- or resolve in work.tl before pledge and pass IPs via env/args.
-local DNS_CACHE: {string:string} = {
-  ["api.anthropic.com"] = "160.79.104.11",
-}
+-- DNS: resolve via cosmic.ip.lookup, cache results for the process lifetime.
+local DNS_CACHE: {string:IpAddr} = {}
 
-local function resolvehost(host: string): string
-  return DNS_CACHE[host]
+local function resolvehost(host: string): IpAddr, string
+  if DNS_CACHE[host] then
+    return DNS_CACHE[host]
+  end
+  local addr, err = ip_mod.lookup(host)
+  if addr then
+    DNS_CACHE[host] = addr
+  end
+  return addr, err
 end
 
 local function log(...: string)
@@ -158,17 +171,10 @@ local function handle_client(client: Socket)
     return
   end
 
-  local ip_str = resolvehost(host)
-  if not ip_str then
-    log("DNS failed:", host)
+  local addr, dns_err = resolvehost(host)
+  if not addr then
+    log("DNS failed:", host, dns_err or "unknown")
     client:send("HTTP/1.1 502 Bad Gateway\r\n\r\nDNS resolution failed\r\n")
-    return
-  end
-
-  local ip = net.parseip(ip_str)
-  if not ip then
-    log("invalid IP:", ip_str)
-    client:send("HTTP/1.1 502 Bad Gateway\r\n\r\nInvalid IP\r\n")
     return
   end
 
@@ -179,7 +185,7 @@ local function handle_client(client: Socket)
     return
   end
 
-  local ok, conn_err = upstream:connect(ip, tonumber(port) as integer)
+  local ok, conn_err = upstream:connect(addr:int() as number, tonumber(port) as integer)
   if not ok then
     log("connect failed:", host, port, conn_err)
     upstream:close()

--- a/lib/ah/test_proxy.tl
+++ b/lib/ah/test_proxy.tl
@@ -1,10 +1,15 @@
 #!/usr/bin/env cosmic
 -- test_proxy.tl: tests for HTTP CONNECT proxy module
 
+local record IpAddr
+  int: function(IpAddr): integer
+  format: function(IpAddr): string
+end
+
 local record Proxy
   serve: function(string): number
   parse_connect: function(string): string, string
-  resolvehost: function(string): string
+  resolvehost: function(string): IpAddr, string
   is_allowed: function(string): boolean
   parse_allow_hosts: function(string): {string:boolean}
 end
@@ -114,16 +119,19 @@ test_is_allowed_suffix()
 
 -- resolvehost: known host
 local function test_resolvehost_known()
-  local ip = proxy.resolvehost("api.anthropic.com")
-  assert(ip == "160.79.104.11", "should resolve to known IP, got: " .. tostring(ip))
+  local addr, err = proxy.resolvehost("api.anthropic.com")
+  assert(addr, "should resolve, got error: " .. tostring(err))
+  local ip_str = addr:format()
+  assert(ip_str:match("^%d+%.%d+%.%d+%.%d+$"), "should format as IPv4, got: " .. ip_str)
   print("✓ resolvehost: resolves known host")
 end
 test_resolvehost_known()
 
 -- resolvehost: unknown host
 local function test_resolvehost_unknown()
-  local ip = proxy.resolvehost("evil.com")
-  assert(ip == nil, "unknown host should return nil")
+  local addr, err = proxy.resolvehost("nonexistent.invalid")
+  assert(addr == nil, "unresolvable host should return nil, got: " .. tostring(addr))
+  assert(err, "should return error message")
   print("✓ resolvehost: nil for unknown host")
 end
 test_resolvehost_unknown()


### PR DESCRIPTION
## Problem

The work workflow fails with `proxy CONNECT failed: HTTP 502` because the proxy has a stale hardcoded IP for api.anthropic.com (`160.79.104.11` vs actual `160.79.104.10`).

(Run 22024728662)

## Fix

Replace the static `DNS_CACHE` table with `cosmic.ip.lookup()`, which calls cosmopolitan's `ResolveIp`. Results are cached per-process in `resolvehost()`.

This also simplifies the connect path — `lookup()` returns a typed `Addr` whose `:int()` passes directly to `socket:connect()`, removing the old `resolvehost` → string → `parseip` → integer round-trip.

## Validation

- `make test`: 27/27 pass
- `make check-types`: 47/47 pass