### PR TITLE
load skill tools automatically when a skill is invoked

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -39,23 +39,29 @@ with unrelated `skills/` directories in the project.
 ## skill tool directories
 
 skills can bundle tools by placing `.tl` or `.lua` tool files in a
-`tools/` subdirectory alongside `SKILL.md`. these tools are **not loaded
-automatically** — the user must explicitly enable them via `--tool`:
+`tools/` subdirectory alongside `SKILL.md`. these tools are loaded
+automatically when the skill is invoked (via `--skill`, `/skill:name`,
+or the `skill` tool at runtime):
 
 ```
 skills/
   my-skill/
     SKILL.md
     tools/
-      gh.tl        ← available but not loaded unless --tool is used
+      gh.tl        ← loaded automatically when my-skill is invoked
 ```
+
+skill tools load between the project tier and `--tool` CLI overrides,
+so `--tool` still has highest precedence. a skill tool can shadow a
+project tool by name, and `--tool name=` can remove a skill tool.
 
 ```bash
-ah --skill my-skill -t gh=skills/my-skill/tools/gh.tl 'do the thing'
-```
+# skill tools load automatically:
+ah --skill my-skill 'do the thing'
 
-this ensures skills cannot silently change the tool surface. the skill's
-`SKILL.md` should document the required `--tool` invocation.
+# --tool can still override or remove skill tools:
+ah --skill my-skill -t gh= 'do the thing without gh'
+```
 
 ## invocation
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -90,8 +90,8 @@ tools are defined as lua or teal modules that return a table:
 ### tiers
 
 tools load from three directory tiers at startup via
-`tools.init_custom_tools(cwd)`, plus a CLI tier. later tiers override
-earlier ones by name:
+`tools.init_custom_tools(cwd)`, plus skill and CLI tiers. later tiers
+override earlier ones by name:
 
 1. **system** (`/zip/embed/sys/tools/`) — built-in tools (read, write,
    edit, bash). compiled from `sys/tools/*.tl` at build time. in dev/test,
@@ -99,7 +99,10 @@ earlier ones by name:
 2. **embed** (`/zip/embed/tools/`) — overlay for custom ah distributions.
 3. **project** (`cwd/.ah/tools/` or `cwd/tools/`) — project-local tools.
    `.ah/tools/` takes precedence if it exists; otherwise `tools/` is used.
-4. **CLI** (`--tool name=cmd`) — highest precedence, overrides everything.
+4. **skill** (`<skill-base-dir>/tools/`) — tools bundled with the active
+   skill. loaded automatically when a skill is invoked via `--skill`,
+   `/skill:name`, or the `skill` tool at runtime.
+5. **CLI** (`--tool name=cmd`) — highest precedence, overrides everything.
 
 ### file type precedence
 

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -1073,6 +1073,7 @@ local function main(args: {string}): integer, string
   local loaded_skills = skills.load_skills(cwd)
 
   -- --skill flag: prepend /skill:<name> to prompt
+  local active_skill_name: string = parsed.skill
   if parsed.skill then
     prompt = "/skill:" .. parsed.skill .. "\n" .. prompt
   end
@@ -1081,6 +1082,10 @@ local function main(args: {string}): integer, string
   local skill_expanded, was_skill = skills.expand_skill(prompt, loaded_skills)
   if was_skill then
     prompt = skill_expanded
+    -- Extract skill name if not already set from --skill flag
+    if not active_skill_name then
+      active_skill_name = prompt:match('^<skill name="([a-z0-9%-]+)"')
+    end
   end
 
   -- Expand commands (prompts starting with /)
@@ -1095,6 +1100,11 @@ local function main(args: {string}): integer, string
   -- Load system prompt
   -- Initialize custom tools (must happen before format_tools_for_prompt)
   tools.init_custom_tools(cwd)
+
+  -- Load tools from the active skill's tools/ subdirectory
+  if active_skill_name and loaded_skills[active_skill_name] then
+    tools.load_skill_tools(loaded_skills[active_skill_name].base_dir)
+  end
 
   -- Apply --tool overrides (highest precedence, overrides everything)
   -- name=cmd adds/replaces a tool; name= (empty cmd) removes it

--- a/lib/ah/test_skill_tool.tl
+++ b/lib/ah/test_skill_tool.tl
@@ -114,4 +114,141 @@ end
 test_empty_name()
 
 cleanup()
+
+-- Test load_skill_tools: loading a skill with tools/ subdirectory auto-loads its tools
+local function test_load_skill_tools()
+  -- Create a test skill with a tools/ subdirectory
+  local skill_dir = fs.join(tmpdir, "test-skill-with-tools")
+  local tools_dir_path = fs.join(skill_dir, "tools")
+  fs.makedirs(tools_dir_path)
+
+  cio.barf(fs.join(skill_dir, "SKILL.md"),
+    "---\nname: zz-test-with-tools\ndescription: A test skill with tools.\n---\n# Test\n\nHas tools.")
+
+  -- Create a simple .lua tool in the tools/ subdirectory
+  cio.barf(fs.join(tools_dir_path, "zz-test-skill-tool-auto.lua"), [[
+return {
+  name = "zz-test-skill-tool-auto",
+  description = "Auto-loaded test tool",
+  input_schema = {type = "object", properties = {}},
+  execute = function(input) return "ok", false end,
+}
+]])
+
+  -- Initialize tools (standard tiers only)
+  tools.init_custom_tools(cwd)
+
+  -- Verify tool is NOT loaded yet
+  local defs_before = tools.get_tool_definitions()
+  local found_before = false
+  for _, d in ipairs(defs_before) do
+    if d.name == "zz-test-skill-tool-auto" then
+      found_before = true
+      break
+    end
+  end
+  assert(not found_before, "skill tool should NOT be loaded before load_skill_tools")
+
+  -- Load skill tools
+  tools.load_skill_tools(skill_dir)
+
+  -- Verify tool IS loaded now
+  local defs_after = tools.get_tool_definitions()
+  local found_after = false
+  for _, d in ipairs(defs_after) do
+    if d.name == "zz-test-skill-tool-auto" then
+      found_after = true
+      break
+    end
+  end
+  assert(found_after, "skill tool should be loaded after load_skill_tools")
+
+  -- Verify the tool is functional
+  local result, is_error = tools.execute_tool("zz-test-skill-tool-auto", {})
+  assert(not is_error, "skill tool should execute without error")
+  assert(result == "ok", "skill tool should return 'ok'")
+
+  -- Cleanup
+  os.remove(fs.join(tools_dir_path, "zz-test-skill-tool-auto.lua"))
+  os.remove(fs.join(skill_dir, "SKILL.md"))
+  fs.rmdir(tools_dir_path)
+  fs.rmdir(skill_dir)
+
+  print("PASS: load_skill_tools auto-loads tools")
+end
+test_load_skill_tools()
+
+-- Test load_skill_tools with no tools/ directory is a no-op
+local function test_load_skill_tools_no_dir()
+  tools.init_custom_tools(cwd)
+  local count_before = #tools.get_tool_definitions()
+
+  -- Call with a directory that has no tools/ subdirectory
+  tools.load_skill_tools(tmpdir)
+
+  local count_after = #tools.get_tool_definitions()
+  assert(count_before == count_after, "tool count should not change when no tools/ dir exists")
+  print("PASS: load_skill_tools no-op without tools/ dir")
+end
+test_load_skill_tools_no_dir()
+
+-- Test that skill tool invocation auto-loads tools
+local function test_skill_tool_auto_loads()
+  -- Create a test skill with tools in the project skills dir
+  local skill_name_auto = "zz-test-auto-load"
+  local skill_dir_auto: string
+  local skill_tools_dir_auto: string
+  local dh2 = fs.opendir(dot_ah_skills)
+  if dh2 then
+    dh2:close()
+    skill_dir_auto = fs.join(dot_ah_skills, skill_name_auto)
+  else
+    skill_dir_auto = fs.join(skills_dir, skill_name_auto)
+  end
+  skill_tools_dir_auto = fs.join(skill_dir_auto, "tools")
+  fs.makedirs(skill_tools_dir_auto)
+
+  cio.barf(fs.join(skill_dir_auto, "SKILL.md"),
+    "---\nname: " .. skill_name_auto .. "\ndescription: Test auto load.\n---\n# Auto\n\nTest.")
+
+  cio.barf(fs.join(skill_tools_dir_auto, "zz-auto-tool.lua"), [[
+return {
+  name = "zz-auto-tool",
+  description = "Auto-loaded via skill tool",
+  input_schema = {type = "object", properties = {}},
+  execute = function(input) return "auto-ok", false end,
+}
+]])
+
+  -- Re-initialize tools
+  tools.init_custom_tools(cwd)
+
+  -- Verify tool NOT loaded yet
+  local found = false
+  for _, d in ipairs(tools.get_tool_definitions()) do
+    if d.name == "zz-auto-tool" then found = true; break end
+  end
+  assert(not found, "zz-auto-tool should not be loaded before skill tool invocation")
+
+  -- Invoke the skill tool — this should auto-load skill tools
+  local result, is_error = tools.execute_tool("skill", {name = skill_name_auto})
+  assert(not is_error, "skill tool should succeed: " .. tostring(result))
+
+  -- Verify tool IS loaded now
+  found = false
+  for _, d in ipairs(tools.get_tool_definitions()) do
+    if d.name == "zz-auto-tool" then found = true; break end
+  end
+  assert(found, "zz-auto-tool should be loaded after skill tool invocation")
+
+  -- Cleanup
+  os.remove(fs.join(skill_tools_dir_auto, "zz-auto-tool.lua"))
+  os.remove(fs.join(skill_dir_auto, "SKILL.md"))
+  fs.rmdir(skill_tools_dir_auto)
+  fs.rmdir(skill_dir_auto)
+
+  print("PASS: skill tool invocation auto-loads tools")
+end
+test_skill_tool_auto_loads()
+
 print("all skill tool tests passed")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -320,6 +320,33 @@ local function init_custom_tools(cwd?: string)
   end
 end
 
+-- Load tools from a skill's tools/ subdirectory and merge them into
+-- the active tool set. Called when a skill is invoked (--skill, /skill:name,
+-- or the skill tool at runtime). Skill tools override project-tier tools
+-- by name but are overridden by --tool CLI overrides.
+local function load_skill_tools(base_dir: string)
+  local tools_dir = base_dir .. "/tools"
+  local dh = fs.opendir(tools_dir)
+  if not dh then return end
+  dh:close()
+
+  -- Build name index of current tools
+  local by_name: {string:Tool} = {}
+  for _, tool in ipairs(tools) do
+    by_name[tool.name] = tool
+  end
+
+  -- Load CLI tools (executables) then module tools (.tl/.lua)
+  -- Module tools override CLI tools with the same basename
+  merge_tools(by_name, load_cli_tools_from_dir(tools_dir))
+  merge_tools(by_name, load_custom_tools_from_dir(tools_dir))
+
+  tools = {}
+  for _, tool in pairs(by_name) do
+    table.insert(tools, tool)
+  end
+end
+
 -- Add a tool override by name.
 -- If cmd ends in .tl or .lua, loads it as a module tool.
 -- Otherwise treats cmd as an executable path (wrapped as a CLI tool).
@@ -674,6 +701,7 @@ return {
   abort_running_tools = abort_running_tools,
   validate_input = validate_input,
   init_custom_tools = init_custom_tools,
+  load_skill_tools = load_skill_tools,
   add_tool_override = add_tool_override,
   remove_tool = remove_tool,
   load_custom_tools_from_dir = load_custom_tools_from_dir,

--- a/sys/tools/skill.tl
+++ b/sys/tools/skill.tl
@@ -1,5 +1,6 @@
 -- sys/tools/skill.tl: load a skill by name from available paths
 local skills = require("ah.skills")
+local tools = require("ah.tools")
 local cio = require("cosmic.io")
 
 -- Cache loaded skills (populated on first call)
@@ -53,6 +54,9 @@ return {
     for _ in body:gmatch("[^\n]*") do
       line_count = line_count + 1
     end
+
+    -- Auto-load tools from the skill's tools/ subdirectory
+    tools.load_skill_tools(skill.base_dir)
 
     return body, false, {
       path = skill.file_path,


### PR DESCRIPTION
when a skill has a `tools/` subdirectory, its tools are now loaded
automatically when the skill is invoked via `--skill` or `/skill:name`,
or when the agent loads a skill at runtime via the skill tool.

previously users had to manually specify `--tool` for each skill tool.
skill tools load between the project tier and `--tool` overrides, so
CLI overrides still have highest precedence.

## changes

- `lib/ah/tools.tl` — added `load_skill_tools(base_dir)` that loads tools from a skill's `tools/` subdirectory into the active tool set
- `lib/ah/init.tl` — after skill expansion and `init_custom_tools()`, calls `load_skill_tools()` for the active skill before `--tool` overrides
- `sys/tools/skill.tl` — calls `load_skill_tools()` after loading a skill at runtime via the skill tool
- `docs/skills.md` — updated skill tool directories section to reflect auto-loading
- `docs/tools.md` — added skill tier (tier 4) to the loading tiers list
- `lib/ah/test_skill_tool.tl` — added 3 tests: `load_skill_tools` basic, no-op without `tools/` dir, skill tool invocation auto-loads

## tier order

1. system → 2. embed → 3. project → **4. skill** → 5. CLI (`--tool`)