### PR TITLE
Increase check token budget to 100k in work.mk

### DIFF
--- a/work.mk
+++ b/work.mk
@@ -112,7 +112,7 @@ $(check_done): $(push_done) $(plan) $(AH)
 		--sandbox \
 		--skill check \
 		--must-produce $(o)/work/check/actions.json \
-		--max-tokens 50000 \
+		--max-tokens 100000 \
 		--unveil $(o)/work/plan:r \
 		--unveil $(o)/work/do:r \
 		--db $(o)/work/check/session.db \


### PR DESCRIPTION
The do target was already at 100k. Bump check from 50k to 100k to match.

https://claude.ai/code/session_01E7wCrbYoav9EpVGJsXAYuK