### PR TITLE
fix: replace origin/HEAD with origin/main in work.mk and check skill

### DIFF
--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -11,6 +11,7 @@ concurrency:
 
 env:
   REPO: ${{ github.repository }}
+  DEFAULT_BRANCH: origin/${{ github.event.repository.default_branch }}
   PATH: o/bin:${{ github.workspace }}/o/bin:/usr/local/bin:/usr/bin:/bin
   GIT_AUTHOR_NAME: ${{ github.actor }}
   GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com

--- a/sys/skills/check.md
+++ b/sys/skills/check.md
@@ -13,7 +13,10 @@ Read `o/work/plan/plan.md` for the plan. Read `o/work/do/do.md` for the executio
 
 ## Instructions
 
-1. Review the diff: `git diff origin/HEAD...HEAD`
+1. Review the diff against the default branch (`$WORK_DEFAULT_BRANCH`, defaults to `origin/main`):
+   ```bash
+   git diff ${WORK_DEFAULT_BRANCH:-origin/main}...HEAD
+   ```
 2. Run validation steps from the plan
 3. Check for unintended changes
 4. Analyze friction from session databases:


### PR DESCRIPTION
## Problem

The work workflow fails at the branch creation step:

```
fatal: 'origin/HEAD' is not a commit and a branch 'work/192-75910245' cannot be created from it
make[1]: *** [work.mk:74: o/work/branch.ok] Error 128
```

`actions/checkout` does not create the `origin/HEAD` symbolic ref.

## Fix

Detect the default branch dynamically via three layers:

1. **CI**: workflow sets `DEFAULT_BRANCH` from `github.event.repository.default_branch`
2. **Local**: `git symbolic-ref refs/remotes/origin/HEAD`
3. **Fallback**: `origin/main`

### Changes
- `.github/workflows/work.yml` — export `DEFAULT_BRANCH` env var with `origin/` prefix
- `work.mk` — consume `DEFAULT_BRANCH` via `?=` (env) + `$(or)` (fallback), export as `WORK_DEFAULT_BRANCH` for agent subprocesses
- `sys/skills/check.md` — use `$WORK_DEFAULT_BRANCH` in diff command

## Evidence

- Run [22025324857](https://github.com/whilp/ah/actions/runs/22025324857) failed at this step
- Verified locally: `DEFAULT_BRANCH=origin/develop make -p -f work.mk` correctly picks up the override