### PR TITLE
fix work loop re-running after successful PR creation

### DIFF
--- a/lib/ah/work/action.tl
+++ b/lib/ah/work/action.tl
@@ -60,7 +60,13 @@ local function execute_create_pr(branch: string, title: string, body: string): b
   if not title then return false, "missing title" end
   if not body then return false, "missing body" end
   local ok, stdout, _, stderr = util.run({"gh", "pr", "create", "--head", branch, "--title", title, "--body", body})
-  if not ok then return false, util.format_run_error("gh pr create failed", stdout, stderr) end
+  if not ok then
+    local combined = (stdout or "") .. (stderr or "")
+    if combined:find("already exists") then
+      return true
+    end
+    return false, util.format_run_error("gh pr create failed", stdout, stderr)
+  end
   return true
 end
 

--- a/lib/work/work.tl
+++ b/lib/work/work.tl
@@ -260,8 +260,12 @@ commands = {
 
             local ok, out = run("gh pr create --head '" .. branch .. "' --title '" .. title:gsub("'", "'\\''") .. "' --body '" .. body:gsub("'", "'\\''") .. "'")
             if not ok then
-               io.stderr:write("  failed: " .. (out or "") .. "\n")
-               all_ok = false
+               if out and out:find("already exists") then
+                  io.stderr:write("  pr already exists, treating as success\n")
+               else
+                  io.stderr:write("  failed: " .. (out or "") .. "\n")
+                  all_ok = false
+               end
             end
          else
             io.stderr:write("  skipped unknown action: " .. action_type .. "\n")

--- a/sys/skills/check.md
+++ b/sys/skills/check.md
@@ -89,6 +89,6 @@ Write `o/work/check/update.md`: 2-4 line summary.
 
 If verdict is "needs-fixes", copy the critical and warning issues into
 `o/work/do/feedback.md` so the do phase can address them on re-run.
-If verdict is "pass" or "fail", write an empty `o/work/do/feedback.md`.
+If verdict is "pass" or "fail", do NOT write `o/work/do/feedback.md`.
 
 Do NOT modify any source files.


### PR DESCRIPTION
## Problem

The work loop (via `make work`) re-executed do/push/check/act after a successful pass verdict and PR creation, wasting tokens and ultimately labeling a successful issue as `failed`.

Two compounding bugs:

### Bug 1: check always writes feedback.md, even on pass

The check skill instructed agents: *"If verdict is pass or fail, write an empty `o/work/do/feedback.md`."* Since `do_done` depends on `feedback.md`, writing it updated the mtime, making `do_done` stale. Make re-ran do → push → check → act in LOOP=2 and LOOP=3.

### Bug 2: act treats "PR already exists" as failure

In LOOP=2, `create_pr` failed because the PR already existed from LOOP=1. `gh pr create` exits non-zero, setting `all_ok = false`, so `success = false`, and the issue got labeled `failed` instead of `done`.

The compound effect: LOOP=1 succeeds (labels issue `done`), LOOP=2 re-runs everything and labels it `failed` (overwriting the success state). The issue ends up with both `done` and `failed` labels.

## Fix

1. **check skill**: don't write `feedback.md` on pass/fail — only on `needs-fixes`. Prevents make from seeing staleness.
2. **act (both paths)**: detect "already exists" in `gh pr create` error output and treat as success. Defense-in-depth for any re-run scenario.

## Files changed

- `sys/skills/check.md` — stop writing feedback.md on pass/fail
- `lib/work/work.tl` — handle PR-already-exists in make-based act
- `lib/ah/work/action.tl` — handle PR-already-exists in unified ah work act