### PR TITLE
add init skill: generate agent-friendly repository documentation

### DIFF
--- a/sys/skills/init.md
+++ b/sys/skills/init.md
@@ -1,24 +1,36 @@
 ---
 name: init
-description: Generate a CLAUDE.md for a repository. Analyze the codebase and produce agent-friendly documentation.
+description: Generate agent-friendly documentation for a repository. Produce a short index file and deeper docs it points to.
 ---
 
 # Init
 
-Generate a `CLAUDE.md` that makes a repository legible to coding agents.
+Generate agent-friendly documentation for a repository. the output is a
+short index file (`CLAUDE.md` or `AGENTS.md`) that serves as a table of
+contents, plus deeper docs it points to.
 
-## Why CLAUDE.md
+## Principles
 
-`CLAUDE.md` is loaded into the system prompt at the start of every session.
-it gives the agent a map of the codebase so it can navigate without
-guessing. a good CLAUDE.md eliminates the most common failure mode:
-the agent doesn't know where things are or how they fit together.
+**a map, not a manual.** the index file is loaded into every agent
+session's system prompt. it must be short (~100 lines). a giant file
+crowds out the task and the code — context is scarce. when everything is
+"important," agents pattern-match locally instead of navigating
+intentionally.
+
+**progressive disclosure.** the index tells agents where to look. deeper
+docs (`docs/`, `ARCHITECTURE.md`, inline comments) provide detail. agents
+load them with `read` when needed. don't inline what can be pointed to.
+
+**repository as system of record.** anything the agent can't access
+in-context effectively doesn't exist. knowledge in chat threads, wikis,
+or people's heads is invisible. push it into the repo as versioned
+markdown.
 
 ## Instructions
 
 ### 1. Analyze the repository
 
-Read files to understand the project. Spend at most 8 tool calls on this.
+Read files to understand the project. Spend at most 8 tool calls.
 
 **Detect:**
 - language and framework (file extensions, package files, imports)
@@ -28,96 +40,113 @@ Read files to understand the project. Spend at most 8 tool calls on this.
 - directory structure and what each top-level directory contains
 - key abstractions (models, services, handlers, routes, etc.)
 - entry points (main, bin, cmd)
-
-**Read these files if they exist:**
-- `README.md` — project description
-- `Makefile` or build config — build/test/lint commands
-- `package.json`, `go.mod`, `Cargo.toml`, `pyproject.toml` — dependencies
-- `.github/workflows/*.yml` — CI configuration
-- existing `CLAUDE.md` or `AGENTS.md` — prior agent docs
+- existing docs (README.md, docs/, ARCHITECTURE.md, CLAUDE.md, AGENTS.md)
 
 ```bash
 find . -maxdepth 2 -type f -not -path './.git/*' -not -path './node_modules/*' -not -path './vendor/*' -not -path './.venv/*' | head -80
 ```
 
-### 2. Write CLAUDE.md
+### 2. Choose the filename
 
-Write `CLAUDE.md` in the repository root. Use this structure:
+- if a `CLAUDE.md` already exists, update it in place.
+- if an `AGENTS.md` already exists (no `CLAUDE.md`), update it in place.
+- if neither exists, create `AGENTS.md`.
+- never create both. one file.
+
+### 3. Write the index file
+
+The index file is short and points elsewhere. use this structure:
 
 ```markdown
 # <project name>
 
-<one-line description of what this project does>
+<one-line description>
 
 ## build
 
-<exact commands to build, test, lint, format>
-<include the single-test command if the framework supports it>
+<exact commands: build, test, lint, format, single-test>
 
 ## structure
 
-<top-level directories and what they contain>
+<top-level directories, one line each>
 <key files and their roles>
 
-## architecture
+## docs
 
-<how the system is organized: layers, modules, data flow>
-<key abstractions and where they live>
-<entry points>
+pointers to deeper documentation. each entry is a path the agent can
+`read` when it needs that context:
 
-## conventions
-
-<language idioms, naming patterns, error handling style>
-<commit message format if enforced>
-<branch naming if relevant>
+- `docs/architecture.md` — system layers, data flow, boundaries
+- `docs/conventions.md` — naming, error handling, commit format
+- `docs/<topic>.md` — ...
 
 ## making changes
 
-<step-by-step: what to do before, during, and after editing code>
+<short checklist: what to do before, during, and after editing>
 <what validation to run>
-<what to watch out for>
 ```
 
