### PR TITLE
fix: force-push work branches to handle diverged remotes

### DIFF
--- a/work.mk
+++ b/work.mk
@@ -105,7 +105,7 @@ $(do_done): $(on_branch) $(plan) $(feedback) $(picked_issue) $(AH)
 $(push_done): $(do_done)
 	@mkdir -p $(@D)
 	@echo "==> push"
-	@git push -u origin HEAD
+	@git push --force-with-lease -u origin HEAD
 	@touch $@
 
 $(check_done): $(push_done) $(plan) $(AH)


### PR DESCRIPTION
## Problem

After the `-B` fix (#255), the local work branch is reset to `DEFAULT_BRANCH` when it already exists. But the remote branch still has commits from the previous run, so `git push -u origin HEAD` is rejected:

```
! [rejected] HEAD -> work/146-62f91bba (non-fast-forward)
```

## Fix

Use `git push --force-with-lease -u origin HEAD` so the push succeeds when the remote branch has diverged. `--force-with-lease` is safe — it only overwrites if no one else has pushed to the branch since we last fetched.