### PR TITLE
feat: update opus 4.6 to 1M context window and 16K default output

### DIFF
--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -61,7 +61,7 @@ do
   end
 end
 local DEFAULT_MODEL = "claude-opus-4-6"
-local DEFAULT_MAX_TOKENS = 8192
+local DEFAULT_MAX_TOKENS = 16384
 
 local MODELS: {string} = {
   "claude-sonnet-4-5-20250929",

--- a/lib/ah/compact.tl
+++ b/lib/ah/compact.tl
@@ -11,7 +11,7 @@ local api = require("ah.api")
 local MODEL_CONTEXT_LIMITS: {string:integer} = {
   ["claude-sonnet-4-5-20250929"] = 200000,
   ["claude-opus-4-5-20251101"] = 200000,
-  ["claude-opus-4-6"] = 200000,
+  ["claude-opus-4-6"] = 1000000,
   ["claude-haiku-4-5-20251001"] = 200000,
 }
 

--- a/lib/ah/test_compact.tl
+++ b/lib/ah/test_compact.tl
@@ -13,7 +13,7 @@ test_get_context_limit_known_model()
 
 local function test_get_context_limit_opus()
   local limit = compact.get_context_limit("claude-opus-4-6")
-  assert(limit == 200000, "opus context limit should be 200000: " .. tostring(limit))
+  assert(limit == 1000000, "opus context limit should be 1000000: " .. tostring(limit))
   print("✓ get_context_limit known model (opus)")
 end
 test_get_context_limit_opus()


### PR DESCRIPTION
update claude opus 4.6 model parameters to match actual API capabilities.

## changes

- **compact.tl**: update `claude-opus-4-6` context window from 200K to 1M (1,000,000 tokens). this matches the actual model capability per litellm/models.dev metadata.
- **api.tl**: bump `DEFAULT_MAX_TOKENS` from 8192 to 16384. opus 4.6 supports up to 128K output tokens; 16K is a reasonable default that works well for agent coding tasks without being wasteful.
- **test_compact.tl**: update opus context limit assertion from 200000 to 1000000.

## context

opus 4.6 launched with a 1M context window and 128K max output tokens. ah was still configured with the old 200K context limit (inherited from opus 4.5) and an 8K default output limit. this caused:
- premature compaction triggers at ~160K tokens instead of ~800K
- unnecessarily small output tokens (8K vs 16K default)

ref: `/home/sprite/pi-mono/packages/ai/src/models.generated.ts` shows opus 4.6 with `maxTokens: 128000`. pi-mono was overriding `contextWindow` to 200K in its generate-models script, but litellm metadata confirms 1M.

closes #342