### PR TITLE
fix: fresh session DB per retry, increase do budget to 200k

### DIFF
--- a/sys/skills/check.md
+++ b/sys/skills/check.md
@@ -22,12 +22,15 @@ Read `o/work/plan/plan.md` for the plan. Read `o/work/do/do.md` for the executio
 4. Analyze friction from session databases:
 
         # for each existing phase db (plan, do):
-        sqlite3 o/work/<phase>/session.db \
-          "select tool_name, substr(tool_input,1,200), substr(tool_output,1,200) from content_blocks where is_error = 1;"
-        sqlite3 o/work/<phase>/session.db \
-          "select tool_name, duration_ms, substr(tool_input,1,200) from content_blocks where duration_ms > 30000 order by duration_ms desc limit 5;"
-        sqlite3 o/work/<phase>/session.db \
-          "select stop_reason, count(*) from messages where role='assistant' group by stop_reason;"
+        # session files are named session-N.db (one per attempt)
+        for db in o/work/<phase>/session-*.db; do
+          sqlite3 "$db" \
+            "select tool_name, substr(tool_input,1,200), substr(tool_output,1,200) from content_blocks where is_error = 1;"
+          sqlite3 "$db" \
+            "select tool_name, duration_ms, substr(tool_input,1,200) from content_blocks where duration_ms > 30000 order by duration_ms desc limit 5;"
+          sqlite3 "$db" \
+            "select stop_reason, count(*) from messages where role='assistant' group by stop_reason;"
+        done
 
 5. Write your assessment
 


### PR DESCRIPTION
## Problem

When work phases retry via `make work`'s convergence loop, they reuse the same `session.db`. Each retry appends to the conversation history, and `get_ancestry` rebuilds it all. The `max_tokens` budget fires immediately on retry — making attempts 2 and 3 useless.

Evidence from [CI run 22027838069](https://github.com/whilp/ah/actions/runs/22027838069):
- Plan: 90k → 202k → 323k cumulative tokens across 3 attempts
- Do: 101k → 210k → 340k cumulative tokens
- Attempts 2 and 3 produced zero useful work

## Fix

### Fresh session DB per attempt

The `work` target passes `LOOP=1`, `LOOP=2`, `LOOP=3` to each convergence call. Each phase uses `session-$(LOOP).db` instead of a shared `session.db`. Prior sessions are preserved for debugging (uploaded as artifacts).

### Increase do budget

`--max-tokens` for the do phase increased from 100k to 200k. 100k was insufficient for multi-file tasks that require reading, editing, testing, and committing.

### Update check skill

Session DB references updated from `session.db` to `session-*.db` glob so the check agent finds all attempt databases.