-### 3. Style guide
+The `## docs` section is the heart of the index. every pointer is a real
+file path that the agent can load. if a doc doesn't exist yet, create it.
 
-Follow these rules when writing CLAUDE.md:
+### 4. Write the deeper docs
+
+Create the files the index points to. at minimum:
+
+**`docs/architecture.md`** — how the system is organized:
+- layers, modules, domains
+- key abstractions and where they live
+- entry points
+- boundaries: what depends on what, what's off-limits
+- data flow for the main operations
+
+**`docs/conventions.md`** — how code is written here:
+- language idioms, naming patterns
+- error handling style
+- testing patterns (unit, integration, what to mock)
+- commit message format if enforced
+- branch naming if relevant
+
+Create additional `docs/<topic>.md` files if the codebase has distinct
+areas that deserve their own reference (API contracts, database schema,
+deployment, etc.). keep each doc focused — one topic per file.
+
+### 5. Style guide
+
+Apply to all generated docs:
 
 - **short declarative sentences.** no filler, no preamble.
 - **concrete over abstract.** file paths, command lines, exact names.
 - **commands must be copy-pasteable.** test them with `bash` if unsure.
-- **progressive disclosure.** start with what the agent needs most
-  (build commands, structure), then add depth (architecture, conventions).
-- **one page.** aim for 80–150 lines. if it's longer, cut the least
-  important sections. a long CLAUDE.md crowds out the actual task.
-- **no redundancy.** don't repeat what's obvious from filenames or
-  standard framework conventions.
-- **use the same voice as the codebase.** if the project uses lowercase
-  everywhere, write lowercase. match the existing tone.
+- **prefer boring.** document well-understood tools and patterns. agents
+  reason better about things with broad training-set coverage.
+- **write for freshness.** avoid specifics that rot (exact line numbers,
+  transient counts, version numbers). prefer stable references: file
+  paths, function names, directory structure.
+- **match the codebase voice.** if the project uses lowercase everywhere,
+  write lowercase.
 
-### 4. Validate
+### 6. Validate
 
-After writing, verify the build/test commands actually work:
+Verify the build/test commands actually work:
 
 ```bash
 # run whatever build command you documented
 # run whatever test command you documented
 ```
 
-If a command fails, fix the CLAUDE.md (not the project).
+If a command fails, fix the docs (not the project).
 
-### 5. Handle existing files
+### 7. Handle existing docs
 
-- **existing CLAUDE.md**: read it first. preserve project-specific
-  context that's still accurate. rewrite the structure to match the
-  template above. don't blindly append.
-- **existing AGENTS.md**: read it. if CLAUDE.md doesn't exist, rename
-  AGENTS.md to CLAUDE.md and rewrite to match the template. if both
-  exist, merge into CLAUDE.md and delete AGENTS.md (CLAUDE.md
-  supersedes AGENTS.md).
+- **existing index file**: read it first. preserve project-specific
+  context that's still accurate. restructure to match the template.
+- **existing docs/**: read them. update rather than replace. fill gaps.
+- **stale content**: remove it. stale rules are worse than no rules —
+  agents can't tell what's still true.
 
 ## Output
 
-Write `CLAUDE.md` in the repository root.
+Write the index file and all `docs/*.md` files it references.
 
-If you renamed or merged AGENTS.md, note that in your response so the
-user can commit the deletion.
+List what you created in your response so the user can review and commit.


### PR DESCRIPTION
## Summary

New built-in skill: `/skill:init`

Analyzes a codebase and generates agent-friendly documentation following the [harness engineering](https://openai.com/index/harness-engineering/) pattern: the index file is a table of contents, not an encyclopedia.

## What the skill produces

1. **Index file** (`CLAUDE.md` or `AGENTS.md`, ~100 lines) — build commands, directory structure, pointers to deeper docs, making-changes checklist
2. **`docs/architecture.md`** — system layers, abstractions, entry points, boundaries, data flow
3. **`docs/conventions.md`** — naming, error handling, testing patterns, commit format
4. **Additional `docs/*.md`** — as needed for distinct areas (API, schema, deployment)

## Key design choices

- **tool-agnostic**: works with CLAUDE.md or AGENTS.md, updates whichever exists, never creates both
- **map not manual**: index is short; deeper docs are loaded on demand via `read`
- **progressive disclosure**: agents start with the index, navigate to detail when needed
- **repository as system of record**: push knowledge into versioned markdown, not wikis/chat
- **freshness over precision**: avoid specifics that rot (line numbers, version counts)

## Usage

```
ah /skill:init
```