### PR TITLE
triage skill: add size assessment, issue breakdown, and stepwise approval

### DIFF
--- a/sys/skills/triage-issues.md
+++ b/sys/skills/triage-issues.md
@@ -1,12 +1,12 @@
 ---
 name: triage-issues
-description: Triage open GitHub issues. Assess priority, deduplicate, label, close stale issues, and refine underspecified issues.
+description: Triage open GitHub issues. Assess priority, deduplicate, label, close stale issues, break down oversized issues, and refine underspecified issues.
 ---
 
 # triage-issues
 
 Triage open issues in the repo. Assess priority, deduplicate, apply labels,
-and refine underspecified issues.
+break down oversized issues, and refine underspecified issues.
 
 ## Usage
 
@@ -18,32 +18,45 @@ and refine underspecified issues.
 
 1. **Fetch open issues**
    ```bash
-   gh issue list --state open --limit 50 --json number,title,body,labels,createdAt,updatedAt
+   gh issue list --state open --limit 50 --json number,title,body,labels,createdAt,updatedAt,comments
    ```
    If `--label` was provided, add `--label <filter>` to the command.
    If `--limit` was provided, use that instead of 50.
 
-2. **Read codebase context** to understand what's actionable:
-   - `sys/system.md`
-   - `sys/work/*.md` — work phases
-   - `Makefile` — build/test targets
-   - scan `lib/` and `bin/` for source files referenced in issues
-
-3. **For each issue, assess:**
+2. **For each issue, assess:**
    - **actionability**: is the problem clear? can it be worked on now?
    - **priority**: p0 (critical/blocking), p1 (high/impactful), p2 (low/minor)
+   - **size**: can it be completed in a short session (~50 tool calls)?
+     an issue is too big if it touches 4+ files across subsystems, requires
+     a design decision between multiple approaches, or bundles independent
+     concerns.
    - **duplicates**: does it overlap with another open issue?
    - **staleness**: is it outdated or already resolved by recent changes?
    - **labels**: which labels should be added or removed?
    - **specificity**: is the body detailed enough to act on? does it identify
      files, functions, root causes, and a concrete approach?
 
-4. **Check for duplicates** by reading bodies of related issues:
+3. **Check for duplicates** by reading bodies of related issues:
    ```bash
    gh issue view <number> --json body,comments
    ```
 
-5. **Apply triage decisions** — for each issue that needs changes:
+4. **Print triage summary table** before taking any action:
+
+   ```
+   | # | title | labels | size | action | reason |
+   |---|-------|--------|------|--------|--------|
+   ```
+
+   size values: small, medium, too big, too vague.
+   actions: keep, close, break down, refine, add labels.
+
+5. **Present each recommended action one at a time** and wait for user
+   approval before executing. this prevents unwanted bulk changes and lets
+   the user redirect (e.g. cancel instead of break down, skip instead of
+   refine).
+
+6. **Apply triage decisions** after approval:
    ```bash
    # add priority label
    gh issue edit <number> --add-label "p1"
@@ -54,27 +67,42 @@ and refine underspecified issues.
    # close stale/resolved issues
    gh issue close <number> --comment "resolved — <reason>"
 
+   # close issues that aren't worth the complexity
+   gh issue close <number> --comment "closing — <reason>"
+
    # flag issues needing more context
    gh issue edit <number> --add-label "needs-investigation"
    ```
 
-6. **Refine one underspecified issue** — pick the thinnest issue (shortest
-   body, fewest details) that is still open and actionable. Research the
-   codebase to fill in specifics, then update it:
+7. **Break down oversized issues** — for issues that are too big for a
+   short session, create focused sub-issues:
 
-   - read the source files referenced or implied by the issue
-   - identify the current state: what exists, what code paths are involved,
-     exact file paths and line numbers
-   - write a concrete proposed approach with files to modify
-   - add constraints, edge cases, and relationships to other issues
+   - each sub-issue should be independently shippable and testable
+   - include a `## Parent` section referencing the original issue
+   - specify concrete files to modify and constraints
+   - note dependencies between sub-issues if any
+   - comment on the parent issue linking all sub-issues
+   - keep the parent open as a tracker, or close it if fully replaced
+
+   ```bash
+   gh issue create --title "<focused title>" --label "todo" \
+     --body "<scoped body with Parent reference>"
+   gh issue comment <parent> --body "broken down into: #A, #B, #C"
+   ```
+
+8. **Refine one underspecified issue** — pick the thinnest issue that is
+   still open and actionable. Research the codebase to fill in specifics:
+
+   - read source files referenced or implied by the issue
+   - identify current state, file paths, line numbers
+   - write a concrete proposed approach
    - update the issue body:
      ```bash
      gh issue edit <number> --body "<refined body>"
      ```
-   - add appropriate labels if missing
 
-   Do only one issue per triage run. Prefer issues that are labeled `todo`
-   (the work loop will pick them up) but have bodies too vague to act on.
+   Do only one refinement per triage run. Skip refinement for issues where
+   the planner can reasonably fill in the gaps from a vague description.
 
 ## Priority criteria
 
@@ -85,25 +113,20 @@ and refine underspecified issues.
 
 ## Output
 
-Print a triage summary table:
+After all actions, print a summary of what was done:
 
 ```
-## Triage summary
-
-| # | title | action | reason |
-|---|-------|--------|--------|
-| 97 | friction: remove per-phase friction.md | keep p0 | blocks workflow improvement |
-| 140 | friction: sandbox blocks bash | close duplicate | same root cause as #135 |
-| 55 | support session name aliases | refine | body lacks file paths and approach |
+| action | issue | detail |
+|--------|-------|--------|
+| created | #285 | sub-issue of #253: gate proxy logging |
+| closed | #211 | cancelled — too complex for the value |
 ```
-
-Then list all actions taken (labels applied, issues closed, comments added,
-issues refined).
 
 ## Rules
 
-- do not close issues unless clearly duplicate or resolved — when in doubt, keep open
+- do not close issues unless clearly duplicate, resolved, or not worth the
+  complexity — when in doubt, keep open
 - always comment before closing, citing the reason
 - if an issue lacks enough context to triage, label it `needs-investigation`
 - prefer merging duplicates into the older or more-detailed issue
-- ask the user before closing more than 3 issues in a single run
+- present actions to the user for approval before executing


### PR DESCRIPTION
updates the triage-issues skill based on a live triage session.

## changes

- **size assessment** — new criterion: can the issue be completed in a short session (~50 tool calls)? flags issues that touch 4+ files across subsystems, require design decisions, or bundle independent concerns.
- **break down step** (step 7) — create focused sub-issues with `## Parent` references, dependency notes, and comment on the parent linking them all.
- **stepwise approval** (step 5) — present each recommended action one at a time and wait for user input before executing. prevents unwanted bulk changes.
- **dropped** the "read codebase context" preamble step — redundant with normal agent behavior.
- **smarter refinement** — skip issues where the planner can fill gaps from a vague description.
- **output format** — actions-taken summary table instead of triage-decisions table.
- **close rationale** — "not worth the complexity" as a valid reason to close.

## context

these changes came from running the skill on ah's own issue backlog. the session broke down #253 (5-file logging overhaul) into 3 independent sub-issues (#285, #286, #287), closed #211 (too complex for the value), and broke #56 into #288 and #289. the stepwise approval flow let the user skip, redirect, or cancel each action.