### PR TITLE
fix: handle non-blocking connect in proxy with poll+SO_ERROR

### DIFF
--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -17,6 +17,7 @@ local record Socket
   listen: function(self: Socket, backlog: number): boolean, string
   accept: function(self: Socket, flags: number): Socket, number, number, string
   connect: function(self: Socket, ip: number, port: number): boolean, string
+  getsockopt: function(self: Socket, level: number, optname: number): number, string
 end
 
 local record M
@@ -26,6 +27,7 @@ local record M
   resolvehost: function(string): ip.Addr, string
   is_allowed: function(string): boolean
   parse_allow_hosts: function(string): {string:boolean}
+  nb_connect: function(Socket, number, integer): boolean, string
 end
 
 local ALLOWLIST: {string:boolean} = {
@@ -77,6 +79,44 @@ end
 local function parse_connect(request: string): string, string
   local host, port = request:match("CONNECT%s+([^:%s]+):(%d+)")
   return host, port
+end
+
+-- Non-blocking connect: initiate connect, poll for completion, check SO_ERROR.
+-- Returns true on success, false + error string on failure.
+local CONNECT_TIMEOUT_MS = 10000
+
+local function nb_connect(sock: Socket, addr: number, port: integer): boolean, string
+  local ok, conn_err = sock:connect(addr, port)
+  if ok then
+    return true
+  end
+
+  -- Non-blocking connect returns false with EINPROGRESS; poll for writability.
+  local fds: {number:number} = { [sock.fd] = net.POLLOUT }
+  local revents, poll_err = net.poll(fds, CONNECT_TIMEOUT_MS)
+  if not revents then
+    return false, "poll failed: " .. (poll_err or "unknown")
+  end
+
+  local ev = revents[sock.fd] or 0
+  if ev == 0 then
+    return false, "connect timed out"
+  end
+
+  if ev & net.POLLERR ~= 0 then
+    local so_err = sock:getsockopt(net.SOL_SOCKET, net.SO_ERROR)
+    return false, "connect error: " .. tostring(so_err or conn_err)
+  end
+
+  if ev & net.POLLOUT ~= 0 then
+    local so_err = sock:getsockopt(net.SOL_SOCKET, net.SO_ERROR)
+    if so_err and so_err ~= 0 then
+      return false, "connect failed: SO_ERROR=" .. tostring(so_err)
+    end
+    return true
+  end
+
+  return false, "connect failed: unexpected poll events=" .. tostring(ev)
 end
 
 local function relay(client: Socket, upstream: Socket)
@@ -161,7 +201,7 @@ local function handle_client(client: Socket)
     return
   end
 
-  local ok, conn_err = upstream:connect(addr:int() as number, tonumber(port) as integer)
+  local ok, conn_err = nb_connect(upstream as Socket, addr:int() as number, tonumber(port) as integer)
   if not ok then
     log("connect failed:", host, port, conn_err)
     upstream:close()
@@ -216,5 +256,6 @@ M.is_allowed = function(dest: string): boolean
   return ALLOWLIST[dest] or false
 end
 M.parse_allow_hosts = parse_allow_hosts
+M.nb_connect = nb_connect
 
 return M

--- a/lib/ah/test_proxy.tl
+++ b/lib/ah/test_proxy.tl
@@ -3,12 +3,24 @@
 
 local ip = require("cosmic.ip")
 
+local net = require("cosmic.net")
+
+local record Socket
+  fd: number
+  close: function(self: Socket): boolean
+  recv: function(self: Socket, bufsiz: number): string, string
+  send: function(self: Socket, data: string): number, string
+  connect: function(self: Socket, ip: number, port: number): boolean, string
+  getsockopt: function(self: Socket, level: number, optname: number): number, string
+end
+
 local record Proxy
   serve: function(string): number
   parse_connect: function(string): string, string
   resolvehost: function(string): ip.Addr, string
   is_allowed: function(string): boolean
   parse_allow_hosts: function(string): {string:boolean}
+  nb_connect: function(Socket, number, integer): boolean, string
 end
 
 local proxy = require("ah.proxy") as Proxy
@@ -198,5 +210,37 @@ local function test_parse_allow_hosts_whitespace()
   print("✓ parse_allow_hosts: trims whitespace")
 end
 test_parse_allow_hosts_whitespace()
+
+-- nb_connect: non-blocking connect to api.anthropic.com succeeds
+local function test_nb_connect()
+  local addr, err = proxy.resolvehost("api.anthropic.com")
+  assert(addr, "DNS should resolve, got: " .. tostring(err))
+
+  local sock = net.socket(net.AF_INET, net.SOCK_STREAM | net.SOCK_NONBLOCK, 0) as Socket
+  assert(sock, "socket creation should succeed")
+
+  local ok, conn_err = proxy.nb_connect(sock, addr:int() as number, 443 as integer)
+  assert(ok, "nb_connect should succeed, got: " .. tostring(conn_err))
+  sock:close()
+  print("✓ nb_connect: non-blocking connect succeeds")
+end
+test_nb_connect()
+
+-- nb_connect: non-blocking connect to unreachable port fails
+local function test_nb_connect_refused()
+  local addr, err = ip.lookup("127.0.0.1")
+  assert(addr, "should resolve localhost, got: " .. tostring(err))
+
+  local sock = net.socket(net.AF_INET, net.SOCK_STREAM | net.SOCK_NONBLOCK, 0) as Socket
+  assert(sock, "socket creation should succeed")
+
+  -- port 1 is almost certainly not listening
+  local ok, conn_err = proxy.nb_connect(sock, addr:int() as number, 1 as integer)
+  assert(not ok, "nb_connect to closed port should fail")
+  assert(conn_err, "should have error message")
+  sock:close()
+  print("✓ nb_connect: connection refused returns error")
+end
+test_nb_connect_refused()
 
 print("\nall proxy tests passed")


### PR DESCRIPTION
The proxy creates sockets with SOCK_NONBLOCK, but connect() on a
non-blocking socket returns EINPROGRESS (reported as false/'connect
failed' by cosmic). The old code treated this as a real failure,
causing all CONNECT requests to fail with HTTP 502.

Fix: add nb_connect() that initiates the connect, polls for POLLOUT
(writability), then checks SO_ERROR to determine actual success/failure.

This was the root cause of all recent work workflow failures — the
agent couldn't reach api.anthropic.com through the proxy.

Tests added:
- nb_connect succeeds for api.anthropic.com:443
- nb_connect returns error for connection-refused (localhost:1)
