### PR TITLE
fix: colorblind-friendly diff colors (blue/yellow instead of red/green)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,8 @@ Makefile               build system
   ah also reads `.env` files.
 - **models**: aliases `sonnet`, `opus`, `haiku` resolve to full model names
   in `api.tl`. default model is `claude-opus-4-6`.
+- **accessibility**: terminal colors must be colorblind-friendly. avoid
+  red/green distinctions — use blue/yellow or bold/dim instead. all visual
+  indicators should be distinguishable without color (e.g. via shape, symbol,
+  or text). test color choices against common forms of color vision deficiency
+  (deuteranopia, protanopia, tritanopia).

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -327,6 +327,7 @@ local function cmd_usage(d: db.DB)
 end
 
 -- Colorize a single diff line with ANSI escape codes.
+-- Uses blue/yellow instead of green/red for colorblind accessibility.
 -- Returns the line with color prefix/suffix applied, or unchanged if not a diff line.
 local function colorize_diff_line(line: string): string
   if line:sub(1, 3) == "+++" or line:sub(1, 3) == "---" then
@@ -334,9 +335,9 @@ local function colorize_diff_line(line: string): string
   elseif line:sub(1, 2) == "@@" then
     return "\27[36m" .. line .. "\27[0m"
   elseif line:sub(1, 1) == "+" then
-    return "\27[32m" .. line .. "\27[0m"
+    return "\27[34m" .. line .. "\27[0m"
   elseif line:sub(1, 1) == "-" then
-    return "\27[31m" .. line .. "\27[0m"
+    return "\27[33m" .. line .. "\27[0m"
   end
   return line
 end

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -527,15 +527,15 @@ local init_diff = require("ah.init") as InitDiff
 
 local function test_colorize_diff_line_plus()
   local result = init_diff.colorize_diff_line("+added line")
-  assert(result == "\27[32m+added line\27[0m", "plus line should be green, got: " .. result)
-  print("✓ colorize_diff_line: + lines green")
+  assert(result == "\27[34m+added line\27[0m", "plus line should be blue, got: " .. result)
+  print("✓ colorize_diff_line: + lines blue")
 end
 test_colorize_diff_line_plus()
 
 local function test_colorize_diff_line_minus()
   local result = init_diff.colorize_diff_line("-removed line")
-  assert(result == "\27[31m-removed line\27[0m", "minus line should be red, got: " .. result)
-  print("✓ colorize_diff_line: - lines red")
+  assert(result == "\27[33m-removed line\27[0m", "minus line should be yellow, got: " .. result)
+  print("✓ colorize_diff_line: - lines yellow")
 end
 test_colorize_diff_line_minus()
 
@@ -570,8 +570,8 @@ test_colorize_diff_line_plain()
 local function test_colorize_diff_block()
   local input = "some text\n```diff\n+added\n-removed\n context\n```\nmore text\n"
   local result = init_diff.colorize_diff_block(input)
-  assert(result:find("\27%[32m%+added\27%[0m"), "should colorize + line green in diff fence")
-  assert(result:find("\27%[31m%-removed\27%[0m"), "should colorize - line red in diff fence")
+  assert(result:find("\27%[34m%+added\27%[0m"), "should colorize + line blue in diff fence")
+  assert(result:find("\27%[33m%-removed\27%[0m"), "should colorize - line yellow in diff fence")
   assert(result:find(" context"), "context line should be unchanged")
   assert(result:find("some text"), "text outside fence should be unchanged")
   assert(result:find("more text"), "text after fence should be unchanged")


### PR DESCRIPTION
Stacks on #351.

## Problem

PR #351 uses red/green terminal colors for diff highlighting. ~8% of men have red-green color vision deficiency (deuteranopia/protanopia), making additions and removals indistinguishable.

## Changes

- **`lib/ah/init.tl`**: replace green (`\27[32m`) with blue (`\27[34m`) for additions, red (`\27[31m`) with yellow (`\27[33m`) for removals. cyan and bold are unchanged (already accessible).
- **`lib/ah/test_init.tl`**: update test expectations to match new color codes.
- **`AGENTS.md`**: add accessibility convention requiring colorblind-friendly terminal colors and non-color-dependent visual indicators.

## Color rationale

Blue/yellow is distinguishable across all major forms of color vision deficiency (deuteranopia, protanopia, tritanopia) while remaining intuitive for full-color vision. File headers (bold) and hunk markers (cyan) were already accessible.