### PR TITLE
proxy: handle short writes and read before error break

### DIFF
--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -29,6 +29,7 @@ local record M
   parse_allow_hosts: function(string): {string:boolean}
   parse_base_url: function(string): string
   nb_connect: function(Socket, number, integer): boolean, string
+  send_all: function(Socket, string): boolean, string
 end
 
 local ALLOWLIST: {string:boolean} = {
@@ -151,6 +152,36 @@ local function nb_connect(sock: Socket, addr: number, port: integer): boolean, s
   return false, "connect failed: unexpected poll events=" .. tostring(ev)
 end
 
+-- Send all data on a socket, handling short writes.
+-- Loops with poll(POLLOUT) until all bytes are sent.
+local SEND_TIMEOUT_MS = 30000
+
+local function send_all(sock: Socket, data: string): boolean, string
+  local sent = 0
+  while sent < #data do
+    local n, err = sock:send(data:sub(sent + 1))
+    if not n or n == 0 then
+      return false, err or "send failed"
+    end
+    sent = sent + (n as integer)
+    if sent < #data then
+      local fds: {number:number} = { [sock.fd] = net.POLLOUT }
+      local revents, poll_err = net.poll(fds, SEND_TIMEOUT_MS)
+      if not revents then
+        return false, "poll failed: " .. (poll_err or "unknown")
+      end
+      local ev = revents[sock.fd] or 0
+      if ev == 0 then
+        return false, "send timed out"
+      end
+      if ev & net.POLLERR ~= 0 then
+        return false, "send error"
+      end
+    end
+  end
+  return true
+end
+
 local function relay(client: Socket, upstream: Socket)
   local BUFSIZ = 65536
   local bytes_relayed: integer = 0
@@ -176,14 +207,11 @@ local function relay(client: Socket, upstream: Socket)
       break
     end
 
-    if client_ev & (net.POLLERR | net.POLLHUP | net.POLLNVAL) ~= 0 then
-      log("relay client event:", tostring(client_ev), "after", tostring(bytes_relayed), "bytes")
-      break
-    end
-    if upstream_ev & (net.POLLERR | net.POLLHUP | net.POLLNVAL) ~= 0 then
-      log("relay upstream event:", tostring(upstream_ev), "after", tostring(bytes_relayed), "bytes")
-      break
-    end
+    -- Read available data before checking error flags.
+    -- When POLLIN is set alongside POLLERR|POLLHUP, there may be an error
+    -- response to forward (e.g. API error message before connection close).
+    local client_err = false
+    local upstream_err = false
 
     if client_ev & net.POLLIN ~= 0 then
       local data = client:recv(BUFSIZ)
@@ -192,7 +220,11 @@ local function relay(client: Socket, upstream: Socket)
         break
       end
       bytes_relayed = bytes_relayed + #data
-      upstream:send(data)
+      local ok, send_err = send_all(upstream, data)
+      if not ok then
+        log("relay send to upstream failed:", send_err, "after", tostring(bytes_relayed), "bytes")
+        break
+      end
     end
 
     if upstream_ev & net.POLLIN ~= 0 then
@@ -202,7 +234,27 @@ local function relay(client: Socket, upstream: Socket)
         break
       end
       bytes_relayed = bytes_relayed + #data
-      client:send(data)
+      local ok, send_err = send_all(client, data)
+      if not ok then
+        log("relay send to client failed:", send_err, "after", tostring(bytes_relayed), "bytes")
+        break
+      end
+    end
+
+    -- Check error/hangup flags after reading any available data.
+    if client_ev & (net.POLLERR | net.POLLHUP | net.POLLNVAL) ~= 0 then
+      client_err = true
+    end
+    if upstream_ev & (net.POLLERR | net.POLLHUP | net.POLLNVAL) ~= 0 then
+      upstream_err = true
+    end
+    if client_err then
+      log("relay client event:", tostring(client_ev), "after", tostring(bytes_relayed), "bytes")
+      break
+    end
+    if upstream_err then
+      log("relay upstream event:", tostring(upstream_ev), "after", tostring(bytes_relayed), "bytes")
+      break
     end
   end
 end
@@ -303,5 +355,6 @@ end
 M.parse_allow_hosts = parse_allow_hosts
 M.parse_base_url = parse_base_url
 M.nb_connect = nb_connect
+M.send_all = send_all
 
 return M

--- a/lib/ah/test_proxy.tl
+++ b/lib/ah/test_proxy.tl
@@ -22,6 +22,7 @@ local record Proxy
   parse_allow_hosts: function(string): {string:boolean}
   parse_base_url: function(string): string
   nb_connect: function(Socket, number, integer): boolean, string
+  send_all: function(Socket, string): boolean, string
 end
 
 local proxy = require("ah.proxy") as Proxy
@@ -315,5 +316,88 @@ local function test_parse_base_url_ftp_scheme()
   print("✓ parse_base_url: unsupported scheme returns nil")
 end
 test_parse_base_url_ftp_scheme()
+
+-- send_all: sends data on a connected socket pair (loopback)
+local function test_send_all_basic()
+  -- Create a listener on loopback
+  local listener = net.socket(net.AF_INET, net.SOCK_STREAM, 0) as Socket
+  assert(listener, "listener socket creation should succeed")
+
+  local lo_addr, lo_err = ip.lookup("127.0.0.1")
+  assert(lo_addr, "should resolve localhost, got: " .. tostring(lo_err))
+
+  -- Bind to port 0 to get an ephemeral port
+  -- Use a simple approach: connect to a listener via unix socket pair
+  listener:close()
+
+  -- Use a unix socket pair instead for simplicity
+  local srv_path = os.tmpname()
+  os.remove(srv_path)
+  local server = net.listen_unix(srv_path, 1)
+  assert(server, "unix listen should succeed")
+
+  -- Connect a client
+  local client = net.connect_unix(srv_path) as Socket
+  assert(client, "unix connect should succeed")
+
+  -- Accept the connection
+  local peer = server:accept(net.SOCK_NONBLOCK) as Socket
+  assert(peer, "accept should succeed")
+
+  -- send_all on connected socket
+  local test_data = string.rep("x", 1024)
+  local ok, err = proxy.send_all(peer, test_data)
+  assert(ok, "send_all should succeed, got: " .. tostring(err))
+
+  -- Read it back
+  local received = (client as Socket):recv(2048)
+  assert(received == test_data, "should receive all data, got " .. tostring(#(received or "")) .. " bytes")
+
+  client:close()
+  peer:close()
+  server:close()
+  os.remove(srv_path)
+  print("✓ send_all: sends complete data")
+end
+test_send_all_basic()
+
+-- send_all: sends large data (>64KB, tests short write handling)
+local function test_send_all_large()
+  local srv_path = os.tmpname()
+  os.remove(srv_path)
+  local server = net.listen_unix(srv_path, 1)
+  assert(server, "unix listen should succeed")
+
+  local client = net.connect_unix(srv_path) as Socket
+  assert(client, "unix connect should succeed")
+
+  local peer = server:accept(net.SOCK_NONBLOCK) as Socket
+  assert(peer, "accept should succeed")
+
+  -- Send 64KB of data — fits in unix socket buffer, verifies send loop
+  local test_data = string.rep("A", 64 * 1024)
+  local ok, err = proxy.send_all(peer, test_data)
+  assert(ok, "send_all should succeed for large data, got: " .. tostring(err))
+
+  -- Read all data back (may need multiple recv calls)
+  local chunks: {string} = {}
+  local total = 0
+  while total < #test_data do
+    local fds: {number:number} = { [(client as Socket).fd] = net.POLLIN }
+    net.poll(fds, 5000)
+    local chunk = (client as Socket):recv(65536)
+    if not chunk or chunk == "" then break end
+    table.insert(chunks, chunk)
+    total = total + #chunk
+  end
+  assert(total == #test_data, "should receive all " .. tostring(#test_data) .. " bytes, got " .. tostring(total))
+
+  client:close()
+  peer:close()
+  server:close()
+  os.remove(srv_path)
+  print("✓ send_all: sends large data (64KB)")
+end
+test_send_all_large()
 
 print("\nall proxy tests passed")


### PR DESCRIPTION
## summary

fixes #405 — proxy relay silently drops data on short writes from non-blocking sockets.

## changes

### `send_all()` helper (lib/ah/proxy.tl)

adds a `send_all(sock, data)` function that loops until all bytes are sent:
- checks `send()` return value for short writes
- polls `POLLOUT` to wait for writability before retrying
- returns `false, err` on send failure, poll failure, timeout, or socket error

replaces bare `upstream:send(data)` and `client:send(data)` calls in the relay loop.

### relay error handling reorder

moves `POLLERR|POLLHUP|POLLNVAL` checks **after** data reads instead of before. when `POLLIN` is set alongside error flags (e.g. event 25 = `POLLIN|POLLERR|POLLHUP`), the relay now reads and forwards the available data before breaking. this surfaces actual API error messages (e.g. "invalid JSON") instead of opaque `transport error`.

### tests

adds two tests for `send_all`:
- basic: 1KB data over unix socket pair
- large: 64KB data over unix socket pair, verifying complete delivery

## root cause

on non-blocking sockets, `send()` can return fewer bytes than requested (short write) when the TCP send buffer fills. the old code ignored the return value, silently dropping unsent bytes. for API requests >~40KB, this corrupted the JSON body, causing the API to RST the connection. retries hit the same buffer conditions → same corruption → deterministic failure.