### PR TITLE
tools: remove CLI tool support, require .tl/.lua modules

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -366,152 +366,7 @@ local function test_bash_env_passthrough()
 end
 test_bash_env_passthrough()
 
--- CLI tool tests
-local function test_load_cli_tools_empty_dir()
-  local empty_dir = fs.join(TEST_TMPDIR, "empty_bin")
-  fs.makedirs(empty_dir)
-
-  local loaded = tools.load_cli_tools_from_dir(empty_dir)
-  assert(#loaded == 0, "should load 0 tools from empty dir")
-  print("✓ load_cli_tools handles empty directory")
-end
-test_load_cli_tools_empty_dir()
-
-local function test_load_cli_tools_nonexistent()
-  local loaded = tools.load_cli_tools_from_dir("/nonexistent/bin")
-  assert(#loaded == 0, "should return empty for nonexistent dir")
-  print("✓ load_cli_tools handles nonexistent directory")
-end
-test_load_cli_tools_nonexistent()
-
-local function test_load_cli_tool_with_md()
-  local bin_dir = fs.join(TEST_TMPDIR, "cli_tools_md")
-  fs.makedirs(bin_dir)
-
-  -- Create executable script
-  local script_path = fs.join(bin_dir, "greet")
-  cio.barf(script_path, [[#!/bin/sh
-echo "Hello, $1!"
-]], tonumber("755", 8))
-
-  -- Create description file with frontmatter and body
-  cio.barf(fs.join(bin_dir, "greet.md"), "---\ndescription: Greet someone by name\n---\n\nUsage: greet <name>\n\nAlways be polite.")
-
-  local loaded = tools.load_cli_tools_from_dir(bin_dir)
-  assert(#loaded == 1, "should load 1 tool")
-  assert(loaded[1].name == "greet", "tool name should be greet")
-  assert(loaded[1].description == "Greet someone by name", "should use description from frontmatter")
-  assert(loaded[1].system_prompt ~= nil, "should have system_prompt from body")
-  assert(loaded[1].system_prompt:match("Always be polite"), "system_prompt should contain body: " .. loaded[1].system_prompt)
-
-  local result, is_error = loaded[1].execute({args = "World"})
-  assert(not is_error, "should execute successfully")
-  assert(result:match("Hello, World!"), "should run command: " .. result)
-  print("✓ load_cli_tools loads tool with .md description")
-end
-test_load_cli_tool_with_md()
-
-local function test_load_cli_tool_with_help()
-  local bin_dir = fs.join(TEST_TMPDIR, "cli_tools_help")
-  fs.makedirs(bin_dir)
-
-  -- Create executable that responds to --help
-  local script_path = fs.join(bin_dir, "helper")
-  cio.barf(script_path, [[#!/bin/sh
-if [ "$1" = "--help" ]; then
-  echo "A helpful utility"
-  exit 0
-fi
-echo "running: $@"
-]], tonumber("755", 8))
-
-  local loaded = tools.load_cli_tools_from_dir(bin_dir)
-  assert(#loaded == 1, "should load 1 tool")
-  assert(loaded[1].name == "helper", "tool name should be helper")
-  assert(loaded[1].description == "A helpful utility", "should use --help output")
-  print("✓ load_cli_tools uses --help for description")
-end
-test_load_cli_tool_with_help()
-
-local function test_no_project_cli_tools_in_bin()
-  -- init_custom_tools should NOT load CLI tools from cwd/bin/
-  local project = fs.join(TEST_TMPDIR, "cli_no_project")
-  local project_bin = fs.join(project, "bin")
-  fs.makedirs(project_bin)
-
-  cio.barf(fs.join(project_bin, "mytool"), "#!/bin/sh\necho project", tonumber("755", 8))
-  cio.barf(fs.join(project_bin, "mytool.md"), "Project version")
-
-  tools.init_custom_tools(project)
-
-  -- mytool should NOT be available (cwd/bin/ is not scanned)
-  local found = false
-  for _, d in ipairs(tools.get_tool_definitions()) do
-    if (d as {string: any}).name == "mytool" then found = true end
-  end
-  assert(not found, "cwd/bin/ tools should not be loaded")
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent_project"))
-  print("✓ cwd/bin/ CLI tools are not loaded")
-end
-test_no_project_cli_tools_in_bin()
-
-local function test_executable_in_project_tools()
-  -- Executables in cwd/tools/ should be loaded as CLI tools
-  local project = fs.join(TEST_TMPDIR, "cli_in_tools")
-  local project_tools = fs.join(project, "tools")
-  fs.makedirs(project_tools)
-
-  cio.barf(fs.join(project_tools, "greet"), "#!/bin/sh\necho \"hello $1\"", tonumber("755", 8))
-  cio.barf(fs.join(project_tools, "greet.md"), "---\ndescription: Greet someone\n---\n\nAlways be polite.")
-
-  tools.init_custom_tools(project)
-
-  local result, is_error = tools.execute_tool("greet", {args = "world"})
-  assert(not is_error, "executable tool should work: " .. tostring(result))
-  assert(result:match("hello world"), "should run executable: " .. result)
-
-  -- Check system_prompt from .md body
-  local prompt = tools.format_tools_for_prompt()
-  assert(prompt:match("Always be polite"), "should include system_prompt from .md body")
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent_project"))
-  print("✓ executables in cwd/tools/ loaded as CLI tools")
-end
-test_executable_in_project_tools()
-
-local function test_lua_overrides_executable()
-  -- When both foo.lua and executable foo exist, lua wins
-  local project = fs.join(TEST_TMPDIR, "lua_over_exec")
-  local project_tools = fs.join(project, "tools")
-  fs.makedirs(project_tools)
-
-  cio.barf(fs.join(project_tools, "dupl"), "#!/bin/sh\necho from-exec", tonumber("755", 8))
-  cio.barf(fs.join(project_tools, "dupl.lua"), [[
-return {
-  name = "dupl",
-  description = "lua version",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function() return "from-lua", false end,
-}
-]])
-
-  tools.init_custom_tools(project)
-
-  local result, is_error = tools.execute_tool("dupl", {})
-  assert(not is_error, "should execute")
-  assert(result == "from-lua", "lua should override executable: " .. result)
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ lua module overrides executable with same name")
-end
-test_lua_overrides_executable()
-
 local function test_teal_tool_loading()
-  -- .tl files should be loadable as tools
   local project = fs.join(TEST_TMPDIR, "teal_tool")
   local project_tools = fs.join(project, "tools")
   fs.makedirs(project_tools)
@@ -582,32 +437,52 @@ test_teal_overrides_lua()
 local function test_add_tool_override()
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
 
-  -- Create an executable
-  local cmd_path = fs.join(TEST_TMPDIR, "my-tool")
-  cio.barf(cmd_path, "#!/bin/sh\necho \"hello from override $1\"", tonumber("755", 8))
+  -- Create a .lua module tool
+  local tool_dir = fs.join(TEST_TMPDIR, "override_tool")
+  fs.makedirs(tool_dir)
+  local tool_path = fs.join(tool_dir, "my-tool.lua")
+  cio.barf(tool_path, [[
+return {
+  name = "my-tool",
+  description = "An override tool",
+  input_schema = {type = "object", properties = {who = {type = "string"}}, required = {}},
+  execute = function(input)
+    return "hello from override " .. (input.who or "world"), false
+  end,
+}
+]])
 
-  tools.add_tool_override("my-tool", cmd_path)
+  tools.add_tool_override("my-tool", tool_path)
 
-  local result, is_error = tools.execute_tool("my-tool", {args = "world"})
+  local result, is_error = tools.execute_tool("my-tool", {who = "world"})
   assert(not is_error, "override tool should execute: " .. tostring(result))
-  assert(result:match("hello from override world"), "should run override cmd: " .. result)
+  assert(result:match("hello from override world"), "should run override: " .. result)
 
   -- Reset
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override registers a CLI tool")
+  print("✓ add_tool_override registers a .lua module tool")
 end
 test_add_tool_override()
 
 local function test_add_tool_override_replaces_existing()
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
 
-  -- bash is a system tool; override it
-  local cmd_path = fs.join(TEST_TMPDIR, "fake-bash")
-  cio.barf(cmd_path, "#!/bin/sh\necho replaced", tonumber("755", 8))
+  -- bash is a system tool; override it with a .lua module
+  local tool_dir = fs.join(TEST_TMPDIR, "override_bash")
+  fs.makedirs(tool_dir)
+  local tool_path = fs.join(tool_dir, "fake-bash.lua")
+  cio.barf(tool_path, [[
+return {
+  name = "bash",
+  description = "Fake bash",
+  input_schema = {type = "object", properties = {command = {type = "string"}}, required = {}},
+  execute = function() return "replaced", false end,
+}
+]])
 
-  tools.add_tool_override("bash", cmd_path)
+  tools.add_tool_override("bash", tool_path)
 
-  local result, is_error = tools.execute_tool("bash", {args = ""})
+  local result, is_error = tools.execute_tool("bash", {command = ""})
   assert(not is_error, "override should execute")
   assert(result:match("replaced"), "should run override, not system bash: " .. result)
 
@@ -617,24 +492,22 @@ local function test_add_tool_override_replaces_existing()
 end
 test_add_tool_override_replaces_existing()
 
-local function test_add_tool_override_with_md()
+local function test_add_tool_override_rejects_non_module()
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
 
-  local cmd_path = fs.join(TEST_TMPDIR, "deploy-tool")
-  cio.barf(cmd_path, "#!/bin/sh\necho deployed", tonumber("755", 8))
-  cio.barf(cmd_path .. ".md", "---\ndescription: Deploy the app\n---\n\nOnly deploy after tests pass.")
+  local defs_before = #tools.get_tool_definitions()
 
-  tools.add_tool_override("deploy", cmd_path)
+  -- Passing an executable (non .tl/.lua) should be rejected
+  tools.add_tool_override("deploy", "/usr/bin/echo")
 
-  local prompt = tools.format_tools_for_prompt()
-  assert(prompt:match("Deploy the app"), "should use description from .md")
-  assert(prompt:match("Only deploy after tests pass"), "should use system_prompt from .md body")
+  local defs_after = #tools.get_tool_definitions()
+  assert(defs_before == defs_after, "non-module tool should not be added")
 
   -- Reset
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override reads .md for description and system_prompt")
+  print("✓ add_tool_override rejects non .tl/.lua files")
 end
-test_add_tool_override_with_md()
+test_add_tool_override_rejects_non_module()
 
 -- Image read tests
 local json = require("cosmic.json")

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -133,158 +133,6 @@ local function load_custom_tools_from_dir(dir: string): {Tool}
   return loaded
 end
 
--- Check if a file is executable
-local function is_executable(path: string): boolean
-  local handle, err = child.spawn({"test", "-x", path})
-  if not handle then return false end
-  local _, _, exit_str = handle:read()
-  return tonumber(exit_str) == 0
-end
-
--- Parse simple yaml frontmatter from markdown content.
--- Returns frontmatter fields and body (content after frontmatter).
-local function parse_frontmatter(content: string): {string: string}, string
-  local fields: {string: string} = {}
-
-  if not content:match("^%-%-%-\n") then
-    return fields, content
-  end
-
-  local fm_end = content:find("\n%-%-%-\n", 4)
-  if not fm_end then
-    return fields, content
-  end
-
-  local fm_block = content:sub(5, fm_end - 1)
-  local body = content:sub(fm_end + 5)
-
-  for line in fm_block:gmatch("[^\n]+") do
-    local key, value = line:match("^([%w_%-]+):%s*(.+)$")
-    if key and value then
-      value = value:match("^[\"'](.+)[\"']$") or value
-      fields[key] = value
-    end
-  end
-
-  return fields, body
-end
-
--- Load CLI tools from a directory.
--- Each executable becomes a tool; description and system_prompt from <name>.md
-local function load_cli_tools_from_dir(dir: string): {Tool}
-  local loaded: {Tool} = {}
-
-  local dh = fs.opendir(dir)
-  if not dh then return loaded end
-
-  while true do
-    local name = dh:read()
-    if not name then break end
-    if name == "." or name == ".." then goto continue end
-
-    local bin_path = fs.join(dir, name)
-
-    -- Skip non-executables and metadata/source files
-    if name:match("%.md$") then goto continue end
-    if name:match("%.lua$") then goto continue end
-    if name:match("%.tl$") then goto continue end
-    if not is_executable(bin_path) then goto continue end
-
-    -- Get description and system_prompt from <name>.md (frontmatter + body)
-    local description = "CLI tool: " .. name
-    local tool_system_prompt: string = nil
-    local md_path = fs.join(dir, name .. ".md")
-    local md_content = cio.slurp(md_path)
-    if md_content then
-      local fields, body = parse_frontmatter(md_content)
-      if fields.description and fields.description ~= "" then
-        description = fields.description
-      else
-        -- Fall back to first non-empty, non-heading line
-        for line in md_content:gmatch("[^\n]+") do
-          local trimmed = line:match("^%s*(.-)%s*$")
-          if trimmed and trimmed ~= "" and not trimmed:match("^#") then
-            description = trimmed
-            break
-          end
-        end
-      end
-      -- Body after frontmatter becomes system_prompt guidance
-      local trimmed_body = body:match("^%s*(.-)%s*$")
-      if trimmed_body and trimmed_body ~= "" then
-        tool_system_prompt = trimmed_body
-      end
-    else
-      -- Try --help
-      local handle = child.spawn({bin_path, "--help"})
-      if handle then
-        local _, stdout = handle:read()
-        if stdout and stdout ~= "" then
-          local first_line = (stdout as string):match("^[^\n]+")
-          if first_line then
-            description = first_line:sub(1, 200)
-          end
-        end
-      end
-    end
-
-    -- Create tool
-    local tool_name = name
-    local tool_path = bin_path
-    local tool: Tool = {
-      name = tool_name,
-      description = description,
-      system_prompt = tool_system_prompt,
-      input_schema = {
-        type = "object",
-        properties = {
-          args = {type = "string", description = "Command-line arguments"},
-        },
-      },
-      execute = function(input: {string: any}): string, boolean, ToolDetails
-        local args_str = (input.args as string) or ""
-
-        -- Invoke via bash -c so args get proper shell expansion
-        local shell_cmd = tool_path
-        if args_str ~= "" then
-          shell_cmd = shell_cmd .. " " .. args_str
-        end
-
-        local handle, err = child.spawn({os.getenv("AH_SHELL") or "bash", "-c", shell_cmd})
-        if not handle then
-          return "error: failed to spawn: " .. tostring(err), true, nil
-        end
-
-        local _, stdout, exit_str = handle:read()
-        local stdout_str = (stdout as string) or ""
-        local exit_code = tonumber(exit_str) as integer or 0
-
-        local result_parts: {string} = {}
-        if stdout_str ~= "" then
-          table.insert(result_parts, stdout_str)
-        end
-        if exit_code ~= 0 then
-          table.insert(result_parts, "exit code: " .. tostring(exit_code))
-        end
-
-        local result = table.concat(result_parts, "\n")
-        if result == "" then
-          result = "(no output)"
-        end
-
-        return result, exit_code ~= 0,
-        {command = tool_name .. " " .. args_str, exit_code = exit_code} as ToolDetails
-      end,
-    }
-
-    table.insert(loaded, tool)
-    ::continue::
-  end
-
-  dh:close()
-  return loaded
-end
-
 -- Merge tools into a name-indexed map (later calls override earlier)
 local function merge_tools(by_name: {string: Tool}, new_tools: {Tool})
   for _, tool in ipairs(new_tools) do
@@ -313,7 +161,6 @@ local function init_custom_tools(cwd?: string)
   merge_tools(by_name, load_custom_tools_from_dir("/zip/embed/tools"))
 
   -- Project tier: .ah/tools wins over tools/ if present
-  -- Precedence within a directory: .tl > .lua > executable
   local dot_ah_tools = fs.join(cwd, ".ah", "tools")
   local bare_tools = fs.join(cwd, "tools")
   local dh_check = fs.opendir(dot_ah_tools)
@@ -324,7 +171,6 @@ local function init_custom_tools(cwd?: string)
   else
     project_tools_dir = bare_tools
   end
-  merge_tools(by_name, load_cli_tools_from_dir(project_tools_dir))
   merge_tools(by_name, load_custom_tools_from_dir(project_tools_dir))
 
   tools = {}
@@ -353,9 +199,7 @@ local function load_skill_tools(base_dir: string)
     by_name[tool.name] = tool
   end
 
-  -- Load CLI tools (executables) then module tools (.tl/.lua)
-  -- Module tools override CLI tools with the same basename
-  merge_tools(by_name, load_cli_tools_from_dir(tools_dir))
+  -- Load module tools (.tl/.lua)
   merge_tools(by_name, load_custom_tools_from_dir(tools_dir))
 
   tools = {}
@@ -365,112 +209,40 @@ local function load_skill_tools(base_dir: string)
 end
 
 -- Add a tool override by name.
--- If cmd ends in .tl or .lua, loads it as a module tool.
--- Otherwise treats cmd as an executable path (wrapped as a CLI tool).
+-- cmd must end in .tl or .lua — loads it as a module tool.
 -- This has highest precedence — it overrides system, embed, and project tools.
 local function add_tool_override(name: string, cmd: string)
-  -- .tl / .lua files: load as module tools
-  if cmd:match("%.tl$") or cmd:match("%.lua$") then
-    -- Add tool's directory to package.path for sibling requires
-    local dir = cmd:match("^(.+)/[^/]+$") or "."
-    add_to_package_path(dir)
-
-    local load_ok, chunk, load_err = pcall(load_tool_file, cmd)
-    if not load_ok then
-      -- chunk holds the thrown error message when pcall catches a throw
-      io.stderr:write(string.format("warning: failed to load tool %s from %s: %s\n", name, cmd, tostring(chunk)))
-      return
-    end
-    if not chunk then
-      io.stderr:write(string.format("warning: failed to load tool %s from %s: %s\n", name, cmd, tostring(load_err)))
-      return
-    end
-    local ok, result = pcall(chunk as function(): any)
-    if not ok then
-      io.stderr:write(string.format("warning: failed to execute tool %s from %s: %s\n", name, cmd, tostring(result)))
-      return
-    end
-    if not is_valid_tool(result) then
-      io.stderr:write(string.format("warning: invalid tool format in %s\n", cmd))
-      return
-    end
-    local tool = result as Tool
-    -- Use the name from --tool flag, not the module's internal name
-    tool.name = name
-
-    -- Override existing or append
-    for i, existing in ipairs(tools) do
-      if existing.name == name then
-        tools[i] = tool
-        return
-      end
-    end
-    table.insert(tools, tool)
+  if not (cmd:match("%.tl$") or cmd:match("%.lua$")) then
+    io.stderr:write(string.format("warning: tool %s: only .tl and .lua files are supported (got %s)\n", name, cmd))
     return
   end
 
-  -- Executable: wrap as CLI tool
-  -- Read description/system_prompt from <cmd>.md if it exists
-  local description = "CLI tool: " .. name
-  local tool_system_prompt: string = nil
-  local md_path = cmd .. ".md"
-  local md_content = cio.slurp(md_path)
-  if md_content then
-    local fields, body = parse_frontmatter(md_content)
-    if fields.description and fields.description ~= "" then
-      description = fields.description
-    end
-    local trimmed_body = body:match("^%s*(.-)%s*$")
-    if trimmed_body and trimmed_body ~= "" then
-      tool_system_prompt = trimmed_body
-    end
+  -- Add tool's directory to package.path for sibling requires
+  local dir = cmd:match("^(.+)/[^/]+$") or "."
+  add_to_package_path(dir)
+
+  local load_ok, chunk, load_err = pcall(load_tool_file, cmd)
+  if not load_ok then
+    -- chunk holds the thrown error message when pcall catches a throw
+    io.stderr:write(string.format("warning: failed to load tool %s from %s: %s\n", name, cmd, tostring(chunk)))
+    return
   end
-
-  local tool_cmd = cmd
-  local tool: Tool = {
-    name = name,
-    description = description,
-    system_prompt = tool_system_prompt,
-    input_schema = {
-      type = "object",
-      properties = {
-        args = {type = "string", description = "Command-line arguments"},
-      },
-    },
-    execute = function(input: {string: any}): string, boolean, ToolDetails
-      local args_str = (input.args as string) or ""
-      -- Invoke via bash -c so args get proper shell expansion
-      local shell_cmd = tool_cmd
-      if args_str ~= "" then
-        shell_cmd = shell_cmd .. " " .. args_str
-      end
-
-      local handle, spawn_err = child.spawn({os.getenv("AH_SHELL") or "bash", "-c", shell_cmd})
-      if not handle then
-        return "error: failed to spawn: " .. tostring(spawn_err), true, nil
-      end
-
-      local _, stdout, exit_str = handle:read()
-      local stdout_str = (stdout as string) or ""
-      local exit_code = tonumber(exit_str) as integer or 0
-
-      local result_parts: {string} = {}
-      if stdout_str ~= "" then
-        table.insert(result_parts, stdout_str)
-      end
-      if exit_code ~= 0 then
-        table.insert(result_parts, "exit code: " .. tostring(exit_code))
-      end
-
-      local result = table.concat(result_parts, "\n")
-      if result == "" then
-        result = "(no output)"
-      end
-
-      return result, exit_code ~= 0,
-      {command = name .. " " .. args_str, exit_code = exit_code} as ToolDetails
-    end,
-  }
+  if not chunk then
+    io.stderr:write(string.format("warning: failed to load tool %s from %s: %s\n", name, cmd, tostring(load_err)))
+    return
+  end
+  local ok, result = pcall(chunk as function(): any)
+  if not ok then
+    io.stderr:write(string.format("warning: failed to execute tool %s from %s: %s\n", name, cmd, tostring(result)))
+    return
+  end
+  if not is_valid_tool(result) then
+    io.stderr:write(string.format("warning: invalid tool format in %s\n", cmd))
+    return
+  end
+  local tool = result as Tool
+  -- Use the name from --tool flag, not the module's internal name
+  tool.name = name
 
   -- Override existing or append
   for i, existing in ipairs(tools) do
@@ -727,7 +499,6 @@ return {
   add_tool_override = add_tool_override,
   remove_tool = remove_tool,
   load_custom_tools_from_dir = load_custom_tools_from_dir,
-  load_cli_tools_from_dir = load_cli_tools_from_dir,
   is_valid_tool = is_valid_tool,
   Tool = Tool,
   ToolDetails = ToolDetails,

--- a/sys/help.md
+++ b/sys/help.md
@@ -23,7 +23,7 @@ options:
   --max-tokens N      stop when cumulative tokens exceed N
   --skill NAME        invoke a skill by name (prepends /skill:<name> to prompt)
   --must-produce FILE require the agent to write FILE before finishing
-  -t, --tool NAME=CMD register a CLI tool (repeatable, overrides all tiers)
+  -t, --tool NAME=CMD register a .tl/.lua tool (repeatable, overrides all tiers)
   --sandbox           run inside network sandbox (proxy + unveil + pledge)
   --timeout N         wall-clock timeout in seconds
   --allow-host H:P    allow egress to host:port (repeatable, default: api.anthropic.com:443)


### PR DESCRIPTION
Remove `load_cli_tools_from_dir` and all executable-as-tool support. Tools must now be `.tl` or `.lua` modules returning `{name, description, input_schema, execute}`. The `execute` function can shell out to any language via `cosmic.child.spawn`.

## Changes

- Remove `is_executable`, `parse_frontmatter`, `load_cli_tools_from_dir` functions
- Remove CLI tool wrapping in `add_tool_override` (now rejects non `.tl`/`.lua` with a warning)
- Remove CLI tool loading from `init_custom_tools` and `load_skill_tools`
- Remove `load_cli_tools_from_dir` export
- Remove all CLI tool tests, replace with module-based equivalents
- Remove executable tools and CLI tool sections from `docs/tools.md`
- Update `--tool` help text in `sys/help.md`

Net: **-385 lines** of code and tests.

Closes #409