### PR TITLE
install teal package searcher for require() in .tl tools

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -1434,4 +1434,63 @@ return {
 end
 test_skill_tool_requires_project_module()
 
+-- Test that .tl skill tools can require() .tl modules from project root (cwd)
+-- Regression: tl.loader() was never called, so the teal package searcher
+-- was not installed and require() only searched for .lua files (issue #364)
+local function test_tl_skill_tool_requires_tl_module()
+  local project = fs.join(TEST_TMPDIR, "tl_skill_cwd_require")
+  local lib_dir = fs.join(project, "lib")
+  local skill_dir = fs.join(project, "skills", "tskill")
+  local skill_tools = fs.join(skill_dir, "tools")
+  fs.makedirs(lib_dir)
+  fs.makedirs(skill_tools)
+
+  -- Shared teal library at lib/tl_shared.tl
+  cio.barf(fs.join(lib_dir, "tl_shared.tl"), [[
+local record M
+  value: function(): string
+end
+
+function M.value(): string
+  return "from-tl-shared-lib"
+end
+
+return M
+]])
+
+  -- Skill tool (.tl) that requires "lib.tl_shared"
+  cio.barf(fs.join(skill_tools, "tskill.tl"), [[
+local shared = require("lib.tl_shared")
+return {
+  name = "tskill",
+  description = "Teal skill tool that uses teal shared lib",
+  input_schema = {type = "object", properties = {}, required = {}},
+  execute = function(): string, boolean
+    return shared.value(), false
+  end,
+}
+]])
+
+  -- init with this project as cwd, then load skill tools
+  tools.init_custom_tools(project)
+
+  local orig_dir = fs.getcwd()
+  fs.chdir(project)
+
+  tools.load_skill_tools(skill_dir)
+
+  fs.chdir(orig_dir)
+
+  -- The .tl skill tool should be loaded and functional
+  local result, is_error = tools.execute_tool("tskill", {})
+  assert(not is_error, "tl skill tool should load and execute: " .. tostring(result))
+  assert(result == "from-tl-shared-lib", "tl skill tool should require tl project module: " .. result)
+
+  -- Clean up
+  package.loaded["lib.tl_shared"] = nil
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ .tl skill tools can require() .tl modules from project root (cwd)")
+end
+test_tl_skill_tool_requires_tl_module()
+
 print("\nAll tools tests passed!")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -52,6 +52,11 @@ local function add_to_package_path(dir: string)
   end
 end
 
+-- Track whether the teal package searcher has been installed.
+-- tl.loader() registers a searcher in package.searchers so that
+-- require() inside .tl files can find other .tl modules.
+local tl_searcher_installed = false
+
 -- Load a tool module from a .tl or .lua file.
 -- Returns the loaded chunk or nil + error string.
 local function load_tool_file(tool_path: string): any, string
@@ -61,6 +66,11 @@ local function load_tool_file(tool_path: string): any, string
       return nil, "failed to read file"
     end
     local tl = require("tl") as {string:any}
+    if not tl_searcher_installed then
+      local tl_loader = tl.loader as function()
+      tl_loader()
+      tl_searcher_installed = true
+    end
     local loader = tl.load as function(string): any, string
     return loader(content)
   end

--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -23,8 +23,8 @@ local FILE_LINES: {string:integer} = {
   ["lib/ah/loop.tl"] = 952,
   ["lib/ah/test_db.tl"] = 506,
   ["lib/ah/test_init.tl"] = 688,
-  ["lib/ah/test_tools.tl"] = 1437,
-  ["lib/ah/tools.tl"] = 716,
+  ["lib/ah/test_tools.tl"] = 1496,
+  ["lib/ah/tools.tl"] = 726,
 }
 
 -- rules ---


### PR DESCRIPTION
## problem

when `ah` loads a `.tl` skill tool via `load_tool_file`, it compiles the teal source with `tl.load(content)` but never installs the teal package searcher. this means `require()` calls inside `.tl` tools only search `package.path` (`.lua` files), not `.tl` files.

## fix

call `tl.loader()` before executing `.tl` tool chunks to register the teal searcher in `package.searchers`. guarded by a module-level flag so it only runs once.

## test

adds a regression test: a `.tl` skill tool that `require("lib.tl_shared")` — a `.tl` module at the project root. without the fix, this fails with `module 'lib.tl_shared' not found`.

fixes #364