### PR TITLE
feat: enable require() for sibling modules in tool directories

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -66,8 +66,6 @@ returned include `path` and `line_count`.
 
 ## tool format
 
-## tool format
-
 tools are defined as lua or teal modules that return a table:
 
 ```lua
@@ -117,6 +115,22 @@ higher-priority formats win. for example, if `tools/` contains both
 embedded tiers (system, embed) only contain `.lua` files since
 `sys/tools/*.tl` is pre-compiled by the Makefile. `.tl` runtime loading
 is primarily useful at the project tier.
+
+### sibling module requires
+
+tools can `require()` sibling lua or teal modules from the same directory.
+when tools are loaded from a directory, that directory is added to
+`package.path`. the teal package searcher automatically finds `.tl` files
+using the same paths, so both `require("helper")` for `helper.lua` and
+`require("helper")` for `helper.tl` work.
+
+sibling modules that are not valid tools (i.e. don't return a table with
+name, description, input_schema, execute) are skipped during tool loading
+but remain available via `require()`.
+
+this also works for tools loaded via `--tool name=path.lua` or
+`--tool name=path.tl` — the file's parent directory is added to
+`package.path`.
 
 ### overriding core tools
 

--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -1244,4 +1244,140 @@ local function test_add_tool_override_lua_nonexistent()
 end
 test_add_tool_override_lua_nonexistent()
 
+-- Test that lua tools can require sibling lua modules
+local function test_lua_tool_require_lua()
+  local tool_dir = fs.join(TEST_TMPDIR, "lua_require_lua")
+  fs.makedirs(tool_dir)
+
+  -- Helper module
+  cio.barf(fs.join(tool_dir, "helper.lua"), [[
+return { greet = function(name) return "hello, " .. name end }
+]])
+
+  -- Tool that requires the helper
+  cio.barf(fs.join(tool_dir, "greeter.lua"), [[
+local helper = require("helper")
+return {
+  name = "greeter",
+  description = "Greet with helper",
+  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}},
+  execute = function(input)
+    return helper.greet(input.name), false
+  end,
+}
+]])
+
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 1, "should load 1 tool (helper is not a valid tool): " .. tostring(#loaded))
+  assert(loaded[1].name == "greeter", "should load greeter tool")
+
+  local result, is_error = loaded[1].execute({name = "world"})
+  assert(not is_error, "greeter should succeed: " .. tostring(result))
+  assert(result == "hello, world", "should use helper module: " .. result)
+
+  -- Clean up package.loaded to avoid interference
+  package.loaded["helper"] = nil
+
+  -- Reset
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ lua tool can require sibling lua module")
+end
+test_lua_tool_require_lua()
+
+-- Test that teal tools can require sibling teal modules
+local function test_teal_tool_require_teal()
+  local tool_dir = fs.join(TEST_TMPDIR, "tl_require_tl")
+  fs.makedirs(tool_dir)
+
+  -- Helper teal module
+  cio.barf(fs.join(tool_dir, "tl_helper.tl"), [[
+local record M
+  greet: function(string): string
+end
+
+function M.greet(name: string): string
+  return "hi, " .. name
+end
+
+return M
+]])
+
+  -- Tool that requires the teal helper
+  cio.barf(fs.join(tool_dir, "tl_greeter.tl"), [[
+local helper = require("tl_helper")
+return {
+  name = "tl_greeter",
+  description = "Greet with teal helper",
+  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}},
+  execute = function(input: {string:any}): string, boolean
+    local who = input.name as string
+    return helper.greet(who), false
+  end,
+}
+]])
+
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+
+  -- Find the greeter tool (helper is also a valid load target but not a tool)
+  local greeter: tools.Tool = nil
+  for _, t in ipairs(loaded) do
+    if t.name == "tl_greeter" then greeter = t end
+  end
+  assert(greeter, "should load tl_greeter tool")
+
+  local result, is_error = greeter.execute({name = "teal"})
+  assert(not is_error, "tl_greeter should succeed: " .. tostring(result))
+  assert(result == "hi, teal", "should use teal helper module: " .. result)
+
+  -- Clean up
+  package.loaded["tl_helper"] = nil
+
+  -- Reset
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ teal tool can require sibling teal module")
+end
+test_teal_tool_require_teal()
+
+-- Test that add_tool_override enables sibling requires
+local function test_add_tool_override_require()
+  local tool_dir = fs.join(TEST_TMPDIR, "override_require")
+  fs.makedirs(tool_dir)
+
+  -- Helper module
+  cio.barf(fs.join(tool_dir, "ovr_helper.lua"), [[
+return { msg = function() return "from-helper" end }
+]])
+
+  -- Tool that requires the helper
+  local tool_path = fs.join(tool_dir, "ovr_tool.lua")
+  cio.barf(tool_path, [[
+local ovr_helper = require("ovr_helper")
+return {
+  name = "ovr_tool",
+  description = "Override tool with require",
+  input_schema = {type = "object", properties = {}, required = {}},
+  execute = function()
+    return ovr_helper.msg(), false
+  end,
+}
+]])
+
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  tools.add_tool_override("ovr_tool", tool_path)
+
+  local result, is_error = tools.execute_tool("ovr_tool", {})
+  assert(not is_error, "override tool should succeed: " .. tostring(result))
+  assert(result == "from-helper", "should use helper via require: " .. result)
+
+  -- Clean up
+  package.loaded["ovr_helper"] = nil
+
+  -- Reset
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ add_tool_override enables sibling requires")
+end
+test_add_tool_override_require()
+
 print("\nAll tools tests passed!")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -42,6 +42,17 @@ local function is_valid_tool(t: any): boolean
   return true
 end
 
+-- Add a directory to package.path if not already present.
+-- This enables require() for sibling .lua and .tl modules in the same directory.
+-- The teal package searcher automatically substitutes .lua with .tl in package.path,
+-- so adding dir/?.lua covers both lua and teal requires.
+local function add_to_package_path(dir: string)
+  local pattern = dir .. "/?.lua"
+  if not package.path:find(pattern, 1, true) then
+    package.path = pattern .. ";" .. dir .. "/?/init.lua;" .. package.path
+  end
+end
+
 -- Load a tool module from a .tl or .lua file.
 -- Returns the loaded chunk or nil + error string.
 local function load_tool_file(tool_path: string): any, string
@@ -83,6 +94,13 @@ local function load_custom_tools_from_dir(dir: string): {Tool}
     end
   end
   dh:close()
+
+  -- Add directory to package.path so tools can require sibling modules
+  local has_candidates = false
+  for _ in pairs(candidates) do has_candidates = true; break end
+  if has_candidates then
+    add_to_package_path(dir)
+  end
 
   for _, tool_path in pairs(candidates) do
     local chunk, load_err = load_tool_file(tool_path)
@@ -310,6 +328,10 @@ end
 local function add_tool_override(name: string, cmd: string)
   -- .tl / .lua files: load as module tools
   if cmd:match("%.tl$") or cmd:match("%.lua$") then
+    -- Add tool's directory to package.path for sibling requires
+    local dir = cmd:match("^(.+)/[^/]+$") or "."
+    add_to_package_path(dir)
+
     local chunk, load_err = load_tool_file(cmd)
     if not chunk then
       io.stderr:write(string.format("warning: failed to load tool %s from %s: %s\n", name, cmd, tostring(load_err)))


### PR DESCRIPTION
tools can now `require()` sibling `.lua` and `.tl` modules from the same directory.

## problem

when a project-level tool (in `.ah/tools/` or `tools/`) or a `--tool` override tried to `require("helper")` for a sibling module in the same directory, it would fail because `package.path` didn't include the tool's directory.

## solution

when tools are loaded from a directory, that directory is added to `package.path` (`dir/?.lua` and `dir/?/init.lua`). the teal package searcher automatically substitutes `.lua` with `.tl` in `package.path`, so both lua and teal sibling requires work with a single path entry.

applied in two places:
- `load_custom_tools_from_dir()` — for project tools loaded at startup
- `add_tool_override()` — for `--tool name=path` overrides

## changes

- `lib/ah/tools.tl`: add `add_to_package_path()` helper, call it from both loading paths
- `lib/ah/test_tools.tl`: 3 new tests (lua→lua, teal→teal, --tool override require)
- `docs/tools.md`: document sibling module requires; fix duplicate heading