### PR TITLE
move cosmic deps to deps/*.mk files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,9 @@ Makefile               build system
 - **validation**: always run `make ci` before committing. it runs tests and
   type checks in parallel.
 - **build output**: everything goes under `o/`. never commit `o/`.
-- **cosmic dependency**: cosmic is pinned by URL and sha256 in `deps/cosmic.mk`
-  and `deps/cosmic-debug.mk`, included by the Makefile. binaries depend on
-  their `.mk` file — changing it triggers re-fetch.
+- **cosmic dependency**: cosmic is pinned by URL and sha256 in `deps/cosmic.mk`,
+  included by the Makefile. binaries depend on the `.mk` file — changing it
+  triggers re-fetch.
 - **releasing**: `make release` creates a GitHub prerelease (`RELEASE=1` for
   full). `.github/workflows/release.yml` runs daily and on manual dispatch.
 - **project context**: ah reads `CLAUDE.md` or `AGENTS.md` from the working

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ export TMPDIR := $(TMP)
 
 # dependencies
 include deps/cosmic.mk
-include deps/cosmic-debug.mk
 
 cosmic := $(o)/bin/cosmic
 
@@ -30,7 +29,7 @@ $(cosmic): deps/cosmic.mk
 
 cosmic_debug := $(o)/bin/cosmic-debug
 
-$(cosmic_debug): deps/cosmic-debug.mk
+$(cosmic_debug): deps/cosmic.mk
 	@rm -f $@
 	@mkdir -p $(@D)
 	@echo "==> fetching $(cosmic_debug_url)"

--- a/deps/cosmic-debug.mk
+++ b/deps/cosmic-debug.mk
@@ -1,2 +1,0 @@
-cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/2026-02-17-93239ce/cosmic-lua-debug
-cosmic_debug_sha := 517426f6327123eebf781f114646002da7b0eb969aac785e5ce2c9340f936197

--- a/deps/cosmic.mk
+++ b/deps/cosmic.mk
@@ -1,2 +1,4 @@
 cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-02-17-93239ce/cosmic-lua
 cosmic_sha := f7847182ec5c1c205e34b5e99dd68ddb02e280fda0f9cad4ee7eb19fd52a4858
+cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/2026-02-17-93239ce/cosmic-lua-debug
+cosmic_debug_sha := 517426f6327123eebf781f114646002da7b0eb969aac785e5ce2c9340f936197

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ embedded files are accessible at runtime under `/zip/embed/`.
 ## cosmic dependency
 
 ah depends on [cosmic](https://github.com/whilp/cosmic), a lua runtime.
-the Makefile includes `deps/cosmic.mk` and `deps/cosmic-debug.mk` which pin
-URL and sha256. binaries depend on their `.mk` file — changing it triggers
-re-fetch. cosmic provides: sqlite, http fetch, filesystem, process management,
+the Makefile includes `deps/cosmic.mk` which pins URL and sha256 for both
+cosmic and cosmic-debug. binaries depend on the `.mk` file — changing it
+triggers re-fetch. cosmic provides: sqlite, http fetch, filesystem, process management,
 signal handling, networking, json, sandbox primitives (unveil/pledge).


### PR DESCRIPTION
replace stamp-based version tracking with `deps/*.mk` includes. each binary depends on its `.mk` file — changing the file triggers re-fetch.

- `deps/cosmic.mk` — cosmic URL and sha256
- `deps/cosmic-debug.mk` — cosmic-debug URL and sha256
- Makefile — remove stamp machinery, use `include deps/*.mk`
- AGENTS.md, docs/architecture.md — updated

matches the pattern from https://github.com/whilp/working/pull/41.