### PR TITLE
feat: add setup-ci skill for bootstrapping ah work loop in new repos

### DIFF
--- a/sys/skills/setup-ci.md
+++ b/sys/skills/setup-ci.md
@@ -1,0 +1,102 @@
+---
+name: setup-ci
+description: Bootstrap ah work loop in a new repository. Generate workflows, Makefile, and CLAUDE.md.
+---
+
+# Setup CI
+
+Configure a repository for ah's automated work loop.
+
+## What this skill does
+
+Generates the files needed to run `ah work` in a repository:
+- `.github/workflows/work.yml` — scheduled workflow that runs `ah work`
+- `.github/workflows/test.yml` — CI workflow for tests and linting
+- `Makefile` — downloads ah binary and provides work/test/lint targets
+- `CLAUDE.md` — project context for the agent
+
+## Instructions
+
+### 1. Analyze the repository
+
+Read files to detect:
+- **Language**: look at file extensions, package files (package.json, go.mod, Cargo.toml, pyproject.toml, etc.)
+- **Build system**: Makefile, npm scripts, cargo, gradle, etc.
+- **Test framework**: what test runner is used, how tests are invoked
+- **Linter**: eslint, golangci-lint, clippy, ruff, etc.
+- **Existing CI**: check `.github/workflows/`, `.circleci/`, `.travis.yml`, etc.
+
+If the repo already has CI, note what exists and only generate what's missing.
+
+### 2. Read templates
+
+Read the template files to use as starting points:
+
+- `/zip/embed/sys/skills/setup-ci/work.yml.tmpl`
+- `/zip/embed/sys/skills/setup-ci/test.yml.tmpl`
+- `/zip/embed/sys/skills/setup-ci/Makefile.tmpl`
+- `/zip/embed/sys/skills/setup-ci/CLAUDE.md.tmpl`
+
+### 3. Generate files
+
+Adapt each template to the repository:
+
+**`.github/workflows/work.yml`**: Use the work.yml template. Replace VERSION
+and SHA with the latest ah release (ask the user or check
+https://github.com/whilp/ah/releases). The user must add a
+`CLAUDE_CODE_OAUTH_TOKEN` secret to their repo.
+
+**`.github/workflows/test.yml`**: Use the test.yml template. Replace
+placeholder test/lint commands with the repo's actual commands. Add
+language-specific setup steps (setup-node, setup-python, setup-go, etc.).
+
+**`Makefile`**: Use the Makefile template if no Makefile exists. If a Makefile
+exists, add the `ah` download target and `work` target to it. Replace
+placeholder test/lint commands with real ones.
+
+**`CLAUDE.md`**: Use the CLAUDE.md template. Fill in the project name,
+description, build/test commands, and architecture from what you learned
+in step 1. If a CLAUDE.md already exists, offer to enhance it rather than
+overwrite it.
+
+### 4. Customization (optional)
+
+If the user wants to customize ah's behavior:
+
+**Custom skills**: Create `sys/skills/*.md` files in the repo. When ah is
+built with `ah embed`, these override the defaults. Explain this to the user.
+
+**Custom system prompt**: Create `sys/system.md` in the repo to override the
+default system prompt.
+
+The `ah embed <dir>` and `ah extract <dir>` commands allow building a custom
+ah binary with overridden prompts, skills, and entrypoints. For most repos,
+the default ah binary works — customization is only needed for specialized
+workflows.
+
+### 5. Validate
+
+After generating files:
+- Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/work.yml'))"`
+  (or equivalent)
+- Verify Makefile syntax: `make -n test` (dry run)
+- Check that `.github/workflows/` directory exists
+
+### 6. Tell the user what to do next
+
+After generating files, tell the user:
+
+1. Add the `CLAUDE_CODE_OAUTH_TOKEN` secret to the repository
+   (Settings → Secrets → Actions → New repository secret)
+2. Review and commit the generated files
+3. Create issues labeled `work` for ah to pick up
+4. The work workflow runs every 3 hours (or trigger manually via workflow_dispatch)
+
+## Important notes
+
+- `ah` is a self-contained binary. It does not need to be built from source.
+- The work loop is language-agnostic. It works with any language or framework.
+- Do NOT try to rewrite ah's internals in another language. Use the binary as-is
+  and customize behavior through prompts and skills.
+- If the repo already has a Makefile with complex build logic, add ah targets
+  alongside existing ones rather than replacing the file.

--- a/sys/skills/setup-ci/CLAUDE.md.tmpl
+++ b/sys/skills/setup-ci/CLAUDE.md.tmpl
@@ -1,0 +1,43 @@
+# Project Name
+
+Brief description of what this project does.
+
+## Build
+
+```bash
+# How to build the project:
+make build
+```
+
+## Test
+
+```bash
+# How to run tests:
+make test
+
+# How to run linters:
+make lint
+
+# How to run all checks:
+make ci
+```
+
+## Architecture
+
+Describe the high-level structure of the codebase:
+
+- `src/` — source code
+- `tests/` — test files
+- `.github/workflows/` — CI workflows
+
+## Key Concepts
+
+List important abstractions, patterns, or conventions used in this project.
+
+## Development
+
+Notes for contributors:
+
+- Branch naming: `work/<issue-number>-<slug>`
+- Commits: use conventional commit messages
+- PRs: target `main`, require CI to pass

--- a/sys/skills/setup-ci/Makefile.tmpl
+++ b/sys/skills/setup-ci/Makefile.tmpl
@@ -1,0 +1,53 @@
+# Makefile for ah work loop.
+# Adapt this template to your repository.
+
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -ec
+
+# ah binary
+# Get the latest release from: https://github.com/whilp/ah/releases
+# Replace VERSION and SHA256 with current values.
+ah_version := VERSION
+ah_url := https://github.com/whilp/ah/releases/download/$(ah_version)/ah
+ah_sha := SHA256
+ah := o/bin/ah
+
+$(ah):
+	@mkdir -p $(@D)
+	@echo "==> fetching ah $(ah_version)"
+	@curl -fsSL -o $@ $(ah_url)
+	@echo "$(ah_sha)  $@" | sha256sum -c - >/dev/null
+	@chmod +x $@
+
+# work: run the ah work loop
+.PHONY: work
+work: $(ah)
+	$(ah) work --repo $(REPO)
+
+# test: run your project's tests (customize these)
+.PHONY: test
+test:
+	@echo "TODO: add test commands"
+
+# lint: run your project's linters (customize these)
+.PHONY: lint
+lint:
+	@echo "TODO: add lint commands"
+
+# ci: run all checks (used by test.yml workflow)
+.PHONY: ci
+ci: test lint
+
+# clean: remove build artifacts
+.PHONY: clean
+clean:
+	rm -rf o/
+
+.PHONY: help
+help:
+	@echo "targets:"
+	@echo "  work   - run ah work loop"
+	@echo "  test   - run tests"
+	@echo "  lint   - run linters"
+	@echo "  ci     - run all checks"
+	@echo "  clean  - remove build artifacts"

--- a/sys/skills/setup-ci/test.yml.tmpl
+++ b/sys/skills/setup-ci/test.yml.tmpl
@@ -1,0 +1,45 @@
+# GitHub Actions workflow for CI tests.
+# Adapt this template to your repository's test/lint commands.
+
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Add language/runtime setup steps here. Examples:
+      #
+      # Node.js:
+      #   - uses: actions/setup-node@v4
+      #     with:
+      #       node-version: '22'
+      #   - run: npm ci
+      #
+      # Python:
+      #   - uses: actions/setup-python@v5
+      #     with:
+      #       python-version: '3.12'
+      #   - run: pip install -r requirements.txt
+      #
+      # Go:
+      #   - uses: actions/setup-go@v5
+      #     with:
+      #       go-version: '1.22'
+      #
+      # Rust:
+      #   - uses: dtolnay/rust-toolchain@stable
+
+      # Replace with your test/lint commands:
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint

--- a/sys/skills/setup-ci/work.yml.tmpl
+++ b/sys/skills/setup-ci/work.yml.tmpl
@@ -1,0 +1,65 @@
+# GitHub Actions workflow for ah work loop.
+# Adapt this template to your repository.
+
+name: work
+
+on:
+  schedule:
+    # Run every 3 hours. Adjust frequency as needed.
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: work
+  cancel-in-progress: false
+
+env:
+  REPO: ${{ github.repository }}
+  PATH: o/bin:${{ github.workspace }}/o/bin:/usr/local/bin:/usr/bin:/bin
+  GIT_AUTHOR_NAME: ${{ github.actor }}
+  GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
+  GIT_COMMITTER_NAME: ${{ github.actor }}
+  GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  work:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Download ah binary. Replace VERSION and SHA with current release values.
+      # Get the latest release from: https://github.com/whilp/ah/releases
+      - name: Download ah
+        run: |
+          mkdir -p o/bin
+          curl -fsSL -o o/bin/ah "https://github.com/whilp/ah/releases/download/VERSION/ah"
+          echo "SHA256  o/bin/ah" | sha256sum -c -
+          chmod +x o/bin/ah
+
+      - name: Run work
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: ah work --repo "$REPO"
+
+      - name: Check for work output
+        id: check
+        if: always()
+        run: |
+          if [ -d o/work ]; then
+            echo "has_output=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.check.outputs.has_output == 'true'
+        with:
+          name: work
+          path: o/


### PR DESCRIPTION
adds a skill that generates GitHub Actions workflows, Makefile, and
CLAUDE.md for any repository. includes template files for work.yml,
test.yml, and Makefile that the agent adapts to the target repo's
language and build system.

the skill uses ah's embed/extract mechanism for customization rather
than requiring source modifications.
