### PR TITLE
skip .tl files in CLI tool scanner, fix bash docs

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -40,7 +40,7 @@ parameters:
 
 ### bash (`sys/tools/bash.tl`)
 
-executes a shell command. uses `/bin/bash -o pipefail -ec`. has a
+executes a shell command. uses `bash -c` (or `$AH_SHELL -c`). has a
 configurable timeout (default 120s). returns stdout + stderr combined.
 
 parameters:

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -153,9 +153,10 @@ local function load_cli_tools_from_dir(dir: string): {Tool}
 
     local bin_path = fs.join(dir, name)
 
-    -- Skip non-executables and .md/.lua files
+    -- Skip non-executables and metadata/source files
     if name:match("%.md$") then goto continue end
     if name:match("%.lua$") then goto continue end
+    if name:match("%.tl$") then goto continue end
     if not is_executable(bin_path) then goto continue end
 
     -- Get description and system_prompt from <name>.md (frontmatter + body)


### PR DESCRIPTION
two small fixes from leftover work on `project-skills`:

**1. skip `.tl` files in CLI tool scanner** (`lib/ah/tools.tl`)

`load_cli_tools_from_dir` skips `.md` and `.lua` files but not `.tl`. if a project has teal source files in its `tools/` directory (alongside compiled `.lua`), the `.tl` files could be picked up as CLI executables. now skipped.

**2. fix bash tool description in docs** (`docs/tools.md`)

docs said `/bin/bash -o pipefail -ec` but the actual bash tool uses `bash -c` (or `$AH_SHELL -c`). updated to match reality.