### PR TITLE
fix: work convergence resilience and proxy relay logging

### DIFF
--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -121,6 +121,7 @@ end
 
 local function relay(client: Socket, upstream: Socket)
   local BUFSIZ = 65536
+  local bytes_relayed: integer = 0
 
   while true do
     local fds: {number:number} = {
@@ -130,7 +131,7 @@ local function relay(client: Socket, upstream: Socket)
 
     local revents, err = net.poll(fds, 30000)
     if not revents then
-      log("poll error:", err)
+      log("relay poll error:", err, "after", tostring(bytes_relayed), "bytes")
       break
     end
 
@@ -139,25 +140,36 @@ local function relay(client: Socket, upstream: Socket)
 
     -- Timeout: no activity on either fd
     if client_ev == 0 and upstream_ev == 0 then
+      log("relay timeout (30s idle) after", tostring(bytes_relayed), "bytes")
       break
     end
 
     if client_ev & (net.POLLERR | net.POLLHUP | net.POLLNVAL) ~= 0 then
+      log("relay client event:", tostring(client_ev), "after", tostring(bytes_relayed), "bytes")
       break
     end
     if upstream_ev & (net.POLLERR | net.POLLHUP | net.POLLNVAL) ~= 0 then
+      log("relay upstream event:", tostring(upstream_ev), "after", tostring(bytes_relayed), "bytes")
       break
     end
 
     if client_ev & net.POLLIN ~= 0 then
       local data = client:recv(BUFSIZ)
-      if not data or data == "" then break end
+      if not data or data == "" then
+        log("relay client closed after", tostring(bytes_relayed), "bytes")
+        break
+      end
+      bytes_relayed = bytes_relayed + #data
       upstream:send(data)
     end
 
     if upstream_ev & net.POLLIN ~= 0 then
       local data = upstream:recv(BUFSIZ)
-      if not data or data == "" then break end
+      if not data or data == "" then
+        log("relay upstream closed after", tostring(bytes_relayed), "bytes")
+        break
+      end
+      bytes_relayed = bytes_relayed + #data
       client:send(data)
     end
   end
@@ -213,6 +225,7 @@ local function handle_client(client: Socket)
   client:send("HTTP/1.1 200 Connection Established\r\n\r\n")
 
   relay(client, upstream as Socket)
+  log("relay done:", dest)
   upstream:close()
 end
 


### PR DESCRIPTION
## Problem

Run [22025686727](https://github.com/whilp/ah/actions/runs/22025686727) failed during the `do` phase with `fetch failed: transport error`. The agent had made 6 commits and was about to fix a test error when the API connection dropped. Despite the `work` target having three `$(MAKE)` retry calls, the second and third never ran — make aborted on the first failure. The relay proxy that broke the connection logged nothing.

## Root cause

1. **Proxy relay breaks silently** — the relay loop exits on timeout, HUP, or empty recv without logging, making transport errors impossible to diagnose.

2. **make convergence doesn't tolerate failure** — the `work` target ran three sequential `$(MAKE) $(check_done)` calls without `-` prefix. When the first failed, make stopped immediately and retries never executed.

3. **Convergence targeted `check_done`, not `act_done`** — even on success, a separate `$(MAKE) $(act_done)` was needed. Simpler to converge on `act_done` directly since it depends on the full chain.

## Changes

**`lib/ah/proxy.tl`** — add logging to every relay termination path (timeout, poll error, client/upstream close, error events) with bytes-relayed count and destination.

**`work.mk`**:
- Add `converge` variable: `converge := $(MAKE) $(act_done)`
- Retry the full chain (do → push → check → act) up to 3 times
- First two attempts use `-` prefix to tolerate failure
- Reset branch to main and clear session on `do` retry when partial commits exist

## Validation

`make ci` — 27 tests pass, 47 type checks pass.