### PR TITLE
add skill tool

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -70,7 +70,14 @@ when invoked, the skill content is prepended to the user prompt.
 `skills.format_skills_for_prompt()` generates an `<available_skills>` XML
 block listing all skill names, descriptions, and file paths. this is
 appended to the system prompt so the agent knows what skills exist and
-can `read` them when relevant.
+can load them when relevant.
+
+## skill tool
+
+the built-in `skill` tool (`sys/tools/skill.tl`) loads a skill by name.
+the agent can call `skill(name="plan")` instead of reading the skill file
+directly. the tool returns the skill body (frontmatter stripped) with a
+metadata header showing source path, base directory, and line count.
 
 ## built-in skills
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,7 +4,7 @@ source: `lib/ah/tools.tl`, `sys/tools/`, `lib/ah/truncate.tl`
 
 ## built-in tools
 
-ah provides four tools to the agent, defined in `sys/tools/`:
+ah provides five tools to the agent, defined in `sys/tools/`:
 
 ### read (`sys/tools/read.tl`)
 
@@ -50,6 +50,21 @@ parameters:
 the tool tracks running processes via `running_processes` for abort
 cleanup on ctrl+c. `tools.abort_running_tools()` finds this table by
 iterating loaded tools.
+
+### skill (`sys/tools/skill.tl`)
+
+loads a skill by name from the available skill paths (system → embed →
+project). returns the skill body (frontmatter stripped) with a metadata
+header showing the source path, base directory, and line count. on
+error, lists available skill names for discoverability.
+
+parameters:
+- `name` (required): skill name (e.g. `plan`, `do`, `check`)
+
+the tool caches the loaded skills map on first invocation. details
+returned include `path` and `line_count`.
+
+## tool format
 
 ## tool format
 

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -47,7 +47,11 @@ local function tool_key_param(tool_name: string, tool_input: string, details_jso
   if details_json then
     local details = json.decode(details_json) as {string:any}
     if details then
-      if details.path then
+      -- skill tool: show "source → name, N lines"
+      if details.skill_name and details.line_count then
+        local src = details.path and shorten_path(details.path as string) or "?"
+        return string.format("%s → %s, %d lines", src, details.skill_name as string, details.line_count as integer)
+      elseif details.path then
         return shorten_path(details.path as string)
       elseif details.command then
         return details.command as string

--- a/lib/ah/test_skill_tool.tl
+++ b/lib/ah/test_skill_tool.tl
@@ -1,0 +1,117 @@
+#!/usr/bin/env cosmic
+-- test_skill_tool.tl: tests for the skill tool
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local tools = require("ah.tools")
+local loop = require("ah.loop")
+local json = require("cosmic.json")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp/test_skill_tool"
+fs.makedirs(tmpdir)
+
+-- Set up a project with skills in the actual cwd
+local cwd = fs.getcwd()
+
+-- Use a unique name to avoid conflicts
+local test_skill_name = "zz-test-skill-tool"
+
+-- Create test skill in skills/ (project tier)
+local skills_dir = fs.join(cwd, "skills")
+local dot_ah_skills = fs.join(cwd, ".ah", "skills")
+local test_skill_file: string
+local dh = fs.opendir(dot_ah_skills)
+if dh then
+  dh:close()
+  test_skill_file = fs.join(dot_ah_skills, test_skill_name .. ".md")
+else
+  fs.makedirs(skills_dir)
+  test_skill_file = fs.join(skills_dir, test_skill_name .. ".md")
+end
+
+cio.barf(test_skill_file,
+  "---\nname: " .. test_skill_name .. "\ndescription: A test skill for the skill tool test.\n---\n# Test Skill\n\nDo the thing.\nLine two.\nLine three.")
+
+local function cleanup()
+  os.remove(test_skill_file)
+end
+
+-- Initialize tools from the cwd
+tools.init_custom_tools(cwd)
+
+-- Verify the skill tool is loaded
+local function test_skill_tool_loaded()
+  local defs = tools.get_tool_definitions()
+  local found = false
+  for _, d in ipairs(defs) do
+    if d.name == "skill" then
+      found = true
+      break
+    end
+  end
+  assert(found, "skill tool should be loaded")
+  print("PASS: skill tool loaded")
+end
+test_skill_tool_loaded()
+
+-- Test loading a known skill: output is just the body
+local function test_load_skill()
+  local result, is_error, details = tools.execute_tool("skill", {name = test_skill_name})
+  assert(not is_error, "should not error: " .. tostring(result))
+  -- Body content only (no metadata header)
+  assert(result:find("# Test Skill") ~= nil, "should contain skill body")
+  assert(result:find("Do the thing.") ~= nil, "should contain skill content")
+  assert(result:find("skill:") == nil, "should NOT contain metadata header")
+  assert(result:find("source:") == nil, "should NOT contain source line")
+  -- Details carry metadata
+  assert(details ~= nil, "should return details")
+  assert(details.path ~= nil, "details should have path")
+  assert(details.skill_name == test_skill_name, "details should have skill_name")
+  assert(details.line_count ~= nil, "details should have line_count")
+  assert(details.line_count > 0, "line_count should be positive")
+  print("PASS: load skill")
+end
+test_load_skill()
+
+-- Test tool_key_param formats skill display correctly
+local function test_key_param_format()
+  local details_json = json.encode({
+    path = "/zip/embed/sys/skills/plan.md",
+    skill_name = "plan",
+    line_count = 42,
+  })
+  local key = loop.tool_key_param("skill", "{}", details_json)
+  assert(key:find("plan") ~= nil, "key should contain skill name: " .. key)
+  assert(key:find("42 lines") ~= nil, "key should contain line count: " .. key)
+  assert(key:find("→") ~= nil, "key should contain arrow: " .. key)
+  print("PASS: key param format")
+end
+test_key_param_format()
+
+-- Test loading an unknown skill
+local function test_unknown_skill()
+  local result, is_error = tools.execute_tool("skill", {name = "nonexistent-zz-does-not-exist"})
+  assert(is_error, "should error for unknown skill")
+  assert(result:find("unknown skill") ~= nil, "should mention unknown skill")
+  assert(result:find("available skills") ~= nil, "should list available skills")
+  print("PASS: unknown skill")
+end
+test_unknown_skill()
+
+-- Test missing name parameter
+local function test_missing_name()
+  local result, is_error = tools.execute_tool("skill", {})
+  assert(is_error, "should error for missing name")
+  print("PASS: missing name")
+end
+test_missing_name()
+
+-- Test empty name parameter
+local function test_empty_name()
+  local result, is_error = tools.execute_tool("skill", {name = ""})
+  assert(is_error, "should error for empty name")
+  print("PASS: empty name")
+end
+test_empty_name()
+
+cleanup()
+print("all skill tool tests passed")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -16,6 +16,7 @@ local record ToolDetails
   exit_code: integer
   duration_ms: integer
   media_type: string
+  skill_name: string
 end
 
 local record Tool

--- a/sys/tools/skill.tl
+++ b/sys/tools/skill.tl
@@ -1,0 +1,63 @@
+-- sys/tools/skill.tl: load a skill by name from available paths
+local skills = require("ah.skills")
+local cio = require("cosmic.io")
+
+-- Cache loaded skills (populated on first call)
+local loaded_skills: {string:skills.Skill} = nil
+
+return {
+  name = "skill",
+  description = "Load a skill by name from available paths",
+  system_prompt = "Use skill to load a skill's content when the task matches its description. Prefer this over reading skill files directly.",
+  input_schema = {
+    type = "object",
+    properties = {
+      name = {type = "string", description = "Skill name to load (e.g. 'plan', 'do', 'check')"},
+    },
+    required = {"name"},
+  },
+  execute = function(input: {string:any}): string, boolean, any
+    local name = input.name as string
+    if not name or name == "" then
+      return "error: name is required", true
+    end
+
+    -- Load skills on first use
+    if not loaded_skills then
+      loaded_skills = skills.load_skills()
+    end
+
+    local skill = loaded_skills[name]
+    if not skill then
+      -- List available skill names for discoverability
+      local available: {string} = {}
+      for k, _ in pairs(loaded_skills) do
+        table.insert(available, k)
+      end
+      table.sort(available)
+      return "error: unknown skill: " .. name .. "\navailable skills: " .. table.concat(available, ", "), true
+    end
+
+    -- Read the file content
+    local content = cio.slurp(skill.file_path)
+    if not content then
+      return "error: failed to read skill file: " .. skill.file_path, true
+    end
+
+    -- Strip frontmatter
+    local body = skills.strip_frontmatter(content)
+    body = body:match("^%s*(.-)%s*$") or ""
+
+    -- Count lines
+    local line_count = 0
+    for _ in body:gmatch("[^\n]*") do
+      line_count = line_count + 1
+    end
+
+    return body, false, {
+      path = skill.file_path,
+      skill_name = skill.name,
+      line_count = line_count,
+    }
+  end,
+}


### PR DESCRIPTION
load skills by name from available paths (system → embed → project).
returns body content to the agent, shows 'source → name, N lines'
to the user via tool_key_param.

- sys/tools/skill.tl: tool implementation
- lib/ah/loop.tl: skill_name + line_count display in tool_key_param
- lib/ah/tools.tl: add skill_name to ToolDetails record
- lib/ah/test_skill_tool.tl: tests
- docs/tools.md, docs/skills.md: updated
