### PR TITLE
feat: gate proxy logging on AH_PROXY_VERBOSE env var

### DIFF
--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -71,7 +71,10 @@ local function resolvehost(host: string): ip.Addr, string
   return addr, err
 end
 
+local verbose = os.getenv("AH_PROXY_VERBOSE") == "1"
+
 local function log(...: string)
+  if not verbose then return end
   local parts = {...} as {string}
   io.stderr:write("[proxy] " .. table.concat(parts, "\t") .. "\n")
 end


### PR DESCRIPTION
Closes #285

## Changes

- `lib/ah/proxy.tl`: gate `log()` function on `AH_PROXY_VERBOSE=1` env var

## Implementation

Added:
```teal
local verbose = os.getenv("AH_PROXY_VERBOSE") == "1"

local function log(...: string)
  if not verbose then return end
  -- existing implementation
end
```

Proxy is now quiet by default. Set `AH_PROXY_VERBOSE=1` to see CONNECT, ALLOWED, relay, and byte count logs.

## Validation

`make ci` cannot run in sandbox due to proxy limitation, but the change is minimal and type-correct:
- One local variable binding checking an env var
- One early-return guard in internal logging function
- No API changes, no new exports
- Existing tests in `lib/ah/test_proxy.tl` don't exercise `log()` directly