### PR TITLE
add --version flag with build-time git version

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -242,6 +242,7 @@ commands:
 
 options:
   -h, --help          show this help
+  -V, --version       show version and exit
   -n, --new           start a new session
   -S, --session ULID  use specific session (prefix match)
   --name NAME         set or match session by name
@@ -853,6 +854,7 @@ local function parse_args(args: {string}): ParsedArgs, string
 
   local longopts = {
     {name = "help", has_arg = "none", short = "h"},
+    {name = "version", has_arg = "none", short = "V"},
     {name = "new", has_arg = "none", short = "n"},
     {name = "session", has_arg = "required", short = "S"},
     {name = "name", has_arg = "required"},
@@ -874,7 +876,7 @@ local function parse_args(args: {string}): ParsedArgs, string
   -- Use + prefix for POSIX mode: stop parsing options at first non-option arg.
   -- This allows subcommands like "work" to have their own flags (--repo, --issue,
   -- --prompt) without the top-level parser rejecting them as unknown options.
-  local parser = getopt.new(args, "+hnS:m:o:t:", longopts)
+  local parser = getopt.new(args, "+hVnS:m:o:t:", longopts)
 
   while true do
     local opt, optarg = parser:next()
@@ -882,6 +884,8 @@ local function parse_args(args: {string}): ParsedArgs, string
 
     if opt == "h" or opt == "help" then
       return nil, "help"
+    elseif opt == "V" or opt == "version" then
+      return nil, "version"
     elseif opt == "n" or opt == "new" then
       result.new_session = true
     elseif opt == "S" or opt == "session" then
@@ -1049,6 +1053,12 @@ local function main(args: {string}): integer, string
 
   local parsed, err = parse_args(args)
   if not parsed then
+    if err == "version" then
+      local mod = "ah.version"
+      local ok, version = pcall(require, mod)
+      io.write("ah " .. (ok and version as string or "dev") .. "\n")
+      return 0
+    end
     usage()
     if err == "help" then
       return 0

--- a/lib/ah/test_version.tl
+++ b/lib/ah/test_version.tl
@@ -1,0 +1,29 @@
+-- test_version: verify --version flag handling
+local ah = require("ah")
+
+local function test_version_flag()
+  -- --version should return exit code 0
+  local code, err = ah.main({"--version"})
+  assert(code == 0, "expected exit 0, got " .. tostring(code))
+  assert(not err, "expected no error, got " .. tostring(err))
+  print("PASS: --version returns 0")
+end
+
+local function test_short_version_flag()
+  -- -V should return exit code 0
+  local code, err = ah.main({"-V"})
+  assert(code == 0, "expected exit 0, got " .. tostring(code))
+  assert(not err, "expected no error, got " .. tostring(err))
+  print("PASS: -V returns 0")
+end
+
+local function test_version_in_usage()
+  local text = ah.usage_text()
+  assert(text:find("%-V"), "usage should mention -V flag")
+  assert(text:find("%-%-version"), "usage should mention --version flag")
+  print("PASS: usage mentions --version")
+end
+
+test_version_flag()
+test_short_version_flag()
+test_version_in_usage()


### PR DESCRIPTION
Add `--version` / `-V` CLI flag that prints the build-time version string.

## version format

| state | output |
|---|---|
| tagged HEAD | tag as-is (e.g. `2026-02-16-1dbe9dd`) |
| untagged, clean | `yyyy-mm-dd-sha` |
| untagged, dirty | `yyyy-mm-dd-sha*` |
| no git | `unknown` |

## changes

- **Makefile**: generate `o/embed/.lua/ah/version.lua` at build time via `git describe --tags --exact-match` (tag) or `git log -1 --format='%cd-%h' --date=format:'%Y-%m-%d'` (date-sha). `.PHONY` so it regenerates every build. added as dependency of `ah` and `ah-debug` targets.
- **lib/ah/init.tl**: add `--version` / `-V` to getopt, usage text, and main(). uses `pcall(require, mod)` to load the generated module with `dev` fallback.
- **lib/ah/test_version.tl**: tests for both flag forms and usage text.