### PR TITLE
refactor tool loading, add project tools and skills

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -23,10 +23,16 @@ name must be lowercase alphanumeric with hyphens, max 64 chars.
 
 ## loading
 
-skills are loaded from two locations (in order):
+skills are loaded from three locations (in order). later sources override
+earlier ones by name:
 
 1. `/zip/embed/sys/skills/` — built-in skills embedded in the executable.
-2. `sys/skills/` — local project skills (for development).
+2. `/zip/embed/skills/` — embed overlay (zip packaging).
+3. `cwd/skills/` — project-local skills.
+
+project skills let repositories ship custom skills that override or extend
+built-in ones. place `.md` files directly in `skills/` or use
+subdirectories with `SKILL.md` files.
 
 ## invocation
 

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -1567,7 +1567,7 @@ local function main(args: {string}): integer, string
   end
 
   -- Load skills
-  local loaded_skills = skills.load_skills()
+  local loaded_skills = skills.load_skills(cwd)
 
   -- --skill flag: prepend /skill:<name> to prompt
   if parsed.skill then

--- a/lib/ah/skills.tl
+++ b/lib/ah/skills.tl
@@ -134,9 +134,13 @@ local function load_skills_from_dir(dir: string): {Skill}
   return skills
 end
 
--- Load all skills from system and embed directories.
--- Embed skills override system skills by name.
-local function load_skills(): {string:Skill}
+-- Load all skills from system, embed, and project directories.
+-- Later sources override earlier ones by name:
+--   1. system (built-in)
+--   2. embed (zip overlay)
+--   3. project (cwd/skills/)
+local function load_skills(cwd?: string): {string:Skill}
+  cwd = cwd or fs.getcwd()
   local skills: {string:Skill} = {}
 
   -- System skills first
@@ -148,6 +152,13 @@ local function load_skills(): {string:Skill}
   -- Embed skills (override system)
   local embed_skills = load_skills_from_dir("/zip/embed/skills")
   for _, skill in ipairs(embed_skills) do
+    skills[skill.name] = skill
+  end
+
+  -- Project skills (override all)
+  local project_dir = fs.join(cwd, "skills")
+  local project_skills = load_skills_from_dir(project_dir)
+  for _, skill in ipairs(project_skills) do
     skills[skill.name] = skill
   end
 

--- a/lib/ah/test_skills.tl
+++ b/lib/ah/test_skills.tl
@@ -260,4 +260,53 @@ local function test_expand_skill_regular_text()
 end
 test_expand_skill_regular_text()
 
+-- Tests for project skills (cwd/skills/)
+local function test_load_skills_project_override()
+  -- Create a fake project with skills/
+  local project = fs.join(tmpdir, "project")
+  local project_skills_dir = fs.join(project, "skills")
+  fs.makedirs(project_skills_dir)
+
+  -- Write a project skill that would override a system skill by name
+  cio.barf(fs.join(project_skills_dir, "my-project-skill.md"),
+    "---\nname: my-project-skill\ndescription: A project-local skill.\n---\n# Project Skill\nDo project things.")
+
+  local loaded = skills.load_skills(project)
+
+  -- The project skill should be present
+  assert(loaded["my-project-skill"] ~= nil, "project skill should be loaded")
+  assert(loaded["my-project-skill"].description == "A project-local skill.",
+    "project skill description mismatch")
+  assert(loaded["my-project-skill"].file_path == fs.join(project_skills_dir, "my-project-skill.md"),
+    "project skill file_path should point to project dir")
+end
+test_load_skills_project_override()
+
+local function test_load_skills_project_no_dir()
+  -- A project with no skills/ should still work (just loads system skills)
+  local empty_project = fs.join(tmpdir, "empty-project")
+  fs.makedirs(empty_project)
+  local loaded = skills.load_skills(empty_project)
+  -- Should not error; system skills should still be present
+  assert(type(loaded) == "table", "should return a table even without project skills dir")
+end
+test_load_skills_project_no_dir()
+
+local function test_load_skills_project_subdirectory_skill()
+  -- Test SKILL.md in a subdirectory under skills/
+  local project = fs.join(tmpdir, "project-subdir")
+  local sub_skill_dir = fs.join(project, "skills", "custom-tool")
+  fs.makedirs(sub_skill_dir)
+  cio.barf(fs.join(sub_skill_dir, "SKILL.md"),
+    "---\ndescription: A custom tool skill.\n---\n# Custom Tool\nUse the custom tool.")
+
+  local loaded = skills.load_skills(project)
+  assert(loaded["custom-tool"] ~= nil, "subdirectory skill should be loaded")
+  assert(loaded["custom-tool"].description == "A custom tool skill.",
+    "subdirectory skill description mismatch")
+  assert(loaded["custom-tool"].base_dir == sub_skill_dir,
+    "subdirectory skill base_dir should be the subdirectory")
+end
+test_load_skills_project_subdirectory_skill()
+
 print("all skills tests passed")


### PR DESCRIPTION
## summary

refactors tool system from hardcoded builtins to a tiered loading architecture. adds project-local tools and skills from `cwd/tools/` and `cwd/skills/`.

## tool changes

- **extracted builtin tools** to `sys/tools/*.tl` (bash, read, write, edit) — each is a standalone module returning a Tool record
- **tiered loading**: system (`/zip/embed/sys/tools`) → embed (`/zip/embed/tools`) → project (`cwd/tools/`), later tiers override earlier by name
- **project tools**: `.tl` > `.lua` > executable precedence within a directory
- **CLI tool metadata**: `.md` sidecar files use yaml frontmatter for `description` and body for `system_prompt` guidance
- **`--tool name=cmd`**: register a CLI tool override (highest precedence)
- **`--tool name=`**: remove a tool entirely (e.g. `--tool bash=` disables bash)
- **`format_tools_for_prompt()`**: generates `Tools:` summary + per-tool `system_prompt` sections, injected into system prompt
- **`system.md` cleanup**: tool guidance moved from static system prompt into per-tool `system_prompt` fields

## skill changes

- `load_skills()` accepts optional `cwd` parameter
- scans `cwd/skills/` for project skills after system/embed tiers
- project skills override built-in skills by name

## testing

- 27 tests pass, 51 type checks pass
- new tests: remove_tool, project tool loading, .tl tool loading, .tl-over-.lua precedence, executable-in-tools, add_tool_override, format_tools_for_prompt, project skills
- manual verification of `--tool hello=/tmp/hello-tool --tool bash=` end-to-end