### PR TITLE
fix: use checkout -B to handle pre-existing work branches

### DIFF
--- a/work.mk
+++ b/work.mk
@@ -83,7 +83,7 @@ $(feedback): $(plan)
 	@touch $@
 
 $(on_branch): $(plan) $(picked_issue)
-	@git checkout -b $$(jq -r .branch $(picked_issue)) $(DEFAULT_BRANCH)
+	@git checkout -B $$(jq -r .branch $(picked_issue)) $(DEFAULT_BRANCH)
 	@touch $@
 
 $(do_done): $(on_branch) $(plan) $(feedback) $(picked_issue) $(AH)


### PR DESCRIPTION
## Problem

`git checkout -b` in `work.mk:86` fails when the branch already exists from a previous work run:

```
fatal: a branch named 'work/55-cd984523' already exists
make[1]: *** [work.mk:86: o/work/branch.ok] Error 128
```

This caused the work workflow to fail even after the plan phase succeeded.

## Fix

Change `git checkout -b` to `git checkout -B`. The `-B` flag creates the branch or resets it to `DEFAULT_BRANCH` if it already exists. This is consistent with the do phase which already does `git reset --hard` on retry.