### PR TITLE
add blank line before usage stats after turn

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -374,6 +374,7 @@ local function make_cli_handler(skill_name: string): events.EventCallback
       local total_out = event.total_output_tokens or 0
       local cache_read = event.total_cache_read_tokens or 0
       if total_in > 0 or total_out > 0 then
+        io.stderr:write("\n")
         local in_str = format_tokens(total_in)
         if cache_read > 0 then
           in_str = in_str .. " (" .. format_tokens(cache_read) .. " cached)"


### PR DESCRIPTION
Fixes #208

Adds a visual separator between agent response text and usage statistics by adding a blank line before the usage line.

## Changes
- `lib/ah/init.tl`: Add `io.stderr:write("\n")` before usage stats in `agent_end` handler

## Result
Agent output now has clearer visual separation:
```
<agent response text>

13.1k in / 3.1k out (16.2k total)
```

The extra newline is only written when there are usage stats to display, and follows the same pattern used elsewhere in the codebase for visual separation.

Closes #208