### PR TITLE
tools: guard against os.exit() in tool loading via AST check

### DIFF
--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -1367,6 +1367,171 @@ return {
 end
 test_tl_skill_tool_requires_tl_module()
 
+-- Tests for looks_like_tool AST guard (issue #408)
+
+local function test_looks_like_tool_valid_lua()
+  local source = [[
+return {
+  name = "foo",
+  description = "A test tool",
+  input_schema = {type = "object", properties = {}},
+  execute = function() return "ok", false end,
+}
+]]
+  assert(tools.looks_like_tool(source, true), "valid lua tool should pass")
+  print("✓ looks_like_tool accepts valid lua tool")
+end
+test_looks_like_tool_valid_lua()
+
+local function test_looks_like_tool_valid_teal()
+  local source = [[
+return {
+  name = "greet",
+  description = "test",
+  input_schema = {type = "object", properties = {}},
+  execute = function(input: {string:any}): string, boolean
+    return "ok", false
+  end,
+}
+]]
+  assert(tools.looks_like_tool(source, false), "valid teal tool should pass")
+  print("✓ looks_like_tool accepts valid teal tool")
+end
+test_looks_like_tool_valid_teal()
+
+local function test_looks_like_tool_os_exit()
+  local source = "os.exit(0)"
+  assert(not tools.looks_like_tool(source, true), "os.exit() script should be rejected")
+  print("✓ looks_like_tool rejects os.exit() script")
+end
+test_looks_like_tool_os_exit()
+
+local function test_looks_like_tool_no_return()
+  local source = "print('hello')"
+  assert(not tools.looks_like_tool(source, true), "script without return should be rejected")
+  print("✓ looks_like_tool rejects script without return")
+end
+test_looks_like_tool_no_return()
+
+local function test_looks_like_tool_empty()
+  assert(not tools.looks_like_tool("", true), "empty source should be rejected")
+  print("✓ looks_like_tool rejects empty source")
+end
+test_looks_like_tool_empty()
+
+local function test_looks_like_tool_syntax_error()
+  assert(not tools.looks_like_tool("invalid !!!", true), "syntax error should be rejected")
+  print("✓ looks_like_tool rejects syntax errors")
+end
+test_looks_like_tool_syntax_error()
+
+local function test_looks_like_tool_missing_name()
+  local source = [[
+return {
+  description = "no name",
+  execute = function() end,
+}
+]]
+  assert(not tools.looks_like_tool(source, true), "table missing name should be rejected")
+  print("✓ looks_like_tool rejects table missing name key")
+end
+test_looks_like_tool_missing_name()
+
+local function test_looks_like_tool_missing_execute()
+  local source = [[
+return {
+  name = "foo",
+  description = "no execute",
+}
+]]
+  assert(not tools.looks_like_tool(source, true), "table missing execute should be rejected")
+  print("✓ looks_like_tool rejects table missing execute key")
+end
+test_looks_like_tool_missing_execute()
+
+local function test_looks_like_tool_variable_return()
+  -- Returns a variable — can't statically verify, should pass optimistically
+  local source = "local t = {} ; t.name = 'foo' ; return t"
+  assert(tools.looks_like_tool(source, true), "variable return should pass optimistically")
+  print("✓ looks_like_tool accepts variable return optimistically")
+end
+test_looks_like_tool_variable_return()
+
+local function test_looks_like_tool_function_call_return()
+  -- Returns a function call — can't statically verify, should pass optimistically
+  local source = "return require('foo').make_tool()"
+  assert(tools.looks_like_tool(source, true), "function call return should pass optimistically")
+  print("✓ looks_like_tool accepts function call return optimistically")
+end
+test_looks_like_tool_function_call_return()
+
+local function test_looks_like_tool_return_nil()
+  local source = "return nil"
+  -- nil return is a variable-like expression, passes optimistically
+  -- is_valid_tool will catch it at runtime
+  assert(tools.looks_like_tool(source, true), "return nil should pass optimistically")
+  print("✓ looks_like_tool accepts return nil optimistically")
+end
+test_looks_like_tool_return_nil()
+
+-- Integration test: os.exit() in tools dir is skipped without killing process
+local function test_os_exit_in_tools_dir_skipped()
+  local tool_dir = fs.join(TEST_TMPDIR, "os_exit_tools")
+  fs.makedirs(tool_dir)
+
+  -- This would kill the process if evaluated
+  cio.barf(fs.join(tool_dir, "killer.lua"), "os.exit(1)")
+
+  -- A valid tool alongside it
+  cio.barf(fs.join(tool_dir, "safe.lua"), [[
+return {
+  name = "safe",
+  description = "Safe tool",
+  input_schema = {type = "object", properties = {}, required = {}},
+  execute = function() return "safe", false end,
+}
+]])
+
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 1, "should load only the safe tool, got: " .. tostring(#loaded))
+  assert(loaded[1].name == "safe", "should load safe tool")
+  print("✓ os.exit() script in tools dir is skipped without killing process")
+end
+test_os_exit_in_tools_dir_skipped()
+
+-- Integration test: os.exit() in teal file is skipped
+local function test_os_exit_teal_skipped()
+  local tool_dir = fs.join(TEST_TMPDIR, "os_exit_teal")
+  fs.makedirs(tool_dir)
+
+  cio.barf(fs.join(tool_dir, "killer.tl"), "os.exit(1)")
+
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 0, "os.exit teal file should be skipped")
+  print("✓ os.exit() in .tl file is skipped without killing process")
+end
+test_os_exit_teal_skipped()
+
+-- Integration test: add_tool_override guards against os.exit()
+local function test_override_os_exit_guarded()
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local defs_before = #tools.get_tool_definitions()
+
+  local tool_dir = fs.join(TEST_TMPDIR, "override_os_exit")
+  fs.makedirs(tool_dir)
+  local bad_path = fs.join(tool_dir, "bad.lua")
+  cio.barf(bad_path, "os.exit(1)")
+
+  tools.add_tool_override("bad", bad_path)
+
+  local defs_after = #tools.get_tool_definitions()
+  assert(defs_before == defs_after, "os.exit override should not be added")
+
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ add_tool_override guards against os.exit() script")
+end
+test_override_os_exit_guarded()
+
 -- Tests for graceful handling of tools that fail to load (issue #321)
 
 local function test_teal_syntax_error_skipped()

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -57,6 +57,67 @@ end
 -- require() inside .tl files can find other .tl modules.
 local tl_searcher_installed = false
 
+-- Ensure the tl package searcher is installed. Called before any tl.load()
+-- or tl.process_string() usage.
+local function ensure_tl_searcher(): {string: any}
+  local tl = require("tl") as {string: any}
+  if not tl_searcher_installed then
+    local tl_loader = tl.loader as function()
+    tl_loader()
+    tl_searcher_installed = true
+  end
+  return tl
+end
+
+-- Check whether source code looks like a tool module by parsing the AST
+-- without evaluating it. This guards against os.exit() and other dangerous
+-- top-level side effects in files that aren't tool modules.
+--
+-- Returns true if the file could be a tool module, false if it definitely
+-- is not (wrong shape). Conservative: returns true for variable/call returns
+-- that can't be statically verified — is_valid_tool catches those at runtime.
+local function looks_like_tool(source: string, is_lua: boolean): boolean
+  local tl = ensure_tl_searcher()
+  local process_string = tl.process_string as function(string, boolean): {string: any}
+  local result = process_string(source, is_lua)
+
+  if result.syntax_errors and #(result.syntax_errors as {any}) > 0 then
+    return false
+  end
+
+  local ast = result.ast as {any}
+  if not ast or #ast == 0 then
+    return false
+  end
+
+  local last = ast[#ast] as {string: any}
+  if not last or last.kind ~= "return" then
+    return false
+  end
+
+  -- Check if the return expression is a literal table with name + execute keys
+  local exps = last.exps as {any}
+  if exps and #exps > 0 then
+    local ret = exps[1] as {string: any}
+    if ret.kind == "literal_table" then
+      local keys: {string: boolean} = {}
+      for _, entry in ipairs(ret as {any}) do
+        local e = entry as {string: any}
+        if e.key then
+          local key = e.key as {string: any}
+          local k = (key.conststr or key.tk) as string
+          if k then keys[k] = true end
+        end
+      end
+      return (keys["name"] and keys["execute"]) as boolean
+    end
+  end
+
+  -- Returns a variable or function call — can't verify statically.
+  -- Let is_valid_tool catch bad shapes at runtime.
+  return true
+end
+
 -- Load a tool module from a .tl or .lua file.
 -- Returns the loaded chunk or nil + error string.
 local function load_tool_file(tool_path: string): any, string
@@ -65,12 +126,7 @@ local function load_tool_file(tool_path: string): any, string
     if not content then
       return nil, "failed to read file"
     end
-    local tl = require("tl") as {string: any}
-    if not tl_searcher_installed then
-      local tl_loader = tl.loader as function()
-      tl_loader()
-      tl_searcher_installed = true
-    end
+    local tl = ensure_tl_searcher()
     local loader = tl.load as function(string): any, string
     return loader(content)
   end
@@ -112,21 +168,30 @@ local function load_custom_tools_from_dir(dir: string): {Tool}
   end
 
   for _, tool_path in pairs(candidates) do
-    local load_ok, chunk, load_err = pcall(load_tool_file, tool_path)
-    if not load_ok then
-      -- chunk holds the thrown error message when pcall catches a throw
-      io.stderr:write(string.format("warning: failed to load %s: %s\n", tool_path, tostring(chunk)))
-    elseif chunk then
-      local ok, result = pcall(chunk as function(): any)
-      if ok and is_valid_tool(result) then
-        table.insert(loaded, result as Tool)
-      elseif not ok then
-        io.stderr:write(string.format("warning: failed to execute %s: %s\n", tool_path, tostring(result)))
-      else
-        io.stderr:write(string.format("warning: invalid tool format in %s\n", tool_path))
-      end
+    -- Read source and check AST before evaluating — guards against os.exit()
+    -- and other dangerous side effects in non-tool files.
+    local source = cio.slurp(tool_path)
+    if not source then
+      io.stderr:write(string.format("warning: failed to read %s\n", tool_path))
+    elseif not looks_like_tool(source, tool_path:match("%.lua$") ~= nil) then
+      io.stderr:write(string.format("warning: skipping %s: does not look like a tool module\n", tool_path))
     else
-      io.stderr:write(string.format("warning: failed to load %s: %s\n", tool_path, tostring(load_err)))
+      local load_ok, chunk, load_err = pcall(load_tool_file, tool_path)
+      if not load_ok then
+        -- chunk holds the thrown error message when pcall catches a throw
+        io.stderr:write(string.format("warning: failed to load %s: %s\n", tool_path, tostring(chunk)))
+      elseif chunk then
+        local ok, result = pcall(chunk as function(): any)
+        if ok and is_valid_tool(result) then
+          table.insert(loaded, result as Tool)
+        elseif not ok then
+          io.stderr:write(string.format("warning: failed to execute %s: %s\n", tool_path, tostring(result)))
+        else
+          io.stderr:write(string.format("warning: invalid tool format in %s\n", tool_path))
+        end
+      else
+        io.stderr:write(string.format("warning: failed to load %s: %s\n", tool_path, tostring(load_err)))
+      end
     end
   end
 
@@ -220,6 +285,17 @@ local function add_tool_override(name: string, cmd: string)
   -- Add tool's directory to package.path for sibling requires
   local dir = cmd:match("^(.+)/[^/]+$") or "."
   add_to_package_path(dir)
+
+  -- Read source and check AST before evaluating — guards against os.exit()
+  local source = cio.slurp(cmd)
+  if not source then
+    io.stderr:write(string.format("warning: failed to read tool %s from %s\n", name, cmd))
+    return
+  end
+  if not looks_like_tool(source, cmd:match("%.lua$") ~= nil) then
+    io.stderr:write(string.format("warning: skipping tool %s from %s: does not look like a tool module\n", name, cmd))
+    return
+  end
 
   local load_ok, chunk, load_err = pcall(load_tool_file, cmd)
   if not load_ok then
@@ -500,6 +576,7 @@ return {
   remove_tool = remove_tool,
   load_custom_tools_from_dir = load_custom_tools_from_dir,
   is_valid_tool = is_valid_tool,
+  looks_like_tool = looks_like_tool,
   Tool = Tool,
   ToolDetails = ToolDetails,
 }

--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -23,7 +23,7 @@ local FILE_LINES: {string: integer} = {
   ["lib/ah/loop.tl"] = 952,
   ["lib/ah/test_db.tl"] = 506,
   ["lib/ah/test_init.tl"] = 846,
-  ["lib/ah/test_tools.tl"] = 1565,
+  ["lib/ah/test_tools.tl"] = 1610,
   ["lib/ah/tools.tl"] = 734,
 }
 


### PR DESCRIPTION
## Summary

Parse tool source files with `tl.process_string()` before evaluating them. Reject files that don't look like tool modules, preventing `os.exit()` and other dangerous top-level side effects from killing the process during tool loading.

## Changes

- **`lib/ah/tools.tl`**: Added `looks_like_tool(source, is_lua)` function that parses the AST without evaluating code. Checks that the last statement is a `return` and, for literal tables, verifies `name` and `execute` keys are present. Variable/call returns pass optimistically (caught by `is_valid_tool` at runtime). Extracted `ensure_tl_searcher()` helper to avoid duplication.

- **`load_custom_tools_from_dir`**: Now reads source and runs `looks_like_tool` before evaluating. Files that fail the check are skipped with a warning.

- **`add_tool_override`**: Same guard applied.

- **`lib/ah/test_tools.tl`**: 15 new tests covering the AST guard (`looks_like_tool` unit tests + integration tests with os.exit scripts in tool dirs and overrides).

## How it works

1. Read source with `cio.slurp`
2. Parse with `tl.process_string(source, is_lua)` — no evaluation
3. If syntax errors → skip
4. If last statement is not `return` → skip (catches `os.exit()`, `print()`, etc.)
5. If return is a literal table → check for `name` + `execute` keys
6. If return is a variable/call → pass optimistically, `is_valid_tool` catches bad shapes at runtime

Fixes #408