### PR TITLE
fix: resolve API_URL and proxy_url lazily so envd vars are available

### DIFF
--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -4,20 +4,21 @@ local fetch = require("cosmic.fetch")
 local time = require("cosmic.time")
 local auth = require("ah.auth")
 
--- Detect proxy from environment (set by work.tl for sandboxed processes)
-local proxy_url: string = nil
-do
+-- Detect proxy from environment (set by work.tl for sandboxed processes).
+-- Resolved lazily so envd.load() has time to set vars before first use.
+local function get_proxy_url(): string
   local http_proxy = os.getenv("https_proxy") or os.getenv("HTTPS_PROXY")
                   or os.getenv("http_proxy") or os.getenv("HTTP_PROXY")
   if http_proxy and http_proxy:sub(1, 7) == "unix://" then
     local path = http_proxy:sub(8)
     local url, err = fetch.unix_proxy(path)
     if url then
-      proxy_url = url
+      return url
     else
       io.stderr:write("[api] warning: invalid proxy url: " .. (err or "unknown") .. "\n")
     end
   end
+  return nil
 end
 
 -- Tool name mapping for Claude Code compatibility (OAuth mode)
@@ -50,14 +51,14 @@ local function now_ms(): integer
   return math.floor(s * 1000 + ns / 1e6) as integer
 end
 
-local API_URL: string
-do
+-- Resolve API URL lazily so envd.load() has time to set ANTHROPIC_BASE_URL.
+local function get_api_url(): string
   local base = os.getenv("ANTHROPIC_BASE_URL")
   if base then
     -- Strip trailing slash before appending path
-    API_URL = base:gsub("/$", "") .. "/v1/messages"
+    return base:gsub("/$", "") .. "/v1/messages"
   else
-    API_URL = "https://api.anthropic.com/v1/messages"
+    return "https://api.anthropic.com/v1/messages"
   end
 end
 local DEFAULT_MODEL = "claude-opus-4-6"
@@ -250,11 +251,11 @@ local function stream(messages: {any}, opts: {string:any}, callback: function({s
   local last_error: string = nil
 
   for attempt = 0, MAX_RETRIES do
-    local stream_result = fetch.stream(API_URL, {
+    local stream_result = fetch.stream(get_api_url(), {
       method = "POST",
       headers = auth_headers,
       body = body,
-      proxy = proxy_url,
+      proxy = get_proxy_url(),
     } as fetch.Opts)
 
     if not stream_result.ok then
@@ -444,6 +445,8 @@ return {
   resolve_model = resolve_model,
   to_claude_code_name = to_claude_code_name,
   from_claude_code_name = from_claude_code_name,
+  get_api_url = get_api_url,
+  get_proxy_url = get_proxy_url,
   DEFAULT_MODEL = DEFAULT_MODEL,
   MODEL_ALIASES = MODEL_ALIASES,
   MAX_RETRIES = MAX_RETRIES,

--- a/lib/ah/test_api.tl
+++ b/lib/ah/test_api.tl
@@ -275,4 +275,74 @@ local function test_build_request_non_oauth_tool_names()
 end
 test_build_request_non_oauth_tool_names()
 
+-- Tests for lazy API URL resolution
+local env = require("cosmic.env")
+
+local function test_get_api_url_default()
+  -- With no ANTHROPIC_BASE_URL set, should return the default
+  local saved = os.getenv("ANTHROPIC_BASE_URL")
+  env.unset("ANTHROPIC_BASE_URL")
+  local url = api.get_api_url()
+  assert(url == "https://api.anthropic.com/v1/messages",
+    "default API URL should be anthropic, got: " .. url)
+  if saved then env.set("ANTHROPIC_BASE_URL", saved) end
+  print("PASS test_get_api_url_default")
+end
+test_get_api_url_default()
+
+local function test_get_api_url_custom()
+  -- With ANTHROPIC_BASE_URL set, should use it (stripping trailing slash)
+  local saved = os.getenv("ANTHROPIC_BASE_URL")
+  env.set("ANTHROPIC_BASE_URL", "http://localhost:8080/")
+  local url = api.get_api_url()
+  assert(url == "http://localhost:8080/v1/messages",
+    "custom API URL should use base, got: " .. url)
+  -- Without trailing slash
+  env.set("ANTHROPIC_BASE_URL", "http://localhost:9090")
+  url = api.get_api_url()
+  assert(url == "http://localhost:9090/v1/messages",
+    "custom API URL without trailing slash, got: " .. url)
+  if saved then env.set("ANTHROPIC_BASE_URL", saved) else env.unset("ANTHROPIC_BASE_URL") end
+  print("PASS test_get_api_url_custom")
+end
+test_get_api_url_custom()
+
+local function test_get_api_url_lazy_after_env_change()
+  -- Simulate the envd.load() scenario: env var not set at first, then set later.
+  -- get_api_url should reflect the change because it reads lazily.
+  local saved = os.getenv("ANTHROPIC_BASE_URL")
+  env.unset("ANTHROPIC_BASE_URL")
+  local url1 = api.get_api_url()
+  assert(url1 == "https://api.anthropic.com/v1/messages", "before envd: default URL")
+  -- Simulate envd.load() setting the var
+  env.set("ANTHROPIC_BASE_URL", "http://litellm:4000")
+  local url2 = api.get_api_url()
+  assert(url2 == "http://litellm:4000/v1/messages",
+    "after envd: should use new base, got: " .. url2)
+  if saved then env.set("ANTHROPIC_BASE_URL", saved) else env.unset("ANTHROPIC_BASE_URL") end
+  print("PASS test_get_api_url_lazy_after_env_change")
+end
+test_get_api_url_lazy_after_env_change()
+
+local function test_get_proxy_url_none()
+  -- With no proxy env vars, should return nil
+  local saved = {
+    os.getenv("https_proxy"), os.getenv("HTTPS_PROXY"),
+    os.getenv("http_proxy"), os.getenv("HTTP_PROXY"),
+  }
+  env.unset("https_proxy")
+  env.unset("HTTPS_PROXY")
+  env.unset("http_proxy")
+  env.unset("HTTP_PROXY")
+  local url = api.get_proxy_url()
+  assert(url == nil, "no proxy vars should return nil, got: " .. tostring(url))
+  -- Restore
+  if saved[1] then env.set("https_proxy", saved[1]) end
+  if saved[2] then env.set("HTTPS_PROXY", saved[2]) end
+  if saved[3] then env.set("http_proxy", saved[3]) end
+  if saved[4] then env.set("HTTP_PROXY", saved[4]) end
+  print("PASS test_get_proxy_url_none")
+end
+test_get_proxy_url_none()
+
 print("all api tests passed")


### PR DESCRIPTION
ah.api cached API_URL from ANTHROPIC_BASE_URL and proxy_url from
https_proxy at module load time (line 12 of init.tl). envd.load()
didn't run until main() (line 756), so embedded env.d vars weren't
set yet. requests went to api.anthropic.com instead of the configured
base URL, causing 401s for litellm setups.

convert both to functions (get_api_url, get_proxy_url) that read from
os.getenv at call time, after envd has loaded. export them and add
tests covering default, custom, and lazy-after-env-change scenarios.
