### PR TITLE
consolidate scenarios/ into docs/design.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ working in that area.
 
 | file | covers |
 |------|--------|
+| [docs/design.md](docs/design.md) | design principles and philosophy |
 | [docs/architecture.md](docs/architecture.md) | module map, data flow, build system, embedding |
 | [docs/agent-loop.md](docs/agent-loop.md) | API call cycle, tool dispatch, loop detection, compaction, streaming |
 | [docs/session.md](docs/session.md) | database schema, conversation tree, branching, session resolution |

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,61 @@
+# design
+
+ah's design principles and philosophy.
+
+## identity
+
+ah is an **a**gent **h**arness. most importantly, it is improvable: because
+it can be improved and extended, it can become good at many other things.
+
+it is built with [cosmic](https://github.com/whilp/cosmic), a lua
+distribution that builds on (a fork of)
+[cosmopolitan](https://github.com/jart/cosmopolitan). because it is cosmic,
+ah has everything it needs to build tools to do more (sqlite, http, json,
+crypto, etc).
+
+## composable
+
+ah is a loop: it takes a prompt, calls tools, and repeats until it's done.
+everything else lives outside ah, in the shell and in other tools.
+
+- commands are markdown prompts in `sys/commands/*.md`; invoke with `/<name>`.
+- state and context live in the conversation; ah doesn't invent its own
+  mechanisms for things the shell already does.
+- the minimal CLI surface is the point: it gives other tools (scripts,
+  pipelines, cron, other programs) the full power of ah without requiring
+  them to know anything about ah.
+
+## embeddable
+
+ah is a portable executable archive. to configure and extend itself, ah
+modifies files in its archive. it generally does not rely on external files
+(except for authentication), though it can explore its environment and
+execute/modify things in the environment.
+
+being embeddable is part of what makes ah portable: copying the ah file
+carries with it everything needed to run.
+
+## reliable
+
+ah is reliable because it is tested. it is tested because the code it writes
+for itself is testable. the tests themselves are reliable because they are
+written first, proving the implementation that follows.
+
+## learnable
+
+ah is learnable because it is small and focused, so there is little to
+learn. documentation lives with the thing it documents: inside ah, accessible
+from the command line, embedded inline in code.
+
+## general
+
+ah is general. in practice, it should be good at coding and other software
+problems. but it can solve other problems by first turning them into software
+problems.
+
+## inspiration
+
+ah is inspired by:
+
+- https://github.com/badlogic/pi-mono
+- https://github.com/strongdm/attractor

--- a/scenarios/composable.md
+++ b/scenarios/composable.md
@@ -1,8 +1,0 @@
-# composable
-
-- `ah` is a loop: it takes a prompt, calls tools, and repeats until it's done
-- everything else lives outside `ah`, in the shell and in other tools
-- there is no "clear" command — you just point `ah` at a new `--db` and start fresh
-- commands are markdown prompts in sys/commands/*.md; invoke with /<name>
-- state and context live in the conversation; `ah` doesn't need to invent its own mechanisms for things the shell already does
-- the minimal CLI surface is the point: it gives other tools (scripts, pipelines, cron, other programs) the full power of `ah` without requiring them to know anything about `ah`

--- a/scenarios/cosmic.md
+++ b/scenarios/cosmic.md
@@ -1,6 +1,0 @@
-# cosmic
-
-- `ah` is cosmic
-- cosmic is a lua distribution with batteries included: https://github.com/whilp/cosmic
-- this matters because cosmic provides a safe (typed), functional, portable basis for `ah`
-  

--- a/scenarios/embeddable.md
+++ b/scenarios/embeddable.md
@@ -1,6 +1,0 @@
-# embeddable
-
-- `ah` itself is a portable executable archive
-- to configure and extend it(self), `ah` modifies files in its archive
-- `ah` generally does not rely on external files (except maybe for authentication), though it can of course explore its environment and execute/modify things in the environment
-- being embeddable is part of what makes `ah` portable: making a copy of the `ah` file carries with it everything needed to run `ah`

--- a/scenarios/general.md
+++ b/scenarios/general.md
@@ -1,5 +1,0 @@
-# general
-
-- `ah` is general.
-- in practice, it should be good at coding and other software problems.
-- but it can solve other problems by first turning them into software problems.

--- a/scenarios/identity.md
+++ b/scenarios/identity.md
@@ -1,6 +1,0 @@
-# identity
-
-- `ah` is an **a**gent **h**arness
-- most importantly, it is improvable: because it can be improved and extended, it can become good at many other things
-- it is built with `whilp/cosmic`, which is a lua distribution that in turn builds on (a fork of) `jart/cosmopolitan`
-- because it is `cosmic`, `ah` has everything it needs to build tools to do more (sqlite, http, json, crypto, etc)

--- a/scenarios/inspo.md
+++ b/scenarios/inspo.md
@@ -1,6 +1,0 @@
-# inspo
-
-`ah` is inspired by (and not as good as) these projects:
-
-- https://github.com/badlogic/pi-mono
-- https://github.com/strongdm/attractor

--- a/scenarios/learnable.md
+++ b/scenarios/learnable.md
@@ -1,6 +1,0 @@
-# learnable
-
-- `ah` is learnable
-- it is learnable because it is small and focused, so there is little to learn
-- it is also learnable because it (and the things it extends and builds) include detailed documentation
-- documentation lives with the thing it documents: inside `ah`, accessible from the command line, embedded inline in code, etc

--- a/scenarios/reliable.md
+++ b/scenarios/reliable.md
@@ -1,6 +1,0 @@
-# reliable
-
-- `ah` is reliable
-- this is because it is tested.
-- and it is tested because the code it writes for itself is testable.
-- and the tests themselves are reliable because they are written first, proving the implementation that follows.


### PR DESCRIPTION
merge 8 scenario files (composable, cosmic, embeddable, general, identity, inspo, learnable, reliable) into a single `docs/design.md`. add design doc to AGENTS.md index. remove `scenarios/` directory.

the scenario files were standalone design philosophy notes not referenced anywhere. consolidating them into docs keeps all documentation in one place.