### PR TITLE
feat: auto-add ANTHROPIC_BASE_URL host to proxy allowlist

### DIFF
--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -27,6 +27,7 @@ local record M
   resolvehost: function(string): ip.Addr, string
   is_allowed: function(string): boolean
   parse_allow_hosts: function(string): {string:boolean}
+  parse_base_url: function(string): string
   nb_connect: function(Socket, number, integer): boolean, string
 end
 
@@ -54,6 +55,34 @@ if allow_hosts_env then
   local extra = parse_allow_hosts(allow_hosts_env)
   for host, _ in pairs(extra) do
     ALLOWLIST[host] = true
+  end
+end
+
+-- Parse a URL into host:port. Returns nil for invalid/empty input.
+-- Only handles http:// and https:// schemes.
+local function parse_base_url(url: string): string
+  if not url or url == "" then return nil end
+  local scheme, rest = url:match("^(https?)://(.+)$")
+  if not scheme or not rest then return nil end
+  -- Strip path: take everything before the first /
+  local hostport = rest:match("^([^/]+)")
+  if not hostport or hostport == "" then return nil end
+  -- Check if port is already specified
+  local h, p = hostport:match("^(.+):(%d+)$")
+  if h and p then
+    return h .. ":" .. p
+  end
+  -- No port specified: default based on scheme
+  local default_port = scheme == "https" and "443" or "80"
+  return hostport .. ":" .. default_port
+end
+
+-- Add ANTHROPIC_BASE_URL host to allowlist at load time
+local base_url_env = os.getenv("ANTHROPIC_BASE_URL")
+if base_url_env then
+  local hostport = parse_base_url(base_url_env)
+  if hostport then
+    ALLOWLIST[hostport] = true
   end
 end
 
@@ -272,6 +301,7 @@ M.is_allowed = function(dest: string): boolean
   return ALLOWLIST[dest] or false
 end
 M.parse_allow_hosts = parse_allow_hosts
+M.parse_base_url = parse_base_url
 M.nb_connect = nb_connect
 
 return M

--- a/lib/ah/test_proxy.tl
+++ b/lib/ah/test_proxy.tl
@@ -20,6 +20,7 @@ local record Proxy
   resolvehost: function(string): ip.Addr, string
   is_allowed: function(string): boolean
   parse_allow_hosts: function(string): {string:boolean}
+  parse_base_url: function(string): string
   nb_connect: function(Socket, number, integer): boolean, string
 end
 
@@ -242,5 +243,77 @@ local function test_nb_connect_refused()
   print("✓ nb_connect: connection refused returns error")
 end
 test_nb_connect_refused()
+
+-- parse_base_url tests
+
+local function test_parse_base_url_https_default_port()
+  local result = proxy.parse_base_url("https://custom.example.com")
+  assert(result == "custom.example.com:443", "should be custom.example.com:443, got: " .. tostring(result))
+  print("✓ parse_base_url: https default port")
+end
+test_parse_base_url_https_default_port()
+
+local function test_parse_base_url_https_explicit_port()
+  local result = proxy.parse_base_url("https://custom.example.com:8443")
+  assert(result == "custom.example.com:8443", "should be custom.example.com:8443, got: " .. tostring(result))
+  print("✓ parse_base_url: https explicit port")
+end
+test_parse_base_url_https_explicit_port()
+
+local function test_parse_base_url_http()
+  local result = proxy.parse_base_url("http://custom.example.com")
+  assert(result == "custom.example.com:80", "should be custom.example.com:80, got: " .. tostring(result))
+  print("✓ parse_base_url: http default port")
+end
+test_parse_base_url_http()
+
+local function test_parse_base_url_with_path()
+  local result = proxy.parse_base_url("https://custom.example.com/v1")
+  assert(result == "custom.example.com:443", "should strip path, got: " .. tostring(result))
+  print("✓ parse_base_url: strips path")
+end
+test_parse_base_url_with_path()
+
+local function test_parse_base_url_with_port_and_path()
+  local result = proxy.parse_base_url("https://custom.example.com:8443/v1/messages")
+  assert(result == "custom.example.com:8443", "should be custom.example.com:8443, got: " .. tostring(result))
+  print("✓ parse_base_url: port and path")
+end
+test_parse_base_url_with_port_and_path()
+
+local function test_parse_base_url_nil()
+  local result = proxy.parse_base_url(nil)
+  assert(result == nil, "nil should return nil, got: " .. tostring(result))
+  print("✓ parse_base_url: nil input")
+end
+test_parse_base_url_nil()
+
+local function test_parse_base_url_empty()
+  local result = proxy.parse_base_url("")
+  assert(result == nil, "empty string should return nil, got: " .. tostring(result))
+  print("✓ parse_base_url: empty string")
+end
+test_parse_base_url_empty()
+
+local function test_parse_base_url_default_anthropic()
+  local result = proxy.parse_base_url("https://api.anthropic.com")
+  assert(result == "api.anthropic.com:443", "should be api.anthropic.com:443, got: " .. tostring(result))
+  print("✓ parse_base_url: default anthropic URL")
+end
+test_parse_base_url_default_anthropic()
+
+local function test_parse_base_url_no_scheme()
+  local result = proxy.parse_base_url("custom.example.com:443")
+  assert(result == nil, "no scheme should return nil, got: " .. tostring(result))
+  print("✓ parse_base_url: no scheme returns nil")
+end
+test_parse_base_url_no_scheme()
+
+local function test_parse_base_url_ftp_scheme()
+  local result = proxy.parse_base_url("ftp://custom.example.com")
+  assert(result == nil, "ftp scheme should return nil, got: " .. tostring(result))
+  print("✓ parse_base_url: unsupported scheme returns nil")
+end
+test_parse_base_url_ftp_scheme()
 
 print("\nall proxy tests passed")


### PR DESCRIPTION
When ANTHROPIC_BASE_URL is set, parse the hostname and port from the URL and add it to the proxy allowlist automatically. This removes the need to manually specify --allow-host when using a custom API endpoint in sandbox mode.

Closes #297

## Changes
- Added `parse_base_url` function to extract host:port from URLs
- Integrated ANTHROPIC_BASE_URL parsing at proxy module load time
- Added 10 comprehensive tests covering various URL formats and edge cases

## Testing
- ✓ All type checks pass
- ✓ All 35 proxy tests pass (25 existing + 10 new)