### PR TITLE
feat: skills reference other skills via the skill tool

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -85,6 +85,40 @@ the agent can call `skill(name="plan")` instead of reading the skill file
 directly. the tool returns the skill body (frontmatter stripped) with a
 metadata header showing source path, base directory, and line count.
 
+## composing skills
+
+skills can reference other skills. when a skill needs behavior defined in
+another skill, it tells the agent to load that skill at runtime using the
+`skill` tool. this avoids duplicating instructions across skills.
+
+prefer runtime loading over inlining — it keeps skills small and lets the
+agent load only what it needs for the current step. use natural language
+directives:
+
+```markdown
+### 6. Create a worktree for the fix
+
+Load the `worktree` skill (`skill(name="worktree")`) and use it to create
+an isolated worktree with branch `fix/<slug>`.
+```
+
+guidelines:
+
+- **reference by name**: use `skill(name="<name>")` so the agent knows
+  exactly which tool call to make.
+- **explain what to use it for**: say what the referenced skill provides
+  in this context (e.g., "use it to create an isolated worktree").
+- **don't duplicate**: if another skill already covers the steps, reference
+  it instead of copying the instructions.
+- **keep it optional when possible**: say "if you need a refresher, load
+  skill X" for conventions the agent may already know.
+
+examples in built-in skills:
+
+- `workflow` references `worktree` for creating fix branches and `pr` for
+  opening pull requests.
+- `fix` references `do` for shared conventions (git rules, staging).
+
 ## built-in skills
 
 | skill | purpose |

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -94,12 +94,10 @@ Trace the error back to source code:
 
 ### 6. On failure — fix via red-green TDD
 
-Create a worktree and branch for the fix:
+Load the `worktree` skill (`skill(name="worktree")`) and use it to create
+an isolated worktree with branch `fix/<slug>`.
 
-```bash
-git worktree add ../fix-<slug> -b fix/<slug> origin/main
-cd ../fix-<slug>
-```
+Inside the worktree:
 
 #### RED: write a failing test first
 
@@ -132,43 +130,13 @@ git push -u origin fix/<slug>
 
 ### 7. Open a PR
 
-```bash
-gh pr create --fill --base main
-```
+Load the `pr` skill (`skill(name="pr")`) and use it to open a PR,
+watch CI, and handle failures.
 
-### 8. Watch CI on the PR
+### 8. Clean up
 
-```bash
-gh pr checks --watch --fail-fast
-```
-
-If checks aren't available yet, wait and retry:
-
-```bash
-sleep 15
-gh pr checks
-```
-
-Then watch the run:
-
-```bash
-gh run watch <run-id> --exit-status
-```
-
-### 9. Handle CI failure on the PR
-
-If PR checks fail:
-
-```bash
-gh run view <run-id> --log-failed
-```
-
-Diagnose, fix, commit, push, and re-watch. Repeat until green.
-
-### 10. Clean up
-
-Report the final state. If a worktree was created, note its location
-so the user can clean up later.
+Report the final state. Offer to remove the worktree (the `worktree`
+skill covers cleanup).
 
 ## Output
 

--- a/sys/skills/fix.md
+++ b/sys/skills/fix.md
@@ -5,7 +5,8 @@ description: Fix issues found during review. Address check feedback, re-validate
 
 # Fix
 
-You are fixing issues found during review. Follow the plan and address the feedback.
+You are fixing issues found during review. This is a focused re-run of the
+`do` skill scoped to review feedback.
 
 ## Environment
 
@@ -20,9 +21,16 @@ The issue JSON follows this prompt with fields: `number`, `title`, `body`, `url`
 ## Instructions
 
 1. Fix the issues described in the review feedback
-2. Run validation steps from the plan
-3. Stage specific files (not `git add -A`)
-4. Commit with a message describing the fixes
+2. Follow the same conventions as the `do` skill — if you need a refresher,
+   load it with `skill(name="do")`
+3. Run validation steps from the plan
+4. Stage specific files (not `git add -A`)
+5. Commit with a message describing the fixes
+
+## Forbidden
+
+Same as the `do` skill: no destructive git commands (`git reset --hard`,
+`git checkout .`, `git clean -fd`, `git stash`, `git commit --no-verify`).
 
 ## Output
 


### PR DESCRIPTION
skills can now compose by telling the agent to load another skill at
runtime using `skill(name="<name>")`. this avoids duplicating instructions
across skills.

## changes

### `skills/workflow/SKILL.md`
- step 6 (worktree creation): replaced inline `git worktree add` instructions with a reference to the `worktree` skill
- steps 7-9 (PR, CI watch, CI failure handling): replaced ~30 lines of inline gh commands with a reference to the `pr` skill
- step 10 (cleanup): defers to `worktree` skill for cleanup
- net: -40 lines of duplicated instructions

### `sys/skills/fix.md`
- added reference to `do` skill for shared conventions
- added explicit `Forbidden` section referencing `do` skill's git rules (previously missing from `fix`)

### `docs/skills.md`
- new "composing skills" section documenting the pattern
- guidelines: reference by name, explain context, don't duplicate, keep optional when possible

## approach

convention-only — no new syntax, no code changes. the `skill` tool already
handles runtime loading. skills use natural language directives like:

> Load the `worktree` skill (`skill(name="worktree")`) and use it to
> create an isolated worktree.

this fits ah's minimal philosophy. the agent loads what it needs, when it
needs it, without bloating context with pre-expanded content.