### PR TITLE
refactor: split large files into focused modules

### DIFF
--- a/lib/ah/args.tl
+++ b/lib/ah/args.tl
@@ -1,0 +1,236 @@
+-- ah/args.tl: CLI argument parsing
+local getopt = require("cosmic.getopt")
+local cio = require("cosmic.io")
+local api = require("ah.api")
+
+local record ParsedArgs
+  model: string
+  db_path: string
+  output_path: string
+  new_session: boolean
+  session_prefix: string
+  session_name: string
+  steer_msg: string
+  followup_msg: string
+  max_tokens: integer
+  sandbox: boolean
+  timeout: integer
+  allow_hosts: {string}
+  unveil_dirs: {string}
+  skill: string
+  must_produce: string
+  tool_overrides: {string}
+  cd_path: string
+  remaining: {string}
+end
+
+local function usage_text(): string
+  local parts: {string} = {}
+
+  -- Load base help text from embedded file
+  local base_help = cio.slurp("/zip/embed/sys/help.md") or ""
+
+  table.insert(parts, base_help)
+
+  -- Append dynamic model aliases
+  for alias, full in pairs(api.MODEL_ALIASES) do
+    table.insert(parts, string.format("  %-18s  %s\n", alias, full))
+  end
+  return table.concat(parts)
+end
+
+local function usage()
+  io.stderr:write(usage_text())
+end
+
+-- Parse colon-separated protect dirs from AH_PROTECT_DIRS env var
+local function parse_protect_dirs(s: string): {string}
+  local dirs: {string} = {}
+  if not s or s == "" then return dirs end
+  for dir in s:gmatch("[^:]+") do
+    table.insert(dirs, dir)
+  end
+  return dirs
+end
+
+-- Parse "path:perms" from --unveil value. Strips suffix, default to read-only
+local function parse_unveil_entry(entry: string): string, string
+  local path, perms = entry:match("^(.+):([rwxc]+)$")
+  if path and perms then
+    return path, perms
+  end
+  -- No perms suffix, default to read-only
+  return entry, "r"
+end
+
+local function parse_args(args: {string}): ParsedArgs, string
+  local result: ParsedArgs = {
+    new_session = false,
+    sandbox = false,
+    allow_hosts = {},
+    unveil_dirs = {},
+    tool_overrides = {},
+    remaining = {},
+  }
+
+  local longopts = {
+    {name = "help", has_arg = "none", short = "h"},
+    {name = "version", has_arg = "none", short = "V"},
+    {name = "new", has_arg = "none", short = "n"},
+    {name = "session", has_arg = "required", short = "S"},
+    {name = "name", has_arg = "required"},
+    {name = "db", has_arg = "required"},
+    {name = "model", has_arg = "required", short = "m"},
+    {name = "output", has_arg = "required", short = "o"},
+    {name = "steer", has_arg = "required"},
+    {name = "followup", has_arg = "required"},
+    {name = "max-tokens", has_arg = "required"},
+    {name = "sandbox", has_arg = "none"},
+    {name = "timeout", has_arg = "required"},
+    {name = "allow-host", has_arg = "required"},
+    {name = "unveil", has_arg = "required"},
+    {name = "skill", has_arg = "required"},
+    {name = "must-produce", has_arg = "required"},
+    {name = "tool", has_arg = "required", short = "t"},
+    {name = "cd", has_arg = "required"},
+  }
+
+  -- Use + prefix for POSIX mode: stop parsing options at first non-option arg.
+  -- This allows subcommands to have their own flags without the top-level
+  -- parser rejecting them as unknown options.
+  local parser = getopt.new(args, "+hVnS:m:o:t:", longopts)
+
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
+
+    if opt == "h" or opt == "help" then
+      return nil, "help"
+    elseif opt == "V" or opt == "version" then
+      return nil, "version"
+    elseif opt == "n" or opt == "new" then
+      result.new_session = true
+    elseif opt == "S" or opt == "session" then
+      result.session_prefix = optarg
+    elseif opt == "name" then
+      result.session_name = optarg
+    elseif opt == "db" then
+      result.db_path = optarg
+    elseif opt == "m" or opt == "model" then
+      result.model = optarg
+    elseif opt == "o" or opt == "output" then
+      result.output_path = optarg
+    elseif opt == "steer" then
+      result.steer_msg = optarg
+    elseif opt == "followup" then
+      result.followup_msg = optarg
+    elseif opt == "max-tokens" then
+      result.max_tokens = tonumber(optarg) as integer
+    elseif opt == "sandbox" then
+      result.sandbox = true
+    elseif opt == "timeout" then
+      result.timeout = tonumber(optarg) as integer
+    elseif opt == "allow-host" then
+      table.insert(result.allow_hosts, optarg)
+    elseif opt == "unveil" then
+      table.insert(result.unveil_dirs, optarg)
+    elseif opt == "skill" then
+      result.skill = optarg
+    elseif opt == "must-produce" then
+      result.must_produce = optarg
+    elseif opt == "t" or opt == "tool" then
+      table.insert(result.tool_overrides, optarg)
+    elseif opt == "cd" then
+      result.cd_path = optarg
+    elseif opt == "?" then
+      return nil, "unknown"
+    end
+  end
+
+  result.remaining = parser:remaining() or {}
+
+  -- Validate sandbox sub-options require --sandbox
+  if not result.sandbox then
+    if #result.unveil_dirs > 0 then
+      return nil, "error: --unveil requires --sandbox"
+    end
+    if #result.allow_hosts > 0 then
+      return nil, "error: --allow-host requires --sandbox"
+    end
+  end
+
+  return result, nil
+end
+
+-- OptionArgType indicates whether an option requires an argument
+local enum OptionArgType
+  "required"
+  "none"
+end
+
+-- OptionDef describes a command-line option
+local record OptionDef
+  name: string -- long name (e.g. "output")
+  short: string -- short name (e.g. "o")
+  has_arg: OptionArgType
+end
+
+-- parse_subcommand_options scans args for options defined in opts.
+-- Returns a table mapping option names to their values (nil if not present).
+-- Supports -s val, -sval, --name val forms. Last occurrence wins.
+-- This allows parsing options that appear after a subcommand.
+local function parse_subcommand_options(args: {string}, opts: {OptionDef}): {string: string}
+  local result: {string: string} = {}
+
+  -- Build optstring for getopt
+  local optstring_parts: {string} = {}
+  local opt_map: {string: string} = {} -- maps short letter to long name
+
+  for _, opt in ipairs(opts) do
+    optstring_parts[#optstring_parts + 1] = opt.short
+    if opt.has_arg == "required" then
+      optstring_parts[#optstring_parts + 1] = ":"
+    end
+    opt_map[opt.short] = opt.name
+  end
+
+  local optstring = table.concat(optstring_parts)
+  -- Convert OptionDef to the format expected by getopt
+  local longopts: {getopt.LongOpt} = {}
+  for i, opt in ipairs(opts) do
+    longopts[i] = {
+      name = opt.name,
+      has_arg = opt.has_arg,
+      short = opt.short
+    }
+  end
+  local parser = getopt.new(args, optstring, longopts)
+
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
+
+    -- Map short option letters to long names
+    local name = opt_map[opt] or opt
+
+    if optarg then
+      result[name] = optarg
+    else
+      result[name] = "true"
+    end
+  end
+
+  return result
+end
+
+return {
+  ParsedArgs = ParsedArgs,
+  OptionArgType = OptionArgType,
+  OptionDef = OptionDef,
+  parse_args = parse_args,
+  parse_subcommand_options = parse_subcommand_options,
+  parse_protect_dirs = parse_protect_dirs,
+  parse_unveil_entry = parse_unveil_entry,
+  usage_text = usage_text,
+  usage = usage,
+}

--- a/lib/ah/cli.tl
+++ b/lib/ah/cli.tl
@@ -1,0 +1,239 @@
+-- ah/cli.tl: CLI display handler and output formatting
+local tty = require("cosmic.tty")
+local events = require("ah.events")
+local loop = require("ah.loop")
+local render = require("ah.render")
+local compact = require("ah.compact")
+
+-- Format token count as human-friendly string (e.g., 1234 -> "1.2k", 12345 -> "12.3k")
+local function format_tokens(n: integer): string
+  if n >= 1000000 then
+    return string.format("%.1fm", n / 1000000)
+  elseif n >= 1000 then
+    return string.format("%.1fk", n / 1000)
+  else
+    return tostring(n)
+  end
+end
+
+-- Colorize a single diff line with ANSI escape codes.
+-- Uses blue/yellow instead of green/red for colorblind accessibility.
+-- Returns the line with color prefix/suffix applied, or unchanged if not a diff line.
+local function colorize_diff_line(line: string): string
+  if line:sub(1, 3) == "+++" or line:sub(1, 3) == "---" then
+    return "\27[1m" .. line .. "\27[0m"
+  elseif line:sub(1, 2) == "@@" then
+    return "\27[36m" .. line .. "\27[0m"
+  elseif line:sub(1, 1) == "+" then
+    return "\27[34m" .. line .. "\27[0m"
+  elseif line:sub(1, 1) == "-" then
+    return "\27[33m" .. line .. "\27[0m"
+  end
+  return line
+end
+
+-- Colorize a single tool output line with ANSI escape codes.
+-- Uses blue+bold for success (PASS) and yellow+bold for errors (FAIL, error, exit code).
+-- Uses blue/yellow instead of green/red for colorblind accessibility.
+-- Returns the line (possibly colored) and a boolean indicating if color was applied.
+local function colorize_tool_line(line: string): string, boolean
+  if line:sub(1, 4) == "PASS" then
+    return "\27[1;34m" .. line .. "\27[0m", true
+  elseif line:sub(1, 4) == "FAIL" then
+    return "\27[1;33m" .. line .. "\27[0m", true
+  elseif line:sub(1, 6) == "error:" or line:sub(1, 6) == "Error:" then
+    return "\27[1;33m" .. line .. "\27[0m", true
+  elseif line:sub(1, 10) == "exit code:" then
+    return "\27[1;33m" .. line .. "\27[0m", true
+  end
+  return line, false
+end
+
+-- CLI display handler: renders structured events to stderr/stdout for terminal use.
+-- This is the application-layer implementation of the event callback.
+-- Other handlers (JSON logging, web UI, etc.) can be substituted.
+local function make_cli_handler(skill_name: string): events.EventCallback
+  local is_tty = tty.isatty(2)
+  local is_stdout_tty = tty.isatty(1)
+  local is_ci = os.getenv("GITHUB_ACTIONS") == "true"
+  local DIM = is_tty and "\27[2m" or ""
+  local RESET = is_tty and "\27[0m" or ""
+  local has_text = false
+  local text_buffer: {string} = {}
+  local captured_model: string = nil
+
+  -- Flush buffered agent response text to stdout
+  local function flush_text()
+    if #text_buffer > 0 then
+      local text = table.concat(text_buffer)
+      if is_stdout_tty then
+        text = render.render_markdown(text)
+      end
+      io.write(text)
+      io.flush()
+      text_buffer = {}
+    end
+  end
+
+  return function(event: events.EventData)
+    local t = event.event_type
+
+    if t == "agent_start" then
+      captured_model = event.model
+      if is_ci and skill_name then
+        io.stdout:write("::group::" .. skill_name .. "\n")
+        io.stdout:flush()
+      end
+      -- In non-interactive mode, echo the prompt for clarity
+      if not is_tty and event.prompt then
+        io.stderr:write(">>> " .. event.prompt .. "\n")
+      end
+
+    elseif t == "text_delta" then
+      -- Buffer text and print when the response is complete
+      table.insert(text_buffer, event.text)
+      has_text = true
+
+    elseif t == "agent_end" then
+      flush_text()
+      -- Trailing newline after text output
+      if has_text then
+        io.write("\n")
+      end
+      -- Display session token totals
+      local total_in = event.total_input_tokens or 0
+      local total_out = event.total_output_tokens or 0
+      local cache_read = event.total_cache_read_tokens or 0
+      if total_in > 0 or total_out > 0 then
+        io.stderr:write("\n")
+        local in_str = format_tokens(total_in)
+        if cache_read > 0 then
+          in_str = in_str .. " (" .. format_tokens(cache_read) .. " cached)"
+        end
+        local total = total_in + total_out
+        local budget = compact.get_context_limit(captured_model)
+        local pct = math.floor(total / budget * 100)
+        io.stderr:write(string.format("%s%s in / %s out (%s/%s total, %d%%)%s\n", DIM, in_str, format_tokens(total_out), format_tokens(total), format_tokens(budget), pct, RESET))
+      end
+      if is_ci and skill_name then
+        io.stdout:write("::endgroup::\n")
+        io.stdout:flush()
+      end
+
+    elseif t == "budget_exceeded" then
+      local total = (event.total_input_tokens or 0) + (event.total_output_tokens or 0)
+      local budget = event.max_tokens or compact.get_context_limit(captured_model)
+      local pct = math.floor(total / budget * 100)
+      io.stderr:write(string.format("\ntoken budget exceeded (%s/%s, %d%%)\n", format_tokens(total), format_tokens(budget), pct))
+
+    elseif t == "error" then
+      local msg = event.error or "unknown"
+      io.stderr:write("\nerror: " .. msg .. "\n")
+      if is_ci then
+        io.stdout:write("::error::" .. msg .. "\n")
+        io.stdout:flush()
+      end
+
+    elseif t == "api_call_end" then
+      -- Flush buffered agent response text now that the response is complete
+      flush_text()
+
+    elseif t == "compaction_triggered" then
+      io.stderr:write(string.format("\n%scompacting conversation (%d/%d tokens)...%s\n", DIM, event.input_tokens, event.context_limit, RESET))
+
+    elseif t == "compaction_complete" then
+      io.stderr:write(string.format("%scompaction complete (summary: %d tokens)%s\n\n", DIM, event.output_tokens, RESET))
+
+    elseif t == "tool_call_start" then
+      -- Separator between text and first tool block
+      if event.tool_index == 1 then
+        if has_text then
+          io.write("\n")
+          has_text = false
+        end
+        io.stderr:write("\n")
+      end
+
+    elseif t == "tool_call_end" then
+      local indent = "  "
+      local elapsed = (event.duration_ms or 0) / 1000
+
+      -- Line 1: tool name and timing
+      -- Use yellow+bold with ✗ prefix for errors, dim with ⠋ for success
+      if is_tty and event.is_error then
+        io.stderr:write(string.format("\27[1;33m✗ %s (%.1fs)\27[0m\n", event.tool_name, elapsed))
+      else
+        local prefix = is_tty and "⠋ " or ""
+        io.stderr:write(string.format("%s%s%s (%.1fs)%s\n", DIM, prefix, event.tool_name, elapsed, RESET))
+      end
+
+      -- Line 2: command (for bash) or key param
+      local key = event.tool_key or ""
+      if key ~= "" then
+        local cmd_prefix = event.tool_name == "bash" and "$ " or ""
+        if event.tool_name == "bash" then
+          local term_width = 80
+          local ws = tty.winsize(2)
+          if ws then term_width = ws.cols as integer end
+          local wrap_indent = indent .. "  "
+          key = loop.wrap_command(key, term_width - #indent - #cmd_prefix, wrap_indent)
+        end
+        io.stderr:write(string.format("%s%s%s%s%s\n", DIM, indent, cmd_prefix, key, RESET))
+      end
+
+      -- Show truncated output (first 3 lines, then count)
+      local result = event.tool_output or ""
+      if result ~= "" and result ~= "(no output)" then
+        -- Detect diff-like commands for colorization
+        local is_diff_cmd = false
+        if is_tty and event.tool_name == "bash" and key ~= "" then
+          is_diff_cmd = key:match("diff") ~= nil
+          or key:match("show") ~= nil
+          or key:match("log %-p") ~= nil
+        end
+
+        local lines: {string} = {}
+        for line in result:gmatch("[^\n]+") do
+          table.insert(lines, line)
+        end
+        local max_lines = 3
+        for j = 1, math.min(max_lines, #lines) do
+          local line = lines[j]
+          if #line > 80 then
+            line = line:sub(1, 77) .. "..."
+          end
+          if is_diff_cmd then
+            local colored = colorize_diff_line(line)
+            if colored ~= line then
+              io.stderr:write(string.format("%s%s%s\n", indent, colored, ""))
+            else
+              io.stderr:write(string.format("%s%s%s%s\n", DIM, indent, line, RESET))
+            end
+          elseif is_tty then
+            local colored, was_colored = colorize_tool_line(line)
+            if was_colored then
+              io.stderr:write(string.format("%s%s%s\n", indent, colored, ""))
+            else
+              io.stderr:write(string.format("%s%s%s%s\n", DIM, indent, line, RESET))
+            end
+          else
+            io.stderr:write(string.format("%s%s%s%s\n", DIM, indent, line, RESET))
+          end
+        end
+        if #lines > max_lines then
+          io.stderr:write(string.format("%s%s... (%d more lines)%s\n", DIM, indent, #lines - max_lines, RESET))
+        end
+      end
+
+      -- Blank line after tool block
+      io.stderr:write("\n")
+    end
+  end
+end
+
+return {
+  format_tokens = format_tokens,
+  colorize_diff_line = colorize_diff_line,
+  colorize_tool_line = colorize_tool_line,
+  make_cli_handler = make_cli_handler,
+}

--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -132,16 +132,19 @@ local record Event
   details: string
 end
 
-local function get_db_path(): string
-  local ah_dir = ".ah"
-  fs.makedirs(ah_dir)
-  return fs.join(ah_dir, "ah.db")
+local record TokenTotals
+  input_tokens: integer
+  output_tokens: integer
+  cache_read_tokens: integer
 end
 
 local function open(db_path?: string): DB, string
-  db_path = db_path or get_db_path()
+  if not db_path then
+    local ah_dir = ".ah"
+    fs.makedirs(ah_dir)
+    db_path = fs.join(ah_dir, "ah.db")
+  end
 
-  -- Ensure parent directory exists for custom paths
   local parent = fs.dirname(db_path)
   if parent and parent ~= "" and parent ~= "." then
     fs.makedirs(parent)
@@ -152,39 +155,21 @@ local function open(db_path?: string): DB, string
     return nil, "failed to open database: " .. db_path .. ": " .. (err or "")
   end
 
-  -- Enable WAL mode for better crash recovery and concurrent access
   local ok, pragma_err = db:exec("pragma journal_mode=wal")
-  if not ok then
-    db:close()
-    return nil, "failed to enable WAL mode: " .. (pragma_err or "")
-  end
-
-  -- Set busy timeout to wait up to 5 seconds for locks
+  if not ok then db:close(); return nil, "failed to enable WAL mode: " .. (pragma_err or "") end
   ok, pragma_err = db:exec("pragma busy_timeout=5000")
-  if not ok then
-    db:close()
-    return nil, "failed to set busy timeout: " .. (pragma_err or "")
-  end
-
-  -- Ensure writes are synced to disk (safety over speed)
+  if not ok then db:close(); return nil, "failed to set busy timeout: " .. (pragma_err or "") end
   db:exec("pragma synchronous=normal")
-
   ok, pragma_err = db:exec(SCHEMA)
-  if not ok then
-    db:close()
-    return nil, "failed to initialize schema: " .. (pragma_err or "")
-  end
+  if not ok then db:close(); return nil, "failed to initialize schema: " .. (pragma_err or "") end
 
   return {_db = db} as DB, nil
 end
 
 local function close(self: DB)
-  if self._db then
-    self._db:close()
-  end
+  if self._db then self._db:close() end
 end
 
--- Transaction support for atomic operations
 local function begin_transaction(self: DB): boolean, string
   return self._db:exec("BEGIN IMMEDIATE")
 end
@@ -197,7 +182,6 @@ local function rollback(self: DB): boolean, string
   return self._db:exec("ROLLBACK")
 end
 
--- Context operations
 local function get_context(self: DB, key: string): string
   for row in self._db:query("select value from context where key = ?", key) do
     return row.value as string
@@ -209,7 +193,6 @@ local function set_context(self: DB, key: string, value: string)
   self._db:exec("insert or replace into context (key, value) values (?, ?)", key, value)
 end
 
--- Message operations
 local function get_message(self: DB, id: string): Message
   for row in self._db:query("select * from messages where id = ?", id) do
     return row as Message
@@ -229,41 +212,28 @@ local function create_message(self: DB, role: string, parent_id?: string, opts?:
     end
   end
 
-  local values: {any} = {id, parent_id, role, seq, now, opts.input_tokens, opts.output_tokens, opts.stop_reason, opts.model, opts.api_latency_ms}
-
   self._db:exec_list([[
     insert into messages (id, parent_id, role, seq, created_at, input_tokens, output_tokens, stop_reason, model, api_latency_ms)
     values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  ]], values, 10)
+  ]], {id, parent_id, role, seq, now, opts.input_tokens, opts.output_tokens, opts.stop_reason, opts.model, opts.api_latency_ms}, 10)
 
   self._db:exec("insert or replace into context (key, value) values (?, ?)", "current_message", id)
 
   return {
-    id = id,
-    parent_id = parent_id,
-    role = role,
-    seq = seq,
-    created_at = now,
-    input_tokens = opts.input_tokens,
-    output_tokens = opts.output_tokens,
-    stop_reason = opts.stop_reason,
-    model = opts.model,
-    api_latency_ms = opts.api_latency_ms,
+    id = id, parent_id = parent_id, role = role, seq = seq, created_at = now,
+    input_tokens = opts.input_tokens, output_tokens = opts.output_tokens,
+    stop_reason = opts.stop_reason, model = opts.model, api_latency_ms = opts.api_latency_ms,
   }
 end
 
 local function get_current_message(self: DB): Message
   local id = get_context(self, "current_message")
-  if id then
-    return get_message(self, id)
-  end
+  if id then return get_message(self, id) end
   return nil
 end
 
 local function get_ancestry(self: DB, message_id: string): {Message}
   local messages: {Message} = {}
-
-  -- Use recursive CTE to fetch entire ancestry chain in a single query
   for row in self._db:query([[
     with recursive ancestry(id, parent_id, role, seq, created_at,
       input_tokens, output_tokens, stop_reason, model, api_latency_ms, depth) as (
@@ -281,18 +251,12 @@ local function get_ancestry(self: DB, message_id: string): {Message}
   ]], message_id) do
     table.insert(messages, row as Message)
   end
-
   return messages
 end
 
 local function get_last_message(self: DB): Message
-  -- First try current_message from context
   local current = get_current_message(self)
-  if current then
-    return current
-  end
-
-  -- Otherwise find the most recent leaf (message with no children)
+  if current then return current end
   for row in self._db:query([[
     select m.* from messages m
     where not exists (select 1 from messages c where c.parent_id = m.id)
@@ -307,63 +271,36 @@ local function delete_message(self: DB, id: string)
   local current = get_context(self, "current_message")
   self._db:exec("delete from content_blocks where message_id = ?", id)
   self._db:exec("delete from messages where id = ?", id)
-
   if current == id then
     self._db:exec("delete from context where key = 'current_message'")
   end
 end
 
--- Content block operations
 local function add_content_block(self: DB, message_id: string, block_type: string, opts: ContentBlockOpts): ContentBlock
   opts = opts or {}
   local id = ulid.generate()
 
   local seq = 0
   for row in self._db:query("select max(seq) as max_seq from content_blocks where message_id = ?", message_id) do
-    if row.max_seq then
-      seq = (row.max_seq as integer) + 1
-    end
+    if row.max_seq then seq = (row.max_seq as integer) + 1 end
   end
-
-  local values: {any} = {
-    id, message_id, block_type, seq,
-    opts.content,
-    opts.tool_id,
-    opts.tool_name,
-    opts.tool_input,
-    opts.tool_output,
-    opts.is_error and 1 or 0,
-    opts.duration_ms,
-    opts.details
-  }
 
   self._db:exec_list([[
     insert into content_blocks (id, message_id, block_type, seq, content, tool_id, tool_name, tool_input, tool_output, is_error, duration_ms, details)
     values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  ]], values, 12)
+  ]], {id, message_id, block_type, seq, opts.content, opts.tool_id, opts.tool_name, opts.tool_input, opts.tool_output, opts.is_error and 1 or 0, opts.duration_ms, opts.details}, 12)
 
   return {
-    id = id,
-    message_id = message_id,
-    block_type = block_type,
-    seq = seq,
-    content = opts.content,
-    tool_id = opts.tool_id,
-    tool_name = opts.tool_name,
-    tool_input = opts.tool_input,
-    tool_output = opts.tool_output,
-    is_error = opts.is_error and 1 or 0,
-    duration_ms = opts.duration_ms,
-    details = opts.details,
+    id = id, message_id = message_id, block_type = block_type, seq = seq,
+    content = opts.content, tool_id = opts.tool_id, tool_name = opts.tool_name,
+    tool_input = opts.tool_input, tool_output = opts.tool_output,
+    is_error = opts.is_error and 1 or 0, duration_ms = opts.duration_ms, details = opts.details,
   }
 end
 
 local function get_content_blocks(self: DB, message_id: string): {ContentBlock}
   local blocks: {ContentBlock} = {}
-  for row in self._db:query([[
-    select * from content_blocks where message_id = ?
-    order by seq asc
-  ]], message_id) do
+  for row in self._db:query("select * from content_blocks where message_id = ? order by seq asc", message_id) do
     table.insert(blocks, row as ContentBlock)
   end
   return blocks
@@ -372,66 +309,33 @@ end
 local function update_content_block(self: DB, id: string, opts: UpdateOpts)
   local sets: {string} = {}
   local values: {any} = {}
-
-  if opts.content then
-    table.insert(sets, "content = ?")
-    table.insert(values, opts.content)
-  end
-  if opts.tool_output then
-    table.insert(sets, "tool_output = ?")
-    table.insert(values, opts.tool_output)
-  end
-  if opts.is_error ~= nil then
-    table.insert(sets, "is_error = ?")
-    table.insert(values, opts.is_error and 1 or 0)
-  end
-
+  if opts.content then table.insert(sets, "content = ?"); table.insert(values, opts.content) end
+  if opts.tool_output then table.insert(sets, "tool_output = ?"); table.insert(values, opts.tool_output) end
+  if opts.is_error ~= nil then table.insert(sets, "is_error = ?"); table.insert(values, opts.is_error and 1 or 0) end
   if #sets == 0 then return end
-
   table.insert(values, id)
-  local sql = "update content_blocks set " .. table.concat(sets, ", ") .. " where id = ?"
-  self._db:exec_list(sql, values, #values)
+  self._db:exec_list("update content_blocks set " .. table.concat(sets, ", ") .. " where id = ?", values, #values)
 end
 
--- Event logging
 local function log_event(self: DB, event_type: string, message_id?: string, details?: string): Event
   local id = ulid.generate()
   local now = os.time()
-
-  local values: {any} = {id, message_id, event_type, now, details}
-
-  self._db:exec_list([[
-    insert into events (id, message_id, event_type, created_at, details)
-    values (?, ?, ?, ?, ?)
-  ]], values, 5)
-
-  return {
-    id = id,
-    message_id = message_id,
-    event_type = event_type,
-    created_at = now,
-    details = details,
-  }
+  self._db:exec_list("insert into events (id, message_id, event_type, created_at, details) values (?, ?, ?, ?, ?)",
+    {id, message_id, event_type, now, details}, 5)
+  return {id = id, message_id = message_id, event_type = event_type, created_at = now, details = details}
 end
 
 local function get_events(self: DB, event_type?: string): {Event}
-  local events: {Event} = {}
+  local ev: {Event} = {}
   local sql = "select * from events"
-  if event_type then
-    sql = sql .. " where event_type = ?"
-  end
+  if event_type then sql = sql .. " where event_type = ?" end
   sql = sql .. " order by created_at asc"
-
   if event_type then
-    for row in self._db:query(sql, event_type) do
-      table.insert(events, row as Event)
-    end
+    for row in self._db:query(sql, event_type) do table.insert(ev, row as Event) end
   else
-    for row in self._db:query(sql) do
-      table.insert(events, row as Event)
-    end
+    for row in self._db:query(sql) do table.insert(ev, row as Event) end
   end
-  return events
+  return ev
 end
 
 local function get_message_count(self: DB): integer
@@ -441,57 +345,32 @@ local function get_message_count(self: DB): integer
   return 0
 end
 
--- Clean up orphan messages (messages without content blocks, from crashes)
--- Only deletes orphans that have no children (leaf orphans)
 local function cleanup_orphans(self: DB): integer
-  -- Find and delete leaf messages with no content blocks
-  -- (messages that have no children pointing to them)
   local orphans: {string} = {}
   for row in self._db:query([[
     select m.id from messages m
     left join content_blocks c on c.message_id = m.id
     where not exists (select 1 from messages child where child.parent_id = m.id)
-    group by m.id
-    having count(c.id) = 0
+    group by m.id having count(c.id) = 0
   ]]) do
     table.insert(orphans, row.id as string)
   end
-
-  for _, id in ipairs(orphans) do
-    delete_message(self, id)
-  end
-
+  for _, id in ipairs(orphans) do delete_message(self, id) end
   return #orphans
-end
-
--- Token totals: sum input and output tokens across all messages in the session
-local record TokenTotals
-  input_tokens: integer
-  output_tokens: integer
-  cache_read_tokens: integer
 end
 
 local function get_session_token_totals(self: DB): TokenTotals
   local totals: TokenTotals = {input_tokens = 0, output_tokens = 0, cache_read_tokens = 0}
-  for row in self._db:query([[
-    select coalesce(sum(input_tokens), 0) as total_input,
-           coalesce(sum(output_tokens), 0) as total_output
-    from messages
-  ]]) do
+  for row in self._db:query("select coalesce(sum(input_tokens), 0) as total_input, coalesce(sum(output_tokens), 0) as total_output from messages") do
     totals.input_tokens = (row.total_input or 0) as integer
     totals.output_tokens = (row.total_output or 0) as integer
   end
-  for row in self._db:query([[
-    select coalesce(sum(json_extract(details, '$.cache_read_input_tokens')), 0) as total_cache_read
-    from events where event_type = 'api_call_end'
-  ]]) do
+  for row in self._db:query("select coalesce(sum(json_extract(details, '$.cache_read_input_tokens')), 0) as total_cache_read from events where event_type = 'api_call_end'") do
     totals.cache_read_tokens = (row.total_cache_read or 0) as integer
   end
   return totals
 end
 
--- Session state management: idle, processing, closed
--- States are stored in the context table under key "session_state"
 local function get_session_state(self: DB): string
   return get_context(self, "session_state") or "idle"
 end
@@ -504,9 +383,7 @@ local function get_first_user_prompt(self: DB): string
   for row in self._db:query([[
     select content from content_blocks
     where block_type = 'text'
-      and message_id in (
-        select id from messages where role = 'user' order by seq asc limit 1
-      )
+      and message_id in (select id from messages where role = 'user' order by seq asc limit 1)
     order by seq asc limit 1
   ]]) do
     return (row.content or "") as string
@@ -515,34 +392,19 @@ local function get_first_user_prompt(self: DB): string
 end
 
 return {
-  open = open,
-  close = close,
-  begin_transaction = begin_transaction,
-  commit = commit,
-  rollback = rollback,
-  get_message = get_message,
-  create_message = create_message,
-  get_ancestry = get_ancestry,
-  get_last_message = get_last_message,
-  add_content_block = add_content_block,
-  get_content_blocks = get_content_blocks,
+  open = open, close = close,
+  begin_transaction = begin_transaction, commit = commit, rollback = rollback,
+  get_message = get_message, create_message = create_message,
+  get_ancestry = get_ancestry, get_last_message = get_last_message,
+  add_content_block = add_content_block, get_content_blocks = get_content_blocks,
   update_content_block = update_content_block,
-  get_message_count = get_message_count,
-  get_first_user_prompt = get_first_user_prompt,
+  get_message_count = get_message_count, get_first_user_prompt = get_first_user_prompt,
   cleanup_orphans = cleanup_orphans,
-  log_event = log_event,
-  get_events = get_events,
-  get_context = get_context,
-  set_context = set_context,
-  get_session_state = get_session_state,
-  set_session_state = set_session_state,
+  log_event = log_event, get_events = get_events,
+  get_context = get_context, set_context = set_context,
+  get_session_state = get_session_state, set_session_state = set_session_state,
   get_session_token_totals = get_session_token_totals,
-  -- Export types for consumers
-  DB = DB,
-  TokenTotals = TokenTotals,
-  Message = Message,
-  ContentBlock = ContentBlock,
-  ContentBlockOpts = ContentBlockOpts,
-  MessageOpts = MessageOpts,
-  Event = Event,
+  DB = DB, TokenTotals = TokenTotals, Message = Message,
+  ContentBlock = ContentBlock, ContentBlockOpts = ContentBlockOpts,
+  MessageOpts = MessageOpts, Event = Event,
 }

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -1,7 +1,6 @@
--- ah/init.tl: CLI interface, session management, prompt expansion
+-- ah/init.tl: CLI entry, session management, agent orchestration
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
-local getopt = require("cosmic.getopt")
 local tty = require("cosmic.tty")
 local proc = require("cosmic.proc")
 local signal = require("cosmic.signal")
@@ -20,677 +19,14 @@ local queue = require("ah.queue")
 local sandbox = require("cosmic.sandbox")
 local util = require("ah.util")
 local envd = require("cosmic.envd")
-local render = require("ah.render")
 local compact = require("ah.compact")
-
--- Session record for listing
-local record Session
-  ulid: string
-  db_path: string
-  msg_count: integer
-  first_prompt: string
-  timestamp: number
-  name: string
-end
+local args_mod = require("ah.args")
+local sessions_mod = require("ah.sessions")
+local prompt_mod = require("ah.prompt")
+local cli_mod = require("ah.cli")
 
 -- Global for signal handling
 global interrupted: boolean = false
-
--- Load CLAUDE.md with embedded base prepended
-local function load_claude_md(cwd: string): string
-  cwd = cwd or fs.getcwd()
-
-  -- CLAUDE.md supersedes AGENTS.md when both exist.
-  -- Projects should pick one file; CLAUDE.md is the conventional name.
-  local project_claude = cio.slurp(fs.join(cwd, "CLAUDE.md"))
-  if project_claude then
-    return "\n\n# Project Context\n\n" .. project_claude
-  end
-
-  local agents_md = cio.slurp(fs.join(cwd, "AGENTS.md"))
-  if agents_md then
-    return "\n\n# Agent Context\n\n" .. agents_md
-  end
-
-  return ""
-end
-
-local child = require("cosmic.child")
-
--- Run a git command in cwd with a 2s timeout. Returns trimmed stdout or nil.
--- Never throws. Any failure (not a repo, git missing, timeout, bad exit) returns nil.
-local function git_cmd(cwd: string, ...: string): string
-  local argv: {string} = {"timeout", "2", "git"}
-  for i = 1, select("#", ...) do
-    argv[#argv + 1] = select(i, ...) as string
-  end
-  local ok, result = pcall(function(): string
-      local h, err = child.spawn(argv, {cwd = cwd})
-      if not h then return nil end
-      local success, stdout, _ = h:read()
-      if not success then return nil end
-      local out = (stdout as string) or ""
-      if out == "" then return nil end
-      return (out:gsub("%s+$", ""))
-    end)
-  if not ok then return nil end
-  return result
-end
-
--- Gather git context for the working directory. Each value is nil
--- when the command fails (not a git repo, git not installed, timeout).
-local function git_context(cwd: string): {string: string}
-  return {
-    branch = git_cmd(cwd, "rev-parse", "--abbrev-ref", "HEAD"),
-    commit = git_cmd(cwd, "rev-parse", "--short", "HEAD"),
-    remote = git_cmd(cwd, "remote", "get-url", "origin"),
-  }
-end
-
--- Load system prompt with precedence:
--- 1. /zip/embed/system.md (user override)
--- 2. /zip/embed/sys/system.md (ah default)
--- Project CLAUDE.md and AGENTS.md are always appended
-local function load_system_prompt(cwd: string): string
-  cwd = cwd or fs.getcwd()
-  local claude_md = load_claude_md(cwd)
-
-  local base: string
-  local user_system = cio.slurp("/zip/embed/system.md")
-  if user_system then
-    base = user_system .. claude_md
-  else
-    local sys_system = cio.slurp("/zip/embed/sys/system.md")
-    if sys_system then
-      base = sys_system .. claude_md
-    else
-      base = claude_md
-    end
-  end
-
-  -- Append runtime context (datetime, working directory, git info)
-  local date_str = os.date("!%Y-%m-%dT%H:%M:%SZ") as string
-  base = base .. "\n\nCurrent date: " .. date_str .. "\nWorking directory: " .. cwd
-
-  local git = git_context(cwd)
-  if git.branch then
-    base = base .. "\nGit branch: " .. git.branch
-  end
-  if git.commit then
-    base = base .. "\nGit commit: " .. git.commit
-  end
-  if git.remote then
-    base = base .. "\nGit remote: " .. git.remote
-  end
-
-  return base
-end
-
--- List session files from .ah/*.db with valid ULID names
-local function list_sessions(cwd?: string): {Session}
-  cwd = cwd or fs.getcwd()
-  local ah_dir = fs.join(cwd, ".ah")
-  local sessions: {Session} = {}
-
-  local dir = fs.opendir(ah_dir)
-  if not dir then
-    return sessions
-  end
-
-  while true do
-    local name = dir:read()
-    if not name then break end
-
-    -- Check if it's a .db file with ULID name
-    if name:match("%.db$") then
-      local session_ulid = name:sub(1, -4) -- remove .db
-      -- Validate ULID by checking length and trying to parse timestamp
-      if #session_ulid == 26 then
-        local ts = ulid.timestamp(session_ulid)
-        if ts then
-          local db_path = fs.join(ah_dir, name)
-          local d = db.open(db_path)
-          if d then
-            table.insert(sessions, {
-                ulid = session_ulid,
-                db_path = db_path,
-                msg_count = db.get_message_count(d),
-                first_prompt = db.get_first_user_prompt(d),
-                timestamp = ts,
-                name = db.get_context(d, "session_name"),
-              })
-            db.close(d)
-          end
-        end
-      end
-    end
-  end
-  dir:close()
-
-  -- Sort by ULID descending (most recent first - ULID encodes timestamp)
-  table.sort(sessions, function(a: Session, b: Session): boolean
-      return a.ulid > b.ulid
-    end)
-
-  return sessions
-end
-
--- Resolve session by name or partial ULID prefix
-local function resolve_session(cwd: string, prefix: string): string, string
-  local sessions = list_sessions(cwd)
-
-  -- First pass: exact name match
-  local name_matches: {string} = {}
-  for _, s in ipairs(sessions) do
-    if s.name and s.name == prefix then
-      table.insert(name_matches, s.ulid)
-    end
-  end
-
-  if #name_matches == 1 then
-    return name_matches[1], nil
-  elseif #name_matches > 1 then
-    return nil, "ambiguous name: " .. prefix .. " matches " .. #name_matches .. " sessions"
-  end
-
-  -- Second pass: ULID prefix match
-  local matches: {string} = {}
-
-  for _, s in ipairs(sessions) do
-    if s.ulid:sub(1, #prefix) == prefix then
-      table.insert(matches, s.ulid)
-    end
-  end
-
-  if #matches == 0 then
-    return nil, "no session matches: " .. prefix
-  elseif #matches > 1 then
-    return nil, "ambiguous prefix: " .. prefix .. " matches " .. #matches .. " sessions"
-  end
-
-  return matches[1], nil
-end
-
--- Format token count as human-friendly string (e.g., 1234 -> "1.2k", 12345 -> "12.3k")
-local function format_tokens(n: integer): string
-  if n >= 1000000 then
-    return string.format("%.1fm", n / 1000000)
-  elseif n >= 1000 then
-    return string.format("%.1fk", n / 1000)
-  else
-    return tostring(n)
-  end
-end
-
-local function usage_text(): string
-  local parts: {string} = {}
-
-  -- Load base help text from embedded file
-  local base_help = cio.slurp("/zip/embed/sys/help.md") or ""
-
-  table.insert(parts, base_help)
-
-  -- Append dynamic model aliases
-  for alias, full in pairs(api.MODEL_ALIASES) do
-    table.insert(parts, string.format("  %-18s  %s\n", alias, full))
-  end
-  return table.concat(parts)
-end
-
-local function usage()
-  io.stderr:write(usage_text())
-end
-
--- List all sessions
-local function cmd_sessions(cwd: string, current_ulid: string)
-  local sessions = list_sessions(cwd)
-  if #sessions == 0 then
-    io.stderr:write("no sessions\n")
-    return
-  end
-
-  for _, s in ipairs(sessions) do
-    local marker = s.ulid == current_ulid and ">" or " "
-    local decoded = ulid.decode(s.ulid)
-    local time_str = decoded and decoded.time or "unknown"
-    local short_ulid = s.ulid:sub(1, 11)
-    local name_str = s.name and string.format("  [%s]", s.name) or ""
-    local preview = s.first_prompt:gsub("\n", " "):sub(1, 40)
-    if #s.first_prompt > 40 then
-      preview = preview .. "..."
-    end
-    io.write(string.format("%s %s  %s  %2d msgs%s  %s\n",
-        marker, short_ulid, time_str, s.msg_count, name_str, preview))
-  end
-end
-
--- Extract short model alias from full model name
-local function short_model(name: string): string
-  if not name then return "unknown" end
-  if name:match("sonnet") then return "sonnet"
-  elseif name:match("opus") then return "opus"
-  elseif name:match("haiku") then return "haiku"
-  else return name
-  end
-end
-
--- Token usage summary for a session
-local function cmd_usage(d: db.DB)
-  local json = require("cosmic.json")
-  local ev = db.get_events(d, "api_call_end")
-
-  local total_input = 0
-  local total_output = 0
-  local total_cache_read = 0
-  local total_cache_create = 0
-  local api_calls = 0
-
-  local record CallInfo
-    input: integer
-    output: integer
-    latency: integer
-    model: string
-  end
-  local calls: {CallInfo} = {}
-
-  for _, e in ipairs(ev) do
-    if e.details then
-      local detail = json.decode(e.details) as {string: any}
-      if detail then
-        local inp = (detail.input_tokens or 0) as integer
-        local out = (detail.output_tokens or 0) as integer
-        local lat = (detail.api_latency_ms or 0) as integer
-        local mdl = (detail.model or "unknown") as string
-        total_input = total_input + inp
-        total_output = total_output + out
-        total_cache_read = total_cache_read + ((detail.cache_read_input_tokens or 0) as integer)
-        total_cache_create = total_cache_create + ((detail.cache_creation_input_tokens or 0) as integer)
-        api_calls = api_calls + 1
-        table.insert(calls, {input = inp, output = out, latency = lat, model = mdl})
-      end
-    end
-  end
-
-  local total = total_input + total_output
-
-  io.write(string.format("api calls:     %d\n", api_calls))
-  io.write(string.format("input:         %s\n", format_tokens(total_input)))
-  io.write(string.format("output:        %s\n", format_tokens(total_output)))
-  io.write(string.format("total:         %s\n", format_tokens(total)))
-  io.write(string.format("cache read:    %s\n", format_tokens(total_cache_read)))
-  io.write(string.format("cache write:   %s\n", format_tokens(total_cache_create)))
-  if total_input > 0 then
-    local cache_pct = math.floor(total_cache_read * 100 / total_input)
-    io.write(string.format("cache hit:     %d%%\n", cache_pct))
-  end
-
-  -- Per-call breakdown
-  if #calls > 0 then
-    io.write("\ncalls:\n")
-    for i, c in ipairs(calls) do
-      io.write(string.format("  #%-3d +%-6s in  +%-6s out  %4dms  %s\n",
-          i, format_tokens(c.input), format_tokens(c.output),
-          c.latency, short_model(c.model)))
-    end
-  end
-end
-
--- Colorize a single diff line with ANSI escape codes.
--- Uses blue/yellow instead of green/red for colorblind accessibility.
--- Returns the line with color prefix/suffix applied, or unchanged if not a diff line.
-local function colorize_diff_line(line: string): string
-  if line:sub(1, 3) == "+++" or line:sub(1, 3) == "---" then
-    return "\27[1m" .. line .. "\27[0m"
-  elseif line:sub(1, 2) == "@@" then
-    return "\27[36m" .. line .. "\27[0m"
-  elseif line:sub(1, 1) == "+" then
-    return "\27[34m" .. line .. "\27[0m"
-  elseif line:sub(1, 1) == "-" then
-    return "\27[33m" .. line .. "\27[0m"
-  end
-  return line
-end
-
--- Colorize a single tool output line with ANSI escape codes.
--- Uses blue+bold for success (PASS) and yellow+bold for errors (FAIL, error, exit code).
--- Uses blue/yellow instead of green/red for colorblind accessibility.
--- Returns the line (possibly colored) and a boolean indicating if color was applied.
-local function colorize_tool_line(line: string): string, boolean
-  if line:sub(1, 4) == "PASS" then
-    return "\27[1;34m" .. line .. "\27[0m", true
-  elseif line:sub(1, 4) == "FAIL" then
-    return "\27[1;33m" .. line .. "\27[0m", true
-  elseif line:sub(1, 6) == "error:" or line:sub(1, 6) == "Error:" then
-    return "\27[1;33m" .. line .. "\27[0m", true
-  elseif line:sub(1, 10) == "exit code:" then
-    return "\27[1;33m" .. line .. "\27[0m", true
-  end
-  return line, false
-end
-
--- CLI display handler: renders structured events to stderr/stdout for terminal use.
--- This is the application-layer implementation of the event callback.
--- Other handlers (JSON logging, web UI, etc.) can be substituted.
-local function make_cli_handler(skill_name: string): events.EventCallback
-  local is_tty = tty.isatty(2)
-  local is_stdout_tty = tty.isatty(1)
-  local is_ci = os.getenv("GITHUB_ACTIONS") == "true"
-  local DIM = is_tty and "\27[2m" or ""
-  local RESET = is_tty and "\27[0m" or ""
-  local has_text = false
-  local text_buffer: {string} = {}
-  local captured_model: string = nil
-
-  -- Flush buffered agent response text to stdout
-  local function flush_text()
-    if #text_buffer > 0 then
-      local text = table.concat(text_buffer)
-      if is_stdout_tty then
-        text = render.render_markdown(text)
-      end
-      io.write(text)
-      io.flush()
-      text_buffer = {}
-    end
-  end
-
-  return function(event: events.EventData)
-    local t = event.event_type
-
-    if t == "agent_start" then
-      captured_model = event.model
-      if is_ci and skill_name then
-        io.stdout:write("::group::" .. skill_name .. "\n")
-        io.stdout:flush()
-      end
-      -- In non-interactive mode, echo the prompt for clarity
-      if not is_tty and event.prompt then
-        io.stderr:write(">>> " .. event.prompt .. "\n")
-      end
-
-    elseif t == "text_delta" then
-      -- Buffer text and print when the response is complete
-      table.insert(text_buffer, event.text)
-      has_text = true
-
-    elseif t == "agent_end" then
-      flush_text()
-      -- Trailing newline after text output
-      if has_text then
-        io.write("\n")
-      end
-      -- Display session token totals
-      local total_in = event.total_input_tokens or 0
-      local total_out = event.total_output_tokens or 0
-      local cache_read = event.total_cache_read_tokens or 0
-      if total_in > 0 or total_out > 0 then
-        io.stderr:write("\n")
-        local in_str = format_tokens(total_in)
-        if cache_read > 0 then
-          in_str = in_str .. " (" .. format_tokens(cache_read) .. " cached)"
-        end
-        local total = total_in + total_out
-        local budget = compact.get_context_limit(captured_model)
-        local pct = math.floor(total / budget * 100)
-        io.stderr:write(string.format("%s%s in / %s out (%s/%s total, %d%%)%s\n", DIM, in_str, format_tokens(total_out), format_tokens(total), format_tokens(budget), pct, RESET))
-      end
-      if is_ci and skill_name then
-        io.stdout:write("::endgroup::\n")
-        io.stdout:flush()
-      end
-
-    elseif t == "budget_exceeded" then
-      local total = (event.total_input_tokens or 0) + (event.total_output_tokens or 0)
-      local budget = event.max_tokens or compact.get_context_limit(captured_model)
-      local pct = math.floor(total / budget * 100)
-      io.stderr:write(string.format("\ntoken budget exceeded (%s/%s, %d%%)\n", format_tokens(total), format_tokens(budget), pct))
-
-    elseif t == "error" then
-      local msg = event.error or "unknown"
-      io.stderr:write("\nerror: " .. msg .. "\n")
-      if is_ci then
-        io.stdout:write("::error::" .. msg .. "\n")
-        io.stdout:flush()
-      end
-
-    elseif t == "api_call_end" then
-      -- Flush buffered agent response text now that the response is complete
-      flush_text()
-
-    elseif t == "compaction_triggered" then
-      io.stderr:write(string.format("\n%scompacting conversation (%d/%d tokens)...%s\n", DIM, event.input_tokens, event.context_limit, RESET))
-
-    elseif t == "compaction_complete" then
-      io.stderr:write(string.format("%scompaction complete (summary: %d tokens)%s\n\n", DIM, event.output_tokens, RESET))
-
-    elseif t == "tool_call_start" then
-      -- Separator between text and first tool block
-      if event.tool_index == 1 then
-        if has_text then
-          io.write("\n")
-          has_text = false
-        end
-        io.stderr:write("\n")
-      end
-
-    elseif t == "tool_call_end" then
-      local indent = "  "
-      local elapsed = (event.duration_ms or 0) / 1000
-
-      -- Line 1: tool name and timing
-      -- Use yellow+bold with ✗ prefix for errors, dim with ⠋ for success
-      if is_tty and event.is_error then
-        io.stderr:write(string.format("\27[1;33m✗ %s (%.1fs)\27[0m\n", event.tool_name, elapsed))
-      else
-        local prefix = is_tty and "⠋ " or ""
-        io.stderr:write(string.format("%s%s%s (%.1fs)%s\n", DIM, prefix, event.tool_name, elapsed, RESET))
-      end
-
-      -- Line 2: command (for bash) or key param
-      local key = event.tool_key or ""
-      if key ~= "" then
-        local cmd_prefix = event.tool_name == "bash" and "$ " or ""
-        if event.tool_name == "bash" then
-          local term_width = 80
-          local ws = tty.winsize(2)
-          if ws then term_width = ws.cols as integer end
-          local wrap_indent = indent .. "  "
-          key = loop.wrap_command(key, term_width - #indent - #cmd_prefix, wrap_indent)
-        end
-        io.stderr:write(string.format("%s%s%s%s%s\n", DIM, indent, cmd_prefix, key, RESET))
-      end
-
-      -- Show truncated output (first 3 lines, then count)
-      local result = event.tool_output or ""
-      if result ~= "" and result ~= "(no output)" then
-        -- Detect diff-like commands for colorization
-        local is_diff_cmd = false
-        if is_tty and event.tool_name == "bash" and key ~= "" then
-          is_diff_cmd = key:match("diff") ~= nil
-          or key:match("show") ~= nil
-          or key:match("log %-p") ~= nil
-        end
-
-        local lines: {string} = {}
-        for line in result:gmatch("[^\n]+") do
-          table.insert(lines, line)
-        end
-        local max_lines = 3
-        for j = 1, math.min(max_lines, #lines) do
-          local line = lines[j]
-          if #line > 80 then
-            line = line:sub(1, 77) .. "..."
-          end
-          if is_diff_cmd then
-            local colored = colorize_diff_line(line)
-            if colored ~= line then
-              io.stderr:write(string.format("%s%s%s\n", indent, colored, ""))
-            else
-              io.stderr:write(string.format("%s%s%s%s\n", DIM, indent, line, RESET))
-            end
-          elseif is_tty then
-            local colored, was_colored = colorize_tool_line(line)
-            if was_colored then
-              io.stderr:write(string.format("%s%s%s\n", indent, colored, ""))
-            else
-              io.stderr:write(string.format("%s%s%s%s\n", DIM, indent, line, RESET))
-            end
-          else
-            io.stderr:write(string.format("%s%s%s%s\n", DIM, indent, line, RESET))
-          end
-        end
-        if #lines > max_lines then
-          io.stderr:write(string.format("%s%s... (%d more lines)%s\n", DIM, indent, #lines - max_lines, RESET))
-        end
-      end
-
-      -- Blank line after tool block
-      io.stderr:write("\n")
-    end
-  end
-end
-
-local record ParsedArgs
-  model: string
-  db_path: string
-  output_path: string
-  new_session: boolean
-  session_prefix: string
-  session_name: string
-  steer_msg: string
-  followup_msg: string
-  max_tokens: integer
-  sandbox: boolean
-  timeout: integer
-  allow_hosts: {string}
-  unveil_dirs: {string}
-  skill: string
-  must_produce: string
-  tool_overrides: {string}
-  cd_path: string
-  remaining: {string}
-end
-
-local function parse_args(args: {string}): ParsedArgs, string
-  local result: ParsedArgs = {
-    new_session = false,
-    sandbox = false,
-    allow_hosts = {},
-    unveil_dirs = {},
-    tool_overrides = {},
-    remaining = {},
-  }
-
-  local longopts = {
-    {name = "help", has_arg = "none", short = "h"},
-    {name = "version", has_arg = "none", short = "V"},
-    {name = "new", has_arg = "none", short = "n"},
-    {name = "session", has_arg = "required", short = "S"},
-    {name = "name", has_arg = "required"},
-    {name = "db", has_arg = "required"},
-    {name = "model", has_arg = "required", short = "m"},
-    {name = "output", has_arg = "required", short = "o"},
-    {name = "steer", has_arg = "required"},
-    {name = "followup", has_arg = "required"},
-    {name = "max-tokens", has_arg = "required"},
-    {name = "sandbox", has_arg = "none"},
-    {name = "timeout", has_arg = "required"},
-    {name = "allow-host", has_arg = "required"},
-    {name = "unveil", has_arg = "required"},
-    {name = "skill", has_arg = "required"},
-    {name = "must-produce", has_arg = "required"},
-    {name = "tool", has_arg = "required", short = "t"},
-    {name = "cd", has_arg = "required"},
-  }
-
-  -- Use + prefix for POSIX mode: stop parsing options at first non-option arg.
-  -- This allows subcommands to have their own flags without the top-level
-  -- parser rejecting them as unknown options.
-  local parser = getopt.new(args, "+hVnS:m:o:t:", longopts)
-
-  while true do
-    local opt, optarg = parser:next()
-    if not opt then break end
-
-    if opt == "h" or opt == "help" then
-      return nil, "help"
-    elseif opt == "V" or opt == "version" then
-      return nil, "version"
-    elseif opt == "n" or opt == "new" then
-      result.new_session = true
-    elseif opt == "S" or opt == "session" then
-      result.session_prefix = optarg
-    elseif opt == "name" then
-      result.session_name = optarg
-    elseif opt == "db" then
-      result.db_path = optarg
-    elseif opt == "m" or opt == "model" then
-      result.model = optarg
-    elseif opt == "o" or opt == "output" then
-      result.output_path = optarg
-    elseif opt == "steer" then
-      result.steer_msg = optarg
-    elseif opt == "followup" then
-      result.followup_msg = optarg
-    elseif opt == "max-tokens" then
-      result.max_tokens = tonumber(optarg) as integer
-    elseif opt == "sandbox" then
-      result.sandbox = true
-    elseif opt == "timeout" then
-      result.timeout = tonumber(optarg) as integer
-    elseif opt == "allow-host" then
-      table.insert(result.allow_hosts, optarg)
-    elseif opt == "unveil" then
-      table.insert(result.unveil_dirs, optarg)
-    elseif opt == "skill" then
-      result.skill = optarg
-    elseif opt == "must-produce" then
-      result.must_produce = optarg
-    elseif opt == "t" or opt == "tool" then
-      table.insert(result.tool_overrides, optarg)
-    elseif opt == "cd" then
-      result.cd_path = optarg
-    elseif opt == "?" then
-      return nil, "unknown"
-    end
-  end
-
-  result.remaining = parser:remaining() or {}
-
-  -- Validate sandbox sub-options require --sandbox
-  if not result.sandbox then
-    if #result.unveil_dirs > 0 then
-      return nil, "error: --unveil requires --sandbox"
-    end
-    if #result.allow_hosts > 0 then
-      return nil, "error: --allow-host requires --sandbox"
-    end
-  end
-
-  return result
-end
-
--- Parse AH_PROTECT_DIRS env var (colon-separated relative paths).
--- Returns a list of directory paths that should be made read-only via unveil.
-local function parse_protect_dirs(value: string): {string}
-  local dirs: {string} = {}
-  if not value or value == "" then return dirs end
-  for dir in value:gmatch("[^:]+") do
-    table.insert(dirs, dir)
-  end
-  return dirs
-end
-
--- Parse an --unveil entry: "path:perms" or just "path" (defaults to "r").
--- Returns path, perms.
-local function parse_unveil_entry(entry: string): string, string
-  local path, perms = entry:match("^(.+):([rwxc]+)$")
-  if path and perms then
-    return path, perms
-  end
-  -- No perms suffix, default to read-only
-  return entry, "r"
-end
 
 -- Record types for sandbox supervisor mode (lazy-loaded modules)
 local record SandboxCtx
@@ -707,10 +43,6 @@ local record SandboxMod
   ah_exe: function(): string
   setup_git_env: function({string})
   env_set: function({string}, string, string)
-end
-
-local record EnvMod
-  all: function(): {string}
 end
 
 local record FetchMod
@@ -730,93 +62,25 @@ local record StderrHandle
   read: function(StderrHandle): string
 end
 
--- OptionArgType indicates whether an option requires an argument
-local enum OptionArgType
-  "required"
-  "none"
-end
-
--- OptionDef describes a command-line option
-local record OptionDef
-  name: string -- long name (e.g. "output")
-  short: string -- short name (e.g. "o")
-  has_arg: OptionArgType
-end
-
--- parse_subcommand_options scans args for options defined in opts.
--- Returns a table mapping option names to their values (nil if not present).
--- Supports -s val, -sval, --name val forms. Last occurrence wins.
--- This allows parsing options that appear after a subcommand.
-local function parse_subcommand_options(args: {string}, opts: {OptionDef}): {string: string}
-  local result: {string: string} = {}
-
-  -- Build optstring for getopt
-  local optstring_parts: {string} = {}
-  local opt_map: {string: string} = {} -- maps short letter to long name
-
-  for _, opt in ipairs(opts) do
-    optstring_parts[#optstring_parts + 1] = opt.short
-    if opt.has_arg == "required" then
-      optstring_parts[#optstring_parts + 1] = ":"
-    end
-    opt_map[opt.short] = opt.name
-  end
-
-  local optstring = table.concat(optstring_parts)
-  -- Convert OptionDef to the format expected by getopt
-  local longopts: {getopt.LongOpt} = {}
-  for i, opt in ipairs(opts) do
-    longopts[i] = {
-      name = opt.name,
-      has_arg = opt.has_arg,
-      short = opt.short
-    }
-  end
-  local parser = getopt.new(args, optstring, longopts)
-
-  while true do
-    local opt, optarg = parser:next()
-    if not opt then break end
-
-    -- Map short option letters to long names
-    local name = opt_map[opt] or opt
-
-    if optarg then
-      result[name] = optarg
-    else
-      result[name] = "true"
-    end
-  end
-
-  return result
-end
-
 local function main(args: {string}): integer, string
   -- Load embedded env.d/ variables before anything else.
-  -- This allows embedding credentials (API keys, OAuth tokens) into the
-  -- executable so they're available for auth and all subsequent logic.
   envd.load()
 
   -- Enable core dumps for crash debugging
-  -- RLIMIT_CORE = 4 on Linux, RLIM_INFINITY = -1
   proc.setrlimit(4, -1, -1)
 
   -- Sandbox mode: when AH_SANDBOX=1, restrict capabilities
-  -- Used by --sandbox flag to run ah with limited network access
   if os.getenv("AH_SANDBOX") then
-    -- Unveil: restrict filesystem visibility
     local cwd_for_unveil = fs.getcwd()
-    sandbox.unveil(cwd_for_unveil, "rwxc") -- workspace
-    -- Protect directories from earlier phases (more specific = higher priority)
-    local protect = parse_protect_dirs(os.getenv("AH_PROTECT_DIRS"))
+    sandbox.unveil(cwd_for_unveil, "rwxc")
+    local protect = args_mod.parse_protect_dirs(os.getenv("AH_PROTECT_DIRS"))
     for _, dir in ipairs(protect) do
       sandbox.unveil(cwd_for_unveil .. "/" .. dir, "r")
     end
-    -- Custom unveil entries from AH_UNVEIL (comma-separated path:perms)
     local unveil_env = os.getenv("AH_UNVEIL")
     if unveil_env then
       for entry in unveil_env:gmatch("[^,]+") do
-        local u_path, u_perms = parse_unveil_entry(entry)
+        local u_path, u_perms = args_mod.parse_unveil_entry(entry)
         if u_path:sub(1, 1) == "/" then
           sandbox.unveil(u_path, u_perms)
         else
@@ -824,38 +88,28 @@ local function main(args: {string}): integer, string
         end
       end
     end
-    sandbox.unveil("/tmp", "rwxc") -- proxy socket, temp files, APE binaries
-    sandbox.unveil("/usr", "rx") -- system binaries
-    sandbox.unveil("/bin", "rx") -- system binaries
-    sandbox.unveil("/lib", "rx") -- shared libraries
-    sandbox.unveil("/lib64", "rx") -- shared libraries (64-bit)
-    sandbox.unveil("/etc/ssl", "r") -- CA certificates
-    sandbox.unveil("/etc/resolv.conf", "r") -- DNS config
-    sandbox.unveil("/dev/null", "rw") -- git and other tools need /dev/null
-    sandbox.unveil("/dev/tty", "rw") -- terminal access for interactive tools
-    sandbox.unveil("/proc/self", "r") -- bash and make need /proc/self for process info
+    sandbox.unveil("/tmp", "rwxc")
+    sandbox.unveil("/usr", "rx")
+    sandbox.unveil("/bin", "rx")
+    sandbox.unveil("/lib", "rx")
+    sandbox.unveil("/lib64", "rx")
+    sandbox.unveil("/etc/ssl", "r")
+    sandbox.unveil("/etc/resolv.conf", "r")
+    sandbox.unveil("/dev/null", "rw")
+    sandbox.unveil("/dev/tty", "rw")
+    sandbox.unveil("/proc/self", "r")
     local home = os.getenv("HOME")
     if home then
-      sandbox.unveil(home, "r") -- git/tool configs
+      sandbox.unveil(home, "r")
     end
-    sandbox.unveil(nil, nil) -- commit unveil
+    sandbox.unveil(nil, nil)
 
-    -- Pledge: drop inet, keep unix for proxy socket
-    -- stdio: basic I/O
-    -- rpath/wpath/cpath: file operations
-    -- flock: file locking for sqlite
-    -- tty: terminal I/O
-    -- proc: fork/wait for subprocesses
-    -- exec: run git, make, etc.
-    -- unix: unix domain sockets (for proxy)
-    -- prot_exec: allow mmap(PROT_EXEC) needed by dynamic linker for native binaries
-    -- Use EPERM mode (2) so blocked calls return error instead of crashing
     local PLEDGE_PENALTY_RETURN_EPERM = 2
     local promises = "stdio rpath wpath cpath flock tty proc exec execnative unix prot_exec"
     sandbox.pledge(promises, promises, PLEDGE_PENALTY_RETURN_EPERM)
   end
 
-  local parsed, err = parse_args(args)
+  local parsed, err = args_mod.parse_args(args)
   if not parsed then
     if err == "version" then
       local mod = "ah.version"
@@ -867,14 +121,11 @@ local function main(args: {string}): integer, string
       io.stderr:write(err .. "\n")
       return 1
     end
-    usage()
-    if err == "help" then
-      return 0
-    end
+    args_mod.usage()
+    if err == "help" then return 0 end
     return 1
   end
 
-  -- Change directory if --cd was specified
   if parsed.cd_path then
     local ok, chdir_err = pcall(fs.chdir, parsed.cd_path)
     if not ok then
@@ -884,7 +135,6 @@ local function main(args: {string}): integer, string
   end
 
   local cwd = fs.getcwd()
-
   local model = parsed.model
   local db_path = parsed.db_path
   local output_path = parsed.output_path
@@ -908,15 +158,11 @@ local function main(args: {string}): integer, string
     end
     util.debug("[sandbox] proxy started on " .. ctx.socket_path)
 
-    -- Build child environment from raw environ (list of "KEY=VALUE" strings)
     local unix = require("cosmo.unix")
     local run_env: {string} = unix.environ() as {string}
     sbox.setup_git_env(run_env)
-
-    -- Set TMPDIR for APE binary extraction
     sbox.env_set(run_env, "TMPDIR", ctx.tmpdir)
 
-    -- Proxy env vars
     local proxy_url, proxy_err = fetch.unix_proxy(ctx.socket_path)
     if not proxy_url then
       io.stderr:write("[sandbox] invalid proxy path: " .. (proxy_err or "unknown") .. "\n")
@@ -929,53 +175,36 @@ local function main(args: {string}): integer, string
     sbox.env_set(run_env, "HTTPS_PROXY", proxy_url)
     sbox.env_set(run_env, "AH_SANDBOX", "1")
 
-    -- Pass allow-host entries to proxy via env
     if #parsed.allow_hosts > 0 then
       sbox.env_set(run_env, "AH_ALLOW_HOSTS", table.concat(parsed.allow_hosts, ","))
     end
-
-    -- Pass unveil entries to child via env
     if #parsed.unveil_dirs > 0 then
       sbox.env_set(run_env, "AH_UNVEIL", table.concat(parsed.unveil_dirs, ","))
     end
 
-    -- Build child argv: strip sandbox-related flags, keep everything else
     local child_args: {string} = {}
     local exe = sbox.ah_exe()
-
-    -- Add timeout wrapper if specified
     if parsed.timeout and parsed.timeout > 0 then
       table.insert(child_args, "timeout")
       table.insert(child_args, tostring(parsed.timeout))
     end
-
     table.insert(child_args, exe)
 
-    -- Rebuild args without --sandbox, --timeout, --allow-host, --unveil
     local i = 1
     while i <= #args do
       local a = args[i]
       if a == "--sandbox" then
         -- skip
-      elseif a == "--timeout" then
-        i = i + 1 -- skip value too
-      elseif a == "--allow-host" then
-        i = i + 1 -- skip value too
-      elseif a == "--unveil" then
-        i = i + 1 -- skip value too
-      else
-        table.insert(child_args, a)
-      end
+      elseif a == "--timeout" then i = i + 1
+      elseif a == "--allow-host" then i = i + 1
+      elseif a == "--unveil" then i = i + 1
+      else table.insert(child_args, a) end
       i = i + 1
     end
 
-    -- Read parent stdin before spawning child (stdin may have prompt data)
     local parent_stdin = sbox.prepare_child_stdin()
-
-    -- Spawn child and wait
     local child_mod = require("cosmic.child") as ChildMod
     util.debug("[sandbox] spawning child: " .. table.concat(child_args, " "))
-    util.debug("[sandbox] stdin: " .. (#parent_stdin > 0 and (tostring(#parent_stdin) .. " bytes") or "none"))
     local handle, spawn_err = child_mod.spawn(child_args, {env = run_env, stdin = parent_stdin})
     if not handle then
       io.stderr:write("error: failed to spawn sandboxed child: " .. (spawn_err or "unknown") .. "\n")
@@ -986,32 +215,20 @@ local function main(args: {string}): integer, string
     local stderr_out = handle.stderr:read()
     local ok, stdout, exit_str = handle:read()
     local exit_code = (tonumber(exit_str) or 0) as integer
-
-    -- Forward child output
-    if stderr_out and stderr_out ~= "" then
-      io.stderr:write(stderr_out)
-    end
-    if stdout and stdout ~= "" then
-      io.write(stdout)
-    end
-
-    -- Cleanup
+    if stderr_out and stderr_out ~= "" then io.stderr:write(stderr_out) end
+    if stdout and stdout ~= "" then io.write(stdout) end
     util.debug("[sandbox] child exited: " .. tostring(exit_code))
-    util.debug("[sandbox] stopping proxy")
     sbox.stop_sandbox(ctx)
-
-    if not ok or exit_code ~= 0 then
-      return exit_code ~= 0 and exit_code or 1
-    end
+    if not ok or exit_code ~= 0 then return exit_code ~= 0 and exit_code or 1 end
     return 0
   end
 
   -- Handle commands that don't need db
   local cmd = remaining[1]
   if cmd == "sessions" then
-    local sessions = list_sessions(cwd)
+    local sessions = sessions_mod.list_sessions(cwd)
     local current_ulid = sessions[1] and sessions[1].ulid or ""
-    cmd_sessions(cwd, current_ulid)
+    sessions_mod.cmd_sessions(cwd, current_ulid)
     return 0
 
   elseif cmd == "embed" then
@@ -1020,62 +237,33 @@ local function main(args: {string}): integer, string
       io.stderr:write("usage: ah embed <dir> [-o <file>]\n")
       return 1
     end
-    -- Scan remaining args (after subcommand and src_dir) for -o/--output.
-    -- This allows `ah embed <dir> --output <path>` in addition to
-    -- the top-level `ah -o <path> embed <dir>` form.
     local sub_args: {string} = {}
-    for si = 3, #remaining do
-      sub_args[#sub_args + 1] = remaining[si]
-    end
-    local embed_opts: {OptionDef} = {{
-        name = "output",
-        short = "o",
-        has_arg = "required"
-      }}
-    local opts = parse_subcommand_options(sub_args, embed_opts)
+    for si = 3, #remaining do sub_args[#sub_args + 1] = remaining[si] end
+    local embed_opts: {args_mod.OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
+    local opts = args_mod.parse_subcommand_options(sub_args, embed_opts)
     local effective_output = opts.output or output_path
-    -- Create temp structure with embed/ prefix
     local tmpdir = fs.mkdtemp("/tmp/ah-embed-XXXXXX")
     local embed_link = fs.join(tmpdir, "embed")
     fs.symlink(fs.realpath(src_dir), embed_link)
     local result = embed.run({tmpdir}, effective_output)
     fs.rmrf(tmpdir)
-    if result.ok then
-      io.write(result.message .. "\n")
-      return 0
-    else
-      io.stderr:write("embed: " .. result.message .. "\n")
-      return 1
-    end
+    if result.ok then io.write(result.message .. "\n"); return 0
+    else io.stderr:write("embed: " .. result.message .. "\n"); return 1 end
 
   elseif cmd == "proxy" then
-    -- Internal command: run HTTP CONNECT proxy for sandboxed network access
     local socket_path = remaining[2]
-    if not socket_path then
-      io.stderr:write("usage: ah proxy <socket-path>\n")
-      return 1
-    end
+    if not socket_path then io.stderr:write("usage: ah proxy <socket-path>\n"); return 1 end
     local proxy = require("ah.proxy")
     return proxy.serve(socket_path)
 
   elseif cmd == "extract" then
     local output_dir = remaining[2]
-    if not output_dir then
-      io.stderr:write("usage: ah extract <dir>\n")
-      return 1
-    end
-    -- Extract only files from embed/ prefix
+    if not output_dir then io.stderr:write("usage: ah extract <dir>\n"); return 1 end
     local exe_path = arg[-1]
     local exe_data = cio.slurp(exe_path)
-    if not exe_data then
-      io.stderr:write("extract: cannot read executable\n")
-      return 1
-    end
-    local reader, err = zip.from(exe_data)
-    if not reader then
-      io.stderr:write("extract: " .. (err or "no zip archive found") .. "\n")
-      return 1
-    end
+    if not exe_data then io.stderr:write("extract: cannot read executable\n"); return 1 end
+    local reader, zerr = zip.from(exe_data)
+    if not reader then io.stderr:write("extract: " .. (zerr or "no zip archive found") .. "\n"); return 1 end
     local prefix = "embed/"
     local entries = reader:list()
     local count = 0
@@ -1097,287 +285,174 @@ local function main(args: {string}): integer, string
     return 0
   end
 
-  -- Session selection logic (only if --db not specified)
+  -- Session selection
   local session_ulid: string = nil
   if not db_path then
     local ah_dir = fs.join(cwd, ".ah")
     fs.makedirs(ah_dir)
 
     if new_session and session_name then
-      -- --new + --name: error, conflicting intent
       return 1, "--new and --name cannot be used together"
     elseif session_name then
-      -- --name NAME: find existing session by name, or create new
-      local sessions = list_sessions(cwd)
-      local found: Session = nil
+      local sessions = sessions_mod.list_sessions(cwd)
+      local found: sessions_mod.Session = nil
       for _, s in ipairs(sessions) do
         if s.name == session_name then
-          if found then
-            return 1, "duplicate session name: " .. session_name
-          end
+          if found then return 1, "duplicate session name: " .. session_name end
           found = s
         end
       end
-      if found then
-        session_ulid = found.ulid
-      else
-        session_ulid = ulid.generate()
-      end
+      if found then session_ulid = found.ulid else session_ulid = ulid.generate() end
     elseif new_session then
-      -- -n: force new session
       session_ulid = ulid.generate()
     elseif session_prefix then
-      -- -S PREFIX: resolve to specific session
-      local resolved, err = resolve_session(cwd, session_prefix)
-      if not resolved then
-        return 1, err
-      end
+      local resolved, rerr = sessions_mod.resolve_session(cwd, session_prefix)
+      if not resolved then return 1, rerr end
       session_ulid = resolved
     else
-      -- Default: use most recent session or create new if needed
-      local sessions = list_sessions(cwd)
-      if #sessions > 0 then
-        session_ulid = sessions[1].ulid
-      else
-        -- No existing sessions - will create new if prompt given
-        session_ulid = ulid.generate()
-      end
+      local sessions = sessions_mod.list_sessions(cwd)
+      if #sessions > 0 then session_ulid = sessions[1].ulid
+      else session_ulid = ulid.generate() end
     end
 
     db_path = fs.join(ah_dir, session_ulid .. ".db")
   end
 
-  -- Queue path is derived from session (same directory as db)
   local queue_path = db_path:gsub("%.db$", ".queue.db")
 
-  -- Handle --steer and --followup options (queue and exit)
   if steer_msg or followup_msg then
     local qdb, qerr = queue.open(queue_path)
-    if not qdb then
-      return 1, qerr
-    end
-
-    if steer_msg then
-      queue.add_steer(qdb, steer_msg)
-      io.stderr:write("queued steering message\n")
-    end
-    if followup_msg then
-      queue.add_followup(qdb, followup_msg)
-      io.stderr:write("queued followup message\n")
-    end
-
+    if not qdb then return 1, qerr end
+    if steer_msg then queue.add_steer(qdb, steer_msg); io.stderr:write("queued steering message\n") end
+    if followup_msg then queue.add_followup(qdb, followup_msg); io.stderr:write("queued followup message\n") end
     queue.close(qdb)
     return 0
   end
 
-  local d, err = db.open(db_path)
-  if not d then
-    return 1, err
-  end
+  local d, derr = db.open(db_path)
+  if not d then return 1, derr end
 
-  -- Set session name in context if --name was used on a new session
   if session_name then
     local existing_name = db.get_context(d, "session_name")
-    if not existing_name then
-      db.set_context(d, "session_name", session_name)
-    end
+    if not existing_name then db.set_context(d, "session_name", session_name) end
   end
 
-  -- Clean up any orphan messages from previous crashes
   local orphans_cleaned = db.cleanup_orphans(d)
   if orphans_cleaned > 0 then
     io.stderr:write(string.format("cleaned up %d orphan message(s) from previous crash\n", orphans_cleaned))
   end
 
-  -- Open queue database (will be used for lock management and steering/followup)
   local qdb, qerr = queue.open(queue_path)
-  if not qdb then
-    db.close(d)
-    return 1, qerr
-  end
+  if not qdb then db.close(d); return 1, qerr end
 
-  -- Handle commands (no lock needed for read-only commands)
   if cmd == "usage" then
-    cmd_usage(d)
-    queue.close(qdb)
-    db.close(d)
+    sessions_mod.cmd_usage(d)
+    queue.close(qdb); db.close(d)
     return 0
-
   end
 
-  -- Handle prompt or continue
   local parent_id: string = nil
   local prompt: string = nil
-
   prompt = table.concat(remaining, " ")
 
-  -- Get parent message - always continue from last message unless forking with @N
   if not parent_id then
     local last = db.get_last_message(d)
-    if last then
-      parent_id = (last as {string: any}).id as string
-    end
+    if last then parent_id = (last as {string: any}).id as string end
   end
 
-  -- If no prompt, read from stdin
   if prompt == "" then
-    -- Show prompt indicator if stdin is a tty
-    if tty.isatty(0) then
-      io.stderr:write(">>> ")
-      io.stderr:flush()
-    end
+    if tty.isatty(0) then io.stderr:write(">>> "); io.stderr:flush() end
     local ok, input = pcall(io.read, "*a")
     if not ok or not input then
-      -- Interrupted or EOF
-      io.stderr:write("\n")
-      queue.close(qdb)
-      db.close(d)
-      return 0
+      io.stderr:write("\n"); queue.close(qdb); db.close(d); return 0
     end
-    prompt = input
-    -- Trim trailing newline
-    prompt = prompt:gsub("%s+$", "")
+    prompt = input:gsub("%s+$", "")
     if prompt == "" and not parsed.skill then
-      usage()
-      queue.close(qdb)
-      db.close(d)
-      return 0
+      args_mod.usage(); queue.close(qdb); db.close(d); return 0
     end
   end
 
-  -- Load skills
   local loaded_skills = skills.load_skills(cwd)
-
-  -- --skill flag: prepend /skill:<name> to prompt
   local active_skill_name: string = parsed.skill
-  if parsed.skill then
-    prompt = "/skill:" .. parsed.skill .. "\n" .. prompt
-  end
+  if parsed.skill then prompt = "/skill:" .. parsed.skill .. "\n" .. prompt end
 
-  -- Expand /skill: invocations first
   local skill_expanded, was_skill = skills.expand_skill(prompt, loaded_skills)
   if was_skill then
     prompt = skill_expanded
-    -- Extract skill name if not already set from --skill flag
-    if not active_skill_name then
-      active_skill_name = prompt:match('^<skill name="([a-z0-9%-]+)"')
-    end
+    if not active_skill_name then active_skill_name = prompt:match('^<skill name="([a-z0-9%-]+)"') end
   end
 
-  -- Expand commands (prompts starting with /)
   if not was_skill then
     local loaded_commands = commands.load_commands()
     local expanded, was_command = commands.expand_command(prompt, loaded_commands)
-    if was_command then
-      prompt = expanded
-    end
+    if was_command then prompt = expanded end
   end
 
-  -- Load system prompt
-  -- Initialize custom tools (must happen before format_tools_for_prompt)
   tools.init_custom_tools(cwd)
-
-  -- Load tools from the active skill's tools/ subdirectory
   if active_skill_name and loaded_skills[active_skill_name] then
     tools.load_skill_tools(loaded_skills[active_skill_name].base_dir)
   end
 
-  -- Apply --tool overrides (highest precedence, overrides everything)
-  -- name=cmd adds/replaces a tool; name= (empty cmd) removes it
   for _, spec in ipairs(parsed.tool_overrides) do
-    local name, cmd = spec:match("^([^=]+)=(.*)")
-    if name and cmd ~= "" then
-      tools.add_tool_override(name, cmd)
-    elseif name then
-      tools.remove_tool(name)
-    else
-      io.stderr:write("warning: invalid --tool spec (expected name=cmd): " .. spec .. "\n")
-    end
+    local name, tcmd = spec:match("^([^=]+)=(.*)")
+    if name and tcmd ~= "" then tools.add_tool_override(name, tcmd)
+    elseif name then tools.remove_tool(name)
+    else io.stderr:write("warning: invalid --tool spec (expected name=cmd): " .. spec .. "\n") end
   end
 
-  local effective_system = load_system_prompt(cwd)
-
-  -- Append dynamic tool guidance to system prompt
+  local effective_system = prompt_mod.load_system_prompt(cwd)
   local tools_prompt = tools.format_tools_for_prompt()
-  if tools_prompt ~= "" then
-    effective_system = effective_system .. "\n\n" .. tools_prompt
-  end
-
-  -- Append skills to system prompt
+  if tools_prompt ~= "" then effective_system = effective_system .. "\n\n" .. tools_prompt end
   local skills_prompt = skills.format_skills_for_prompt(loaded_skills)
-  if skills_prompt ~= "" then
-    effective_system = effective_system .. "\n\n" .. skills_prompt
-  end
-
-  -- Reinforce must-produce in system prompt
+  if skills_prompt ~= "" then effective_system = effective_system .. "\n\n" .. skills_prompt end
   if parsed.must_produce then
     effective_system = effective_system .. "\n\nIMPORTANT: You must write the file `" .. parsed.must_produce .. "` before finishing."
   end
 
-  -- Try to acquire session lock
   local lock_acquired, lock_err = queue.try_acquire_lock(qdb)
   if not lock_acquired then
-    -- Session is locked by another process - queue as followup
     queue.add_followup(qdb, prompt)
     io.stderr:write("session locked, queued as followup: " .. (lock_err or "") .. "\n")
-    queue.close(qdb)
-    db.close(d)
+    queue.close(qdb); db.close(d)
     return 0
   end
 
-  -- Install SIGINT handler for graceful Ctrl+C with abort cascade:
-  -- 1. Set interrupted flag (checked by loop between iterations and mid-stream)
-  -- 2. Immediately abort any running tool processes (SIGTERM -> SIGKILL)
-  -- 3. Release session lock
   signal.sigaction(signal.SIGINT, function()
       interrupted = true
       tools.abort_running_tools()
       queue.release_lock(qdb)
     end)
 
-  -- Resolve model: --model flag > AH_MODEL env > default
   local effective_model = api.resolve_model(model or os.getenv("AH_MODEL"))
-
-  -- Run agent with CLI event handler
-  local on_event = make_cli_handler(parsed.skill)
+  local on_event = cli_mod.make_cli_handler(parsed.skill)
   local agent_opts: loop.AgentOpts = {}
-  if max_tokens then
-    agent_opts.max_tokens = max_tokens
-  end
-  if parsed.must_produce then
-    agent_opts.must_produce = parsed.must_produce
-  end
+  if max_tokens then agent_opts.max_tokens = max_tokens end
+  if parsed.must_produce then agent_opts.must_produce = parsed.must_produce end
   local stop_reason = loop.run_agent(d, qdb, effective_system, effective_model, prompt, parent_id, on_event, agent_opts)
 
-  -- Mark session as closed before exit
   db.set_session_state(d, "closed")
-
-  -- Release lock and clean up
   queue.release_lock(qdb)
   queue.close(qdb)
   db.close(d)
 
-  -- Return non-zero exit code for error stop reasons
-  if stop_reason == "error" then
-    return 1
-  end
-
+  if stop_reason == "error" then return 1 end
   return 0
 end
 
 return {
   main = main,
-  parse_args = parse_args,
-  parse_subcommand_options = parse_subcommand_options,
-  load_system_prompt = load_system_prompt,
-  load_claude_md = load_claude_md,
-  list_sessions = list_sessions,
-  resolve_session = resolve_session,
-  parse_protect_dirs = parse_protect_dirs,
-  parse_unveil_entry = parse_unveil_entry,
-  usage_text = usage_text,
-  colorize_diff_line = colorize_diff_line,
-  colorize_tool_line = colorize_tool_line,
-  format_tokens = format_tokens,
-  make_cli_handler = make_cli_handler,
+  -- Re-export from submodules for backward compatibility
+  parse_args = args_mod.parse_args,
+  parse_subcommand_options = args_mod.parse_subcommand_options,
+  load_system_prompt = prompt_mod.load_system_prompt,
+  load_claude_md = prompt_mod.load_claude_md,
+  list_sessions = sessions_mod.list_sessions,
+  resolve_session = sessions_mod.resolve_session,
+  parse_protect_dirs = args_mod.parse_protect_dirs,
+  parse_unveil_entry = args_mod.parse_unveil_entry,
+  usage_text = args_mod.usage_text,
+  colorize_diff_line = cli_mod.colorize_diff_line,
+  colorize_tool_line = cli_mod.colorize_tool_line,
+  format_tokens = cli_mod.format_tokens,
+  make_cli_handler = cli_mod.make_cli_handler,
 }

--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -1,7 +1,5 @@
--- ah/loop.tl: agent loop (tool dispatch, event emission)
+-- ah/loop.tl: agent loop (API call → tool dispatch → repeat)
 local json = require("cosmic.json")
-local time = require("cosmic.time")
-local cfs = require("cosmic.fs")
 local db = require("ah.db")
 local api = require("ah.api")
 local tools = require("ah.tools")
@@ -10,171 +8,15 @@ local events = require("ah.events")
 local queue = require("ah.queue")
 local truncate = require("ah.truncate")
 local compact = require("ah.compact")
+local looputil = require("ah.looputil")
+local looptool = require("ah.looptool")
 
 -- Reference the global interrupted flag (set by application layer)
 global interrupted: boolean
 
--- Shorten an absolute path to a relative one when under cwd
-local _cwd: string
-local function shorten_path(p: string): string
-  if not _cwd then
-    _cwd = cfs.getcwd() or ""
-  end
-  if _cwd ~= "" and p:sub(1, #_cwd) == _cwd then
-    local rest = p:sub(#_cwd + 1)
-    if rest:sub(1, 1) == "/" then
-      rest = rest:sub(2)
-    end
-    if rest == "" then return "." end
-    return rest
-  end
-  return p
-end
-
 -- Loop detection thresholds
-local LOOP_WARN_THRESHOLD = 3 -- Consecutive identical turns before steering injection
-local LOOP_BREAK_THRESHOLD = 5 -- Consecutive identical turns before forced break
-
--- Get monotonic time in seconds
-local function now(): number
-  local s, ns = time.monotonic()
-  return s + ns / 1e9
-end
-
--- Extract key parameter from tool details or input for display
-local function tool_key_param(tool_name: string, tool_input: string, details_json: string): string
-  -- Try details first (structured data from tool execution)
-  if details_json then
-    local details = json.decode(details_json) as {string: any}
-    if details then
-      -- skill tool: show "source → name, N lines"
-      if details.skill_name and details.line_count then
-        local src = details.path and shorten_path(details.path as string) or "?"
-        return string.format("%s → %s, %d lines", src, details.skill_name as string, details.line_count as integer)
-      elseif details.path then
-        return shorten_path(details.path as string)
-      elseif details.command then
-        return details.command as string
-      end
-    end
-  end
-
-  -- Fall back to parsing tool_input JSON
-  if not tool_input then return "" end
-  local input = json.decode(tool_input) as {string: any}
-  if not input then return "" end
-
-  if tool_name == "read" or tool_name == "write" or tool_name == "edit" then
-    return shorten_path((input.path or "") as string)
-  elseif tool_name == "bash" then
-    return (input.command or "") as string
-  end
-  return ""
-end
-
--- Wrap a long command at flag boundaries with \ continuations.
--- Returns cmd unchanged if it fits within width.
--- Otherwise splits at spaces before -- or - flags, joining with \<newline> + indent.
--- Falls back to splitting at any space if no flag boundaries found.
-local function wrap_command(cmd: string, width: integer, indent: string): string
-  width = width or 80
-  indent = indent or "    "
-  if #cmd <= width and not cmd:find(" #") then
-    return cmd
-  end
-
-  -- Try splitting at comment/flag boundaries
-  local parts: {string} = {}
-  local current = ""
-  for token in cmd:gmatch("%S+") do
-    local is_comment = token:sub(1, 1) == "#" and current ~= ""
-    local is_flag = #parts > 0 and token:sub(1, 1) == "-" and #current + 1 + #token > width
-    if is_comment or is_flag then
-      table.insert(parts, current)
-      current = indent .. token
-    elseif current == "" then
-      current = token
-    else
-      local candidate = current .. " " .. token
-      if #candidate > width and #parts > 0 then
-        -- Even without a flag boundary, line is too long
-        table.insert(parts, current)
-        current = indent .. token
-      else
-        current = candidate
-      end
-    end
-  end
-  if current ~= "" then
-    table.insert(parts, current)
-  end
-
-  if #parts > 1 then
-    return table.concat(parts, " \\\n")
-  end
-
-  -- Fallback: split at any space boundary near the width
-  parts = {}
-  current = ""
-  for token in cmd:gmatch("%S+") do
-    if current == "" then
-      current = token
-    elseif #current + 1 + #token > width then
-      table.insert(parts, current)
-      current = indent .. token
-    else
-      current = current .. " " .. token
-    end
-  end
-  if current ~= "" then
-    table.insert(parts, current)
-  end
-
-  if #parts > 1 then
-    return table.concat(parts, " \\\n")
-  end
-
-  return cmd
-end
-
--- Compute a turn signature from a list of tool calls.
--- The signature captures the tool names and key parameters to identify
--- repetitive patterns across turns. For edit operations, includes the full
--- old_string and new_string to distinguish edits to the same file.
-local function turn_signature(tool_calls: {any}): string
-  local parts: {string} = {}
-  for _, tool_call in ipairs(tool_calls) do
-    local tc = tool_call as {string: any}
-    local input = (tc.input or {}) as {string: any}
-    local input_json = json.encode(input)
-    local key = tool_key_param(tc.name as string, input_json, nil)
-    -- For edit tool, append old_string and new_string to avoid collisions
-    -- when multiple edits target the same file with different content.
-    if tc.name == "edit" and input then
-      local old_s = (input.old_string or "") as string
-      local new_s = (input.new_string or "") as string
-      key = key .. "|" .. old_s .. "|" .. new_s
-    end
-    table.insert(parts, (tc.name as string) .. ":" .. key)
-  end
-  return table.concat(parts, "|")
-end
-
--- Check for consecutive identical signatures at the end of the history.
--- Returns the count of consecutive identical entries (1 = no repetition).
-local function check_loop(history: {string}): integer
-  if #history < 2 then return #history end
-  local current = history[#history]
-  local count = 1
-  for i = #history - 1, 1, -1 do
-    if history[i] == current then
-      count = count + 1
-    else
-      break
-    end
-  end
-  return count
-end
+local LOOP_WARN_THRESHOLD = 3
+local LOOP_BREAK_THRESHOLD = 5
 
 -- Emit an event through the callback, silently ignoring if no callback
 local function emit(on_event: events.EventCallback, event: events.EventData)
@@ -195,104 +37,55 @@ end
 
 -- Options for run_agent
 local record AgentOpts
-  max_tokens: integer -- Optional token budget (input + output combined). Stop with budget_exceeded when exceeded.
-  must_produce: string -- Optional file path that must exist when agent finishes. Retries once with a reminder.
+  max_tokens: integer
+  must_produce: string
 end
 
--- Send prompt and run agent loop
--- qdb: optional queue database for inter-process coordination (steering/followup)
--- on_event: optional callback for structured lifecycle events.
--- When provided, the loop emits events instead of writing directly to stderr/stdout.
--- When nil, the loop still functions but produces no output.
--- opts: optional agent options (e.g. token budget)
-local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, model: string, prompt: string, parent_id: string, on_event: events.EventCallback, opts: AgentOpts): string
-  opts = opts or {}
-  local max_tokens = opts.max_tokens
-  local must_produce = opts.must_produce
-  local must_produce_reminded = false
-
-  -- Load credentials to determine if OAuth mode
-  local creds, creds_err = auth.load_credentials()
-  if not creds then
-    emit(on_event, events.error_event("credentials: " .. creds_err))
-    return "error"
-  end
-  local is_oauth = creds.is_oauth or false
-
-  -- Transition to processing state
-  transition_state(d, on_event, "processing")
-
-  -- Emit agent_start event
-  emit(on_event, events.agent_start(model, prompt, parent_id))
-
-  -- Create user message (atomic: message + content block)
-  db.begin_transaction(d)
-  local user_msg = db.create_message(d, "user", parent_id)
-  db.add_content_block(d, user_msg.id, "text", {content = prompt})
-  db.commit(d)
-
-  -- Build messages from ancestry (skip incomplete messages from crashes)
-  local ancestry = db.get_ancestry(d, user_msg.id)
+-- Build API messages from ancestry chain, skipping incomplete messages
+local function build_api_messages(d: db.DB, message_id: string, on_event: events.EventCallback): {any}
+  local ancestry = db.get_ancestry(d, message_id)
   local api_messages: {any} = {}
 
   for _, msg in ipairs(ancestry) do
     local blocks = db.get_content_blocks(d, msg.id)
-
-    -- Skip messages with no content blocks (incomplete from crash)
     if #blocks == 0 then
       emit(on_event, events.error_event(string.format("skipping incomplete message %s (no content blocks)", msg.id)))
       goto continue
     end
 
     local content: {any} = {}
-
     for _, block in ipairs(blocks) do
       if block.block_type == "text" then
         table.insert(content, {type = "text", text = block.content})
       elseif block.block_type == "tool_use" then
         local input = block.tool_input and json.decode(block.tool_input as string) or {}
-        table.insert(content, {
-            type = "tool_use",
-            id = block.tool_id,
-            name = block.tool_name,
-            input = input,
-          })
+        table.insert(content, {type = "tool_use", id = block.tool_id, name = block.tool_name, input = input})
       elseif block.block_type == "tool_result" then
-        -- Truncate stored output for API (full output preserved in DB)
         local tool_output = block.tool_output as string
         local truncation = truncate.truncate_output(tool_output or "", block.tool_name as string or "")
         local api_content: any = truncation.content
-        -- Check if result is structured (image content)
         if tool_output and tool_output:sub(1, 14) == '{"__image__":' then
           local parsed = json.decode(tool_output) as {string: any}
           if parsed and parsed.__image__ and parsed.content then
             api_content = parsed.content
           end
         end
-        table.insert(content, {
-            type = "tool_result",
-            tool_use_id = block.tool_id,
-            content = api_content,
-            is_error = block.is_error == 1,
-          })
+        table.insert(content, {type = "tool_result", tool_use_id = block.tool_id, content = api_content, is_error = block.is_error == 1})
       end
     end
 
-    table.insert(api_messages, {
-        role = msg.role,
-        content = content,
-      })
+    table.insert(api_messages, {role = msg.role, content = content})
     ::continue::
   end
 
-  -- Repair dangling tool_use: if an assistant message has tool_use blocks
-  -- but the next message is not a user message with matching tool_results,
-  -- inject synthetic error tool_results. This handles corruption from
-  -- budget_exceeded, crashes, or other interrupted exits.
+  return api_messages
+end
+
+-- Repair dangling tool_use blocks in message history
+local function repair_dangling_tool_use(api_messages: {any}, on_event: events.EventCallback)
   for i = 1, #api_messages - 1 do
     local msg = api_messages[i] as {string: any}
     if msg.role == "assistant" then
-      -- Collect tool_use IDs from this assistant message
       local tool_use_ids: {string} = {}
       local msg_content = msg.content as {any}
       for _, block in ipairs(msg_content) do
@@ -303,7 +96,6 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       end
 
       if #tool_use_ids > 0 then
-        -- Check if next message has matching tool_results
         local next_msg = api_messages[i + 1] as {string: any}
         local has_tool_results = false
         if next_msg.role == "user" then
@@ -318,78 +110,70 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
         end
 
         if not has_tool_results then
-          -- Inject a synthetic tool_result message after this assistant message
           local synthetic_results: {any} = {}
           for _, tid in ipairs(tool_use_ids) do
-            table.insert(synthetic_results, {
-                type = "tool_result",
-                tool_use_id = tid,
-                content = "error: tool execution was interrupted (session resumed)",
-                is_error = true,
-              })
+            table.insert(synthetic_results, {type = "tool_result", tool_use_id = tid, content = "error: tool execution was interrupted (session resumed)", is_error = true})
           end
-          -- Insert the synthetic user message right after the assistant message
-          table.insert(api_messages, i + 1, {
-              role = "user",
-              content = synthetic_results,
-            })
-          emit(on_event, events.error_event(string.format(
-                "repaired %d dangling tool_use block(s) in message history",
-                #tool_use_ids)))
+          table.insert(api_messages, i + 1, {role = "user", content = synthetic_results})
+          emit(on_event, events.error_event(string.format("repaired %d dangling tool_use block(s) in message history", #tool_use_ids)))
         end
       end
     end
   end
+end
 
-  -- Track final stop reason for agent_end event
+-- Send prompt and run agent loop
+local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, model: string, prompt: string, parent_id: string, on_event: events.EventCallback, opts: AgentOpts): string
+  opts = opts or {}
+  local max_tokens = opts.max_tokens
+  local must_produce = opts.must_produce
+  local must_produce_reminded = false
+
+  local creds, creds_err = auth.load_credentials()
+  if not creds then
+    emit(on_event, events.error_event("credentials: " .. creds_err))
+    return "error"
+  end
+
+  transition_state(d, on_event, "processing")
+  emit(on_event, events.agent_start(model, prompt, parent_id))
+
+  db.begin_transaction(d)
+  local user_msg = db.create_message(d, "user", parent_id)
+  db.add_content_block(d, user_msg.id, "text", {content = prompt})
+  db.commit(d)
+
+  local api_messages = build_api_messages(d, user_msg.id, on_event)
+  repair_dangling_tool_use(api_messages, on_event)
+
   local final_stop_reason = "unknown"
-
-  -- Track last error message for agent_end
   local last_error: string = nil
-
-  -- Turn signature history for loop detection
   local turn_history: {string} = {}
-
-  -- Track input tokens from last API response for compaction decisions
   local last_input_tokens: integer = 0
-
-  -- Track cumulative tokens for budget enforcement
   local cumulative_input_tokens: integer = 0
   local cumulative_output_tokens: integer = 0
 
-  -- Closure for api.stream to check interruption mid-stream
   local function is_interrupted(): boolean
     return interrupted
   end
 
-  -- Agent loop
   while not interrupted do
-    -- Update heartbeat and drain steering queue before API call
+    -- Drain steering queue
     if qdb then
       queue.update_heartbeat(qdb)
-
       local steering_msgs = queue.drain_steering(qdb)
       for _, steer_msg in ipairs(steering_msgs) do
         emit(on_event, events.steering_received(steer_msg.content, #steering_msgs))
-
-        -- Create steering user message and add to conversation
         db.begin_transaction(d)
         local steer_user_msg = db.create_message(d, "user", user_msg.id)
         db.add_content_block(d, steer_user_msg.id, "text", {content = "[STEERING] " .. steer_msg.content})
         db.commit(d)
-
-        -- Add to API messages
-        table.insert(api_messages, {
-            role = "user",
-            content = {{type = "text", text = "[STEERING] " .. steer_msg.content}},
-          })
-
-        -- Update parent for next iteration
+        table.insert(api_messages, {role = "user", content = {{type = "text", text = "[STEERING] " .. steer_msg.content}}})
         user_msg = steer_user_msg
       end
     end
 
-    -- Check if compaction is needed before API call
+    -- Compaction
     if last_input_tokens > 0 and compact.needs_compaction(last_input_tokens, model) then
       local context_limit = compact.get_context_limit(model)
       emit(on_event, events.compaction_triggered(last_input_tokens, context_limit))
@@ -397,38 +181,25 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
 
       local compact_result, compact_err = compact.compact(api_messages, model, is_interrupted)
       if compact_result then
-        -- Persist compaction summary as a user message so it survives crashes.
-        -- The full conversation is always preserved; this message acts as the
-        -- compaction checkpoint that a new invocation can rebuild from.
         db.begin_transaction(d)
         local compact_msg = db.create_message(d, "user", user_msg.id)
         db.add_content_block(d, compact_msg.id, "text", {content = "[COMPACTION SUMMARY]\n" .. compact_result.summary})
         db.commit(d)
         user_msg = compact_msg
-
-        -- Replace api_messages with compacted summary
-        api_messages = {{
-            role = "user",
-            content = {{type = "text", text = compact_result.summary}},
-          }}
-        last_input_tokens = 0 -- Reset to avoid re-triggering
-
+        api_messages = {{role = "user", content = {{type = "text", text = compact_result.summary}}}}
+        last_input_tokens = 0
         emit(on_event, events.compaction_complete(compact_result.input_tokens, compact_result.output_tokens))
         db.log_event(d, "compaction_complete", nil, events.to_json(events.compaction_complete(compact_result.input_tokens, compact_result.output_tokens)))
       else
-        -- Compaction failed - continue without it
         emit(on_event, events.error_event(compact_err))
         db.log_event(d, "error", nil, events.to_json(events.error_event(compact_err)))
-        last_input_tokens = 0 -- Don't keep retrying
+        last_input_tokens = 0
       end
     end
 
-    -- Emit api_call_start
     emit(on_event, events.api_call_start())
 
-    -- Add cache_control breakpoint on the last content block of the last message.
-    -- This tells the Anthropic API to cache everything up to this point,
-    -- reducing input token costs on subsequent turns.
+    -- Cache breakpoint
     local cache_msg_idx: integer = nil
     local cache_block_idx: integer = nil
     for i = #api_messages, 1, -1 do
@@ -443,11 +214,8 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       end
     end
 
-    -- Stream response with mid-stream interruption support
     local response, err = api.stream(api_messages, {
-        system = system_prompt,
-        model = model,
-        tools = tools.get_tool_definitions(),
+        system = system_prompt, model = model, tools = tools.get_tool_definitions(),
       }, function(event: {string: any})
         if event.type == "content_block_delta" and event.delta then
           local delta = event.delta as {string: any}
@@ -457,7 +225,6 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
         end
       end, is_interrupted)
 
-    -- Remove the cache_control marker we added (clean up for next iteration)
     if cache_msg_idx and cache_block_idx then
       local msg = api_messages[cache_msg_idx] as {string: any}
       local content = msg.content as {any}
@@ -481,30 +248,25 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       break
     end
 
-    -- Check if stream was interrupted - persist partial response and exit
     local resp = response as {string: any}
     if interrupted or resp.stop_reason == "interrupted" then
-      -- Persist partial assistant response if we have any content
       local resp_content = resp.content as {any}
       if resp_content and #resp_content > 0 then
-        local assistant_blocks: {{string: any}} = {}
+        local abl: {{string: any}} = {}
         for _, block in ipairs(resp_content) do
           local b = block as {string: any}
           if b.type == "text" and b.text then
-            table.insert(assistant_blocks, {block_type = "text", content = b.text as string})
+            table.insert(abl, {block_type = "text", content = b.text as string})
           end
         end
-        if #assistant_blocks > 0 then
-          local usage = (resp.usage or {}) as {string: any}
+        if #abl > 0 then
+          local u = (resp.usage or {}) as {string: any}
           db.begin_transaction(d)
           local partial_msg = db.create_message(d, "assistant", user_msg.id, {
-              input_tokens = usage.input_tokens as integer,
-              output_tokens = usage.output_tokens as integer,
-              stop_reason = "interrupted",
-              model = resp.model as string,
-              api_latency_ms = resp.api_latency_ms as integer,
+              input_tokens = u.input_tokens as integer, output_tokens = u.output_tokens as integer,
+              stop_reason = "interrupted", model = resp.model as string, api_latency_ms = resp.api_latency_ms as integer,
             })
-          for _, blk in ipairs(assistant_blocks) do
+          for _, blk in ipairs(abl) do
             db.add_content_block(d, partial_msg.id, "text", {content = blk.content as string})
           end
           db.commit(d)
@@ -514,11 +276,10 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       break
     end
 
-    -- Collect response content blocks before writing to DB
+    -- Collect response content blocks
     local resp_content = resp.content as {any}
     local assistant_api_content: {any} = {}
     local assistant_blocks: {{string: any}} = {}
-
     for _, block in ipairs(resp_content) do
       local b = block as {string: any}
       if b.type == "text" then
@@ -526,337 +287,117 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
         table.insert(assistant_api_content, {type = "text", text = b.text})
       elseif b.type == "tool_use" then
         local input_json = json.encode(b.input or {})
-        table.insert(assistant_blocks, {
-            block_type = "tool_use",
-            tool_id = b.id as string,
-            tool_name = b.name as string,
-            tool_input = input_json,
-          })
-        table.insert(assistant_api_content, {
-            type = "tool_use",
-            id = b.id,
-            name = b.name,
-            input = b.input or {},
-          })
+        table.insert(assistant_blocks, {block_type = "tool_use", tool_id = b.id as string, tool_name = b.name as string, tool_input = input_json})
+        table.insert(assistant_api_content, {type = "tool_use", id = b.id, name = b.name, input = b.input or {}})
       end
     end
 
-    -- Extract usage and metadata from response
     local usage = (resp.usage or {}) as {string: any}
     local cache_creation_tokens = (usage.cache_creation_input_tokens or 0) as integer
     local cache_read_tokens = (usage.cache_read_input_tokens or 0) as integer
-    -- Effective input = uncached + cache read + cache creation (full prompt size)
     local effective_input_tokens = ((usage.input_tokens or 0) as integer) + cache_creation_tokens + cache_read_tokens
     last_input_tokens = effective_input_tokens
-    local msg_opts: db.MessageOpts = {
-      input_tokens = effective_input_tokens,
-      output_tokens = usage.output_tokens as integer,
-      stop_reason = resp.stop_reason as string,
-      model = resp.model as string,
-      api_latency_ms = resp.api_latency_ms as integer,
-    }
 
-    -- Atomically write assistant message + all content blocks
     db.begin_transaction(d)
-    local assistant_msg = db.create_message(d, "assistant", user_msg.id, msg_opts)
+    local assistant_msg = db.create_message(d, "assistant", user_msg.id, {
+        input_tokens = effective_input_tokens, output_tokens = usage.output_tokens as integer,
+        stop_reason = resp.stop_reason as string, model = resp.model as string, api_latency_ms = resp.api_latency_ms as integer,
+      })
     for _, blk in ipairs(assistant_blocks) do
       if blk.block_type == "text" then
         db.add_content_block(d, assistant_msg.id, "text", {content = blk.content as string})
       elseif blk.block_type == "tool_use" then
-        db.add_content_block(d, assistant_msg.id, "tool_use", {
-            tool_id = blk.tool_id as string,
-            tool_name = blk.tool_name as string,
-            tool_input = blk.tool_input as string,
-          })
+        db.add_content_block(d, assistant_msg.id, "tool_use", {tool_id = blk.tool_id as string, tool_name = blk.tool_name as string, tool_input = blk.tool_input as string})
       end
     end
-
-    -- Log retry events if any occurred
     local retries = resp.retries as {{string: any}}
     if retries then
       for _, retry in ipairs(retries) do
         local retry_json = json.encode(retry)
         db.log_event(d, "retry", assistant_msg.id, retry_json)
-        emit(on_event, events.retry_event(
-            (retry.attempt or 0) as integer,
-            (retry.delay_ms or 0) as integer,
-            (retry.status or 0) as integer,
-            (retry.error or "") as string
-          ))
+        emit(on_event, events.retry_event((retry.attempt or 0) as integer, (retry.delay_ms or 0) as integer, (retry.status or 0) as integer, (retry.error or "") as string))
       end
     end
-
     db.commit(d)
 
-    -- Emit api_call_end with message metadata and cache stats
-    emit(on_event, events.api_call_end(
-        assistant_msg.id,
-        usage.input_tokens as integer,
-        usage.output_tokens as integer,
-        resp.api_latency_ms as integer,
-        resp.model as string,
-        cache_creation_tokens,
-        cache_read_tokens
-      ))
+    emit(on_event, events.api_call_end(assistant_msg.id, usage.input_tokens as integer, usage.output_tokens as integer, resp.api_latency_ms as integer, resp.model as string, cache_creation_tokens, cache_read_tokens))
+    db.log_event(d, "api_call_end", assistant_msg.id, events.to_json(events.api_call_end(assistant_msg.id, usage.input_tokens as integer, usage.output_tokens as integer, resp.api_latency_ms as integer, resp.model as string, cache_creation_tokens, cache_read_tokens)))
 
-    -- Log api_call_end event to DB
-    db.log_event(d, "api_call_end", assistant_msg.id, events.to_json(events.api_call_end(
-          assistant_msg.id,
-          usage.input_tokens as integer,
-          usage.output_tokens as integer,
-          resp.api_latency_ms as integer,
-          resp.model as string,
-          cache_creation_tokens,
-          cache_read_tokens
-        )))
-
-    -- Track tokens for budget enforcement
-    -- Use last call's effective input (current context size) rather than
-    -- cumulative input, which would double-count the growing conversation.
     cumulative_input_tokens = effective_input_tokens
     cumulative_output_tokens = cumulative_output_tokens + ((usage.output_tokens or 0) as integer)
 
-    -- Check token budget: current context size + total output generated
     if max_tokens and (cumulative_input_tokens + cumulative_output_tokens) > max_tokens then
       emit(on_event, events.budget_exceeded(cumulative_input_tokens, cumulative_output_tokens, max_tokens))
-      db.log_event(d, "budget_exceeded", assistant_msg.id,
-        events.to_json(events.budget_exceeded(cumulative_input_tokens, cumulative_output_tokens, max_tokens)))
-
-      -- Persist stub tool_results for any tool_use blocks in the assistant
-      -- message so the DB stays consistent for session resume.
+      db.log_event(d, "budget_exceeded", assistant_msg.id, events.to_json(events.budget_exceeded(cumulative_input_tokens, cumulative_output_tokens, max_tokens)))
       local pending_tool_ids: {string} = {}
       for _, blk in ipairs(assistant_blocks) do
-        if blk.block_type == "tool_use" then
-          table.insert(pending_tool_ids, blk.tool_id as string)
-        end
+        if blk.block_type == "tool_use" then table.insert(pending_tool_ids, blk.tool_id as string) end
       end
       if #pending_tool_ids > 0 then
         db.begin_transaction(d)
         local stub_msg = db.create_message(d, "user", assistant_msg.id)
         for _, tid in ipairs(pending_tool_ids) do
-          db.add_content_block(d, stub_msg.id, "tool_result", {
-              tool_id = tid,
-              tool_output = "error: tool execution skipped (token budget exceeded)",
-              is_error = true,
-              duration_ms = 0,
-            })
+          db.add_content_block(d, stub_msg.id, "tool_result", {tool_id = tid, tool_output = "error: tool execution skipped (token budget exceeded)", is_error = true, duration_ms = 0})
         end
         db.commit(d)
       end
-
       final_stop_reason = "budget_exceeded"
       break
     end
 
-    -- Add assistant message to API messages
     table.insert(api_messages, {role = "assistant", content = assistant_api_content})
 
-    -- Check for tool calls
     local tool_calls = api.extract_tool_calls(response) as {any}
     if #tool_calls == 0 then
-      -- No tool calls - check for followup messages before exiting
       if qdb then
         local followup_msgs = queue.drain_followup(qdb)
         if #followup_msgs > 0 then
-          -- Process followup messages by injecting them as new user messages
           for _, followup_msg in ipairs(followup_msgs) do
             emit(on_event, events.followup_received(followup_msg.content, #followup_msgs))
-
-            -- Create followup user message
             db.begin_transaction(d)
             local followup_user_msg = db.create_message(d, "user", assistant_msg.id)
             db.add_content_block(d, followup_user_msg.id, "text", {content = followup_msg.content})
             db.commit(d)
-
-            -- Add to API messages
-            table.insert(api_messages, {
-                role = "user",
-                content = {{type = "text", text = followup_msg.content}},
-              })
-
-            -- Update user_msg for next iteration
+            table.insert(api_messages, {role = "user", content = {{type = "text", text = followup_msg.content}}})
             user_msg = followup_user_msg
           end
-          -- Continue the loop with followup messages
           goto continue_loop
         end
       end
 
-      -- Check must_produce: if file doesn't exist, remind once then continue
       if must_produce and not must_produce_reminded then
         local f = io.open(must_produce, "r")
-        if f then
-          f:close()
+        if f then f:close()
         else
           must_produce_reminded = true
           local reminder = "You must write the file `" .. must_produce .. "` before finishing. Please produce it now."
-
-          -- Create reminder user message
           db.begin_transaction(d)
           local reminder_msg = db.create_message(d, "user", assistant_msg.id)
           db.add_content_block(d, reminder_msg.id, "text", {content = reminder})
           db.commit(d)
-
-          table.insert(api_messages, {
-              role = "user",
-              content = {{type = "text", text = reminder}},
-            })
-
+          table.insert(api_messages, {role = "user", content = {{type = "text", text = reminder}}})
           user_msg = reminder_msg
           goto continue_loop
         end
       end
 
       final_stop_reason = resp.stop_reason as string or "end_turn"
-      break -- Done, no tool calls and no followup
-    end
-
-    -- Execute tool calls and collect results before writing to DB
-    local tool_results_content: {any} = {}
-    local tool_result_blocks: {{string: any}} = {}
-    local think_time = (resp.think_time or 0) as number
-    local tool_count = #tool_calls
-
-    for i, tool_call in ipairs(tool_calls) do
-      -- Check for interruption between tool calls
-      if interrupted then
-        -- Abort any running tool processes
-        tools.abort_running_tools()
-        final_stop_reason = "interrupted"
-        break
-      end
-
-      local tc = tool_call as {string: any}
-      local input_json = json.encode(tc.input or {})
-
-      -- Compute preliminary key from input for tool_call_start event
-      local key = tool_key_param(tc.name as string, input_json, nil)
-
-      -- Emit tool_call_start
-      emit(on_event, events.tool_call_start(tc.name as string, input_json, key, i, tool_count))
-
-      local start = now()
-      local result, is_error, details = tools.execute_tool(tc.name as string, (tc.input or {}) as {string: any})
-      local elapsed = now() - start
-
-      -- If interrupted during tool execution, abort remaining tools
-      if interrupted then
-        tools.abort_running_tools()
-        -- Still record this tool's result (it completed or was killed)
-        local elapsed_ms = math.floor(elapsed * 1000) as integer
-        emit(on_event, events.tool_call_end(tc.name as string, result, is_error, elapsed_ms, key, i, tool_count))
-        db.log_event(d, "tool_call_end", assistant_msg.id, events.to_json(events.tool_call_end(tc.name as string, "", is_error, elapsed_ms, key, i, tool_count)))
-
-        -- Encode details for interrupted tool result
-        local int_details_json: string = nil
-        if details then
-          int_details_json = json.encode(details as {string: any})
-        end
-
-        table.insert(tool_result_blocks, {
-            tool_id = tc.id as string,
-            tool_output = result,
-            is_error = is_error,
-            duration_ms = elapsed_ms,
-            details = int_details_json,
-          })
-        table.insert(tool_results_content, {
-            type = "tool_result",
-            tool_use_id = tc.id,
-            content = result,
-            is_error = is_error,
-          })
-        final_stop_reason = "interrupted"
-        break
-      end
-
-      -- First tool includes think time in its timing
-      if i == 1 then
-        elapsed = elapsed + think_time
-      end
-
-      local elapsed_ms = math.floor(elapsed * 1000) as integer
-
-      -- Encode details for display and persistence
-      local details_json: string = nil
-      if details then
-        details_json = json.encode(details as {string: any})
-      end
-
-      -- Recompute key with details for richer display in tool_call_end
-      key = tool_key_param(tc.name as string, input_json, details_json)
-
-      -- Emit tool_call_end with full (non-truncated) output
-      emit(on_event, events.tool_call_end(tc.name as string, result, is_error, elapsed_ms, key, i, tool_count))
-
-      -- Log tool_call_end event to DB (without output to avoid bloat)
-      db.log_event(d, "tool_call_end", assistant_msg.id, events.to_json(events.tool_call_end(tc.name as string, "", is_error, elapsed_ms, key, i, tool_count)))
-
-      -- Truncate output for the API (full output preserved in DB and events)
-      local truncation = truncate.truncate_output(result, tc.name as string)
-      local api_result = truncation.content
-
-      -- Check if result is structured (image content) — skip truncation for images
-      local api_content: any = api_result
-      if result:sub(1, 14) == '{"__image__":' then
-        local parsed = json.decode(result) as {string: any}
-        if parsed and parsed.__image__ and parsed.content then
-          api_content = parsed.content
-        end
-      end
-
-      -- Collect for later atomic write (store full output in DB)
-      table.insert(tool_result_blocks, {
-          tool_id = tc.id as string,
-          tool_output = result,
-          is_error = is_error,
-          duration_ms = elapsed_ms,
-          details = details_json,
-        })
-
-      -- Add to API messages content (truncated output)
-      table.insert(tool_results_content, {
-          type = "tool_result",
-          tool_use_id = tc.id,
-          content = api_content,
-          is_error = is_error,
-        })
-    end
-
-    -- Write tool results if we have any (even partial results from interruption)
-    if #tool_result_blocks > 0 then
-      -- Atomically write tool result message + all content blocks
-      db.begin_transaction(d)
-      local tool_result_msg = db.create_message(d, "user", assistant_msg.id)
-      for _, blk in ipairs(tool_result_blocks) do
-        db.add_content_block(d, tool_result_msg.id, "tool_result", {
-            tool_id = blk.tool_id as string,
-            tool_output = blk.tool_output as string,
-            is_error = blk.is_error as boolean,
-            duration_ms = blk.duration_ms as integer,
-            details = blk.details as string,
-          })
-      end
-      db.commit(d)
-
-      -- Add the tool results as a user message to API messages
-      table.insert(api_messages, {role = "user", content = tool_results_content})
-
-      -- Update user_msg for next iteration parent
-      user_msg = tool_result_msg
-    end
-
-    -- Exit if interrupted during tool execution
-    if interrupted then
       break
     end
 
-    -- Loop detection: check for repetitive tool call patterns
-    local sig = turn_signature(tool_calls)
-    table.insert(turn_history, sig)
+    -- Execute tool calls
+    local exec_result = looptool.execute_tool_calls(tool_calls, (resp.think_time or 0) as number, assistant_msg.id, d, on_event)
+    local new_user_msg = looptool.persist_tool_results(d, assistant_msg.id, exec_result, api_messages)
+    if new_user_msg then user_msg = new_user_msg end
 
-    -- Cap turn history to avoid unbounded growth. Only the most recent
-    -- entries matter for loop detection; older entries are never examined.
+    if exec_result.was_interrupted then
+      final_stop_reason = "interrupted"
+      break
+    end
+
+    -- Loop detection
+    local sig = looputil.turn_signature(tool_calls)
+    table.insert(turn_history, sig)
     local max_history = LOOP_BREAK_THRESHOLD * 2
     if #turn_history > max_history then
       local trimmed: {string} = {}
@@ -866,70 +407,41 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
       turn_history = trimmed
     end
 
-    local consecutive = check_loop(turn_history)
-
+    local consecutive = looputil.check_loop(turn_history)
     if consecutive >= LOOP_BREAK_THRESHOLD then
-      -- Too many identical turns even after steering - force break
       emit(on_event, events.loop_detected(consecutive, sig, "break"))
-      db.log_event(d, "loop_detected", assistant_msg.id,
-        events.to_json(events.loop_detected(consecutive, sig, "break")))
+      db.log_event(d, "loop_detected", assistant_msg.id, events.to_json(events.loop_detected(consecutive, sig, "break")))
       final_stop_reason = "loop_detected"
       break
     elseif consecutive >= LOOP_WARN_THRESHOLD then
-      -- Inject steering to break the loop
       emit(on_event, events.loop_detected(consecutive, sig, "warn"))
-      db.log_event(d, "loop_detected", assistant_msg.id,
-        events.to_json(events.loop_detected(consecutive, sig, "warn")))
-
-      local steering_text = string.format(
-        "[LOOP DETECTED] You have repeated the same tool call pattern %d times (%s). " ..
-        "This indicates you may be stuck in a loop. Try a different approach or " ..
-        "ask the user for help.",
-        consecutive, sig)
-
-      -- Create steering user message
+      db.log_event(d, "loop_detected", assistant_msg.id, events.to_json(events.loop_detected(consecutive, sig, "warn")))
+      local steering_text = string.format("[LOOP DETECTED] You have repeated the same tool call pattern %d times (%s). This indicates you may be stuck in a loop. Try a different approach or ask the user for help.", consecutive, sig)
       db.begin_transaction(d)
       local loop_steer_msg = db.create_message(d, "user", user_msg.id)
       db.add_content_block(d, loop_steer_msg.id, "text", {content = steering_text})
       db.commit(d)
-
-      -- Add to API messages
-      table.insert(api_messages, {
-          role = "user",
-          content = {{type = "text", text = steering_text}},
-        })
-
+      table.insert(api_messages, {role = "user", content = {{type = "text", text = steering_text}}})
       user_msg = loop_steer_msg
     end
 
     final_stop_reason = "tool_use"
-
     ::continue_loop::
   end
 
   if interrupted then
-    -- Final cleanup: abort any straggler processes
     tools.abort_running_tools()
     final_stop_reason = "interrupted"
   end
 
-  -- Transition to idle (or closed if interrupted)
   transition_state(d, on_event, "idle")
-
-  -- Query final token totals from DB (includes all messages in session, not just this run)
   local totals = db.get_session_token_totals(d)
-
-  -- Emit agent_end with token totals
   emit(on_event, events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens, last_error, totals.cache_read_tokens))
-
-  -- Log agent_end event to DB
   db.log_event(d, "agent_end", nil, events.to_json(events.agent_end(final_stop_reason, totals.input_tokens, totals.output_tokens, last_error, totals.cache_read_tokens)))
 
-  -- Check must_produce after agent ends
   if must_produce then
     local f = io.open(must_produce, "r")
-    if f then
-      f:close()
+    if f then f:close()
     else
       emit(on_event, events.error_event("must_produce: " .. must_produce .. " not created"))
       return "error"
@@ -942,11 +454,11 @@ end
 return {
   run_agent = run_agent,
   AgentOpts = AgentOpts,
-  tool_key_param = tool_key_param,
-  wrap_command = wrap_command,
-  shorten_path = shorten_path,
-  turn_signature = turn_signature,
-  check_loop = check_loop,
+  tool_key_param = looputil.tool_key_param,
+  wrap_command = looputil.wrap_command,
+  shorten_path = looputil.shorten_path,
+  turn_signature = looputil.turn_signature,
+  check_loop = looputil.check_loop,
   LOOP_WARN_THRESHOLD = LOOP_WARN_THRESHOLD,
   LOOP_BREAK_THRESHOLD = LOOP_BREAK_THRESHOLD,
 }

--- a/lib/ah/looptool.tl
+++ b/lib/ah/looptool.tl
@@ -1,0 +1,186 @@
+-- ah/looptool.tl: tool execution within the agent loop
+local json = require("cosmic.json")
+local time = require("cosmic.time")
+local db = require("ah.db")
+local tools = require("ah.tools")
+local events = require("ah.events")
+local truncate = require("ah.truncate")
+local looputil = require("ah.looputil")
+
+-- Reference the global interrupted flag
+global interrupted: boolean
+
+-- Get monotonic time in seconds
+local function now(): number
+  local s, ns = time.monotonic()
+  return s + ns / 1e9
+end
+
+-- Emit an event through the callback
+local function emit(on_event: events.EventCallback, event: events.EventData)
+  if on_event then
+    on_event(event)
+  end
+end
+
+-- Result of executing all tool calls in a turn
+local record ToolExecResult
+  tool_result_blocks: {{string: any}}
+  tool_results_content: {any}
+  was_interrupted: boolean
+end
+
+-- Execute all tool calls for a turn, emitting events and handling interruption.
+-- Returns the collected results for DB persistence and API message building.
+local function execute_tool_calls(
+    tool_calls: {any},
+    think_time: number,
+    assistant_msg_id: string,
+    d: db.DB,
+    on_event: events.EventCallback
+  ): ToolExecResult
+
+  local tool_results_content: {any} = {}
+  local tool_result_blocks: {{string: any}} = {}
+  local tool_count = #tool_calls
+
+  for i, tool_call in ipairs(tool_calls) do
+    if interrupted then
+      tools.abort_running_tools()
+      return {
+        tool_result_blocks = tool_result_blocks,
+        tool_results_content = tool_results_content,
+        was_interrupted = true,
+      }
+    end
+
+    local tc = tool_call as {string: any}
+    local input_json = json.encode(tc.input or {})
+    local key = looputil.tool_key_param(tc.name as string, input_json, nil)
+
+    emit(on_event, events.tool_call_start(tc.name as string, input_json, key, i, tool_count))
+
+    local start = now()
+    local result, is_error, details = tools.execute_tool(tc.name as string, (tc.input or {}) as {string: any})
+    local elapsed = now() - start
+
+    if interrupted then
+      tools.abort_running_tools()
+      local elapsed_ms = math.floor(elapsed * 1000) as integer
+      emit(on_event, events.tool_call_end(tc.name as string, result, is_error, elapsed_ms, key, i, tool_count))
+      db.log_event(d, "tool_call_end", assistant_msg_id, events.to_json(events.tool_call_end(tc.name as string, "", is_error, elapsed_ms, key, i, tool_count)))
+
+      local int_details_json: string = nil
+      if details then
+        int_details_json = json.encode(details as {string: any})
+      end
+
+      table.insert(tool_result_blocks, {
+          tool_id = tc.id as string,
+          tool_output = result,
+          is_error = is_error,
+          duration_ms = elapsed_ms,
+          details = int_details_json,
+        })
+      table.insert(tool_results_content, {
+          type = "tool_result",
+          tool_use_id = tc.id,
+          content = result,
+          is_error = is_error,
+        })
+      return {
+        tool_result_blocks = tool_result_blocks,
+        tool_results_content = tool_results_content,
+        was_interrupted = true,
+      }
+    end
+
+    -- First tool includes think time in its timing
+    if i == 1 then
+      elapsed = elapsed + think_time
+    end
+
+    local elapsed_ms = math.floor(elapsed * 1000) as integer
+
+    local details_json: string = nil
+    if details then
+      details_json = json.encode(details as {string: any})
+    end
+
+    -- Recompute key with details for richer display
+    key = looputil.tool_key_param(tc.name as string, input_json, details_json)
+
+    emit(on_event, events.tool_call_end(tc.name as string, result, is_error, elapsed_ms, key, i, tool_count))
+    db.log_event(d, "tool_call_end", assistant_msg_id, events.to_json(events.tool_call_end(tc.name as string, "", is_error, elapsed_ms, key, i, tool_count)))
+
+    -- Truncate output for the API (full output preserved in DB and events)
+    local truncation = truncate.truncate_output(result, tc.name as string)
+    local api_result = truncation.content
+
+    -- Check if result is structured (image content)
+    local api_content: any = api_result
+    if result:sub(1, 14) == '{"__image__":' then
+      local parsed = json.decode(result) as {string: any}
+      if parsed and parsed.__image__ and parsed.content then
+        api_content = parsed.content
+      end
+    end
+
+    table.insert(tool_result_blocks, {
+        tool_id = tc.id as string,
+        tool_output = result,
+        is_error = is_error,
+        duration_ms = elapsed_ms,
+        details = details_json,
+      })
+    table.insert(tool_results_content, {
+        type = "tool_result",
+        tool_use_id = tc.id,
+        content = api_content,
+        is_error = is_error,
+      })
+  end
+
+  return {
+    tool_result_blocks = tool_result_blocks,
+    tool_results_content = tool_results_content,
+    was_interrupted = false,
+  }
+end
+
+-- Persist tool results to DB and add to API messages.
+-- Returns the new user message (tool result message).
+local function persist_tool_results(
+    d: db.DB,
+    assistant_msg_id: string,
+    result: ToolExecResult,
+    api_messages: {any}
+  ): db.Message
+
+  if #result.tool_result_blocks == 0 then
+    return nil
+  end
+
+  db.begin_transaction(d)
+  local tool_result_msg = db.create_message(d, "user", assistant_msg_id)
+  for _, blk in ipairs(result.tool_result_blocks) do
+    db.add_content_block(d, tool_result_msg.id, "tool_result", {
+        tool_id = blk.tool_id as string,
+        tool_output = blk.tool_output as string,
+        is_error = blk.is_error as boolean,
+        duration_ms = blk.duration_ms as integer,
+        details = blk.details as string,
+      })
+  end
+  db.commit(d)
+
+  table.insert(api_messages, {role = "user", content = result.tool_results_content})
+
+  return tool_result_msg
+end
+
+return {
+  execute_tool_calls = execute_tool_calls,
+  persist_tool_results = persist_tool_results,
+  ToolExecResult = ToolExecResult,
+}

--- a/lib/ah/looputil.tl
+++ b/lib/ah/looputil.tl
@@ -1,0 +1,163 @@
+-- ah/looputil.tl: utility functions for the agent loop
+local json = require("cosmic.json")
+local cfs = require("cosmic.fs")
+
+-- Shorten an absolute path to a relative one when under cwd
+local _cwd: string
+local function shorten_path(p: string): string
+  if not _cwd then
+    _cwd = cfs.getcwd() or ""
+  end
+  if _cwd ~= "" and p:sub(1, #_cwd) == _cwd then
+    local rest = p:sub(#_cwd + 1)
+    if rest:sub(1, 1) == "/" then
+      rest = rest:sub(2)
+    end
+    if rest == "" then return "." end
+    return rest
+  end
+  return p
+end
+
+-- Extract key parameter from tool details or input for display
+local function tool_key_param(tool_name: string, tool_input: string, details_json: string): string
+  -- Try details first (structured data from tool execution)
+  if details_json then
+    local details = json.decode(details_json) as {string: any}
+    if details then
+      -- skill tool: show "source → name, N lines"
+      if details.skill_name and details.line_count then
+        local src = details.path and shorten_path(details.path as string) or "?"
+        return string.format("%s → %s, %d lines", src, details.skill_name as string, details.line_count as integer)
+      elseif details.path then
+        return shorten_path(details.path as string)
+      elseif details.command then
+        return details.command as string
+      end
+    end
+  end
+
+  -- Fall back to parsing tool_input JSON
+  if not tool_input then return "" end
+  local input = json.decode(tool_input) as {string: any}
+  if not input then return "" end
+
+  if tool_name == "read" or tool_name == "write" or tool_name == "edit" then
+    return shorten_path((input.path or "") as string)
+  elseif tool_name == "bash" then
+    return (input.command or "") as string
+  end
+  return ""
+end
+
+-- Wrap a long command at flag boundaries with \ continuations.
+-- Returns cmd unchanged if it fits within width.
+-- Otherwise splits at spaces before -- or - flags, joining with \<newline> + indent.
+-- Falls back to splitting at any space if no flag boundaries found.
+local function wrap_command(cmd: string, width: integer, indent: string): string
+  width = width or 80
+  indent = indent or "    "
+  if #cmd <= width and not cmd:find(" #") then
+    return cmd
+  end
+
+  -- Try splitting at comment/flag boundaries
+  local parts: {string} = {}
+  local current = ""
+  for token in cmd:gmatch("%S+") do
+    local is_comment = token:sub(1, 1) == "#" and current ~= ""
+    local is_flag = #parts > 0 and token:sub(1, 1) == "-" and #current + 1 + #token > width
+    if is_comment or is_flag then
+      table.insert(parts, current)
+      current = indent .. token
+    elseif current == "" then
+      current = token
+    else
+      local candidate = current .. " " .. token
+      if #candidate > width and #parts > 0 then
+        -- Even without a flag boundary, line is too long
+        table.insert(parts, current)
+        current = indent .. token
+      else
+        current = candidate
+      end
+    end
+  end
+  if current ~= "" then
+    table.insert(parts, current)
+  end
+
+  if #parts > 1 then
+    return table.concat(parts, " \\\n")
+  end
+
+  -- Fallback: split at any space boundary near the width
+  parts = {}
+  current = ""
+  for token in cmd:gmatch("%S+") do
+    if current == "" then
+      current = token
+    elseif #current + 1 + #token > width then
+      table.insert(parts, current)
+      current = indent .. token
+    else
+      current = current .. " " .. token
+    end
+  end
+  if current ~= "" then
+    table.insert(parts, current)
+  end
+
+  if #parts > 1 then
+    return table.concat(parts, " \\\n")
+  end
+
+  return cmd
+end
+
+-- Compute a turn signature from a list of tool calls.
+-- The signature captures the tool names and key parameters to identify
+-- repetitive patterns across turns. For edit operations, includes the full
+-- old_string and new_string to distinguish edits to the same file.
+local function turn_signature(tool_calls: {any}): string
+  local parts: {string} = {}
+  for _, tool_call in ipairs(tool_calls) do
+    local tc = tool_call as {string: any}
+    local input = (tc.input or {}) as {string: any}
+    local input_json = json.encode(input)
+    local key = tool_key_param(tc.name as string, input_json, nil)
+    -- For edit tool, append old_string and new_string to avoid collisions
+    -- when multiple edits target the same file with different content.
+    if tc.name == "edit" and input then
+      local old_s = (input.old_string or "") as string
+      local new_s = (input.new_string or "") as string
+      key = key .. "|" .. old_s .. "|" .. new_s
+    end
+    table.insert(parts, (tc.name as string) .. ":" .. key)
+  end
+  return table.concat(parts, "|")
+end
+
+-- Check for consecutive identical signatures at the end of the history.
+-- Returns the count of consecutive identical entries (1 = no repetition).
+local function check_loop(history: {string}): integer
+  if #history < 2 then return #history end
+  local current = history[#history]
+  local count = 1
+  for i = #history - 1, 1, -1 do
+    if history[i] == current then
+      count = count + 1
+    else
+      break
+    end
+  end
+  return count
+end
+
+return {
+  shorten_path = shorten_path,
+  tool_key_param = tool_key_param,
+  wrap_command = wrap_command,
+  turn_signature = turn_signature,
+  check_loop = check_loop,
+}

--- a/lib/ah/prompt.tl
+++ b/lib/ah/prompt.tl
@@ -1,0 +1,97 @@
+-- ah/prompt.tl: system prompt loading and project context
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local child = require("cosmic.child")
+
+-- Load CLAUDE.md with embedded base prepended
+local function load_claude_md(cwd: string): string
+  cwd = cwd or fs.getcwd()
+
+  -- CLAUDE.md supersedes AGENTS.md when both exist.
+  -- Projects should pick one file; CLAUDE.md is the conventional name.
+  local project_claude = cio.slurp(fs.join(cwd, "CLAUDE.md"))
+  if project_claude then
+    return "\n\n# Project Context\n\n" .. project_claude
+  end
+
+  local agents_md = cio.slurp(fs.join(cwd, "AGENTS.md"))
+  if agents_md then
+    return "\n\n# Agent Context\n\n" .. agents_md
+  end
+
+  return ""
+end
+
+-- Run a git command in cwd with a 2s timeout. Returns trimmed stdout or nil.
+-- Never throws. Any failure (not a repo, git missing, timeout, bad exit) returns nil.
+local function git_cmd(cwd: string, ...: string): string
+  local argv: {string} = {"timeout", "2", "git"}
+  for i = 1, select("#", ...) do
+    argv[#argv + 1] = select(i, ...) as string
+  end
+  local ok, result = pcall(function(): string
+      local h, err = child.spawn(argv, {cwd = cwd})
+      if not h then return nil end
+      local success, stdout, _ = h:read()
+      if not success then return nil end
+      local out = (stdout as string) or ""
+      if out == "" then return nil end
+      return (out:gsub("%s+$", ""))
+    end)
+  if not ok then return nil end
+  return result
+end
+
+-- Gather git context for the working directory. Each value is nil
+-- when the command fails (not a git repo, git not installed, timeout).
+local function git_context(cwd: string): {string: string}
+  return {
+    branch = git_cmd(cwd, "rev-parse", "--abbrev-ref", "HEAD"),
+    commit = git_cmd(cwd, "rev-parse", "--short", "HEAD"),
+    remote = git_cmd(cwd, "remote", "get-url", "origin"),
+  }
+end
+
+-- Load system prompt with precedence:
+-- 1. /zip/embed/system.md (user override)
+-- 2. /zip/embed/sys/system.md (ah default)
+-- Project CLAUDE.md and AGENTS.md are always appended
+local function load_system_prompt(cwd: string): string
+  cwd = cwd or fs.getcwd()
+  local claude_md = load_claude_md(cwd)
+
+  local base: string
+  local user_system = cio.slurp("/zip/embed/system.md")
+  if user_system then
+    base = user_system .. claude_md
+  else
+    local sys_system = cio.slurp("/zip/embed/sys/system.md")
+    if sys_system then
+      base = sys_system .. claude_md
+    else
+      base = claude_md
+    end
+  end
+
+  -- Append runtime context (datetime, working directory, git info)
+  local date_str = os.date("!%Y-%m-%dT%H:%M:%SZ") as string
+  base = base .. "\n\nCurrent date: " .. date_str .. "\nWorking directory: " .. cwd
+
+  local git = git_context(cwd)
+  if git.branch then
+    base = base .. "\nGit branch: " .. git.branch
+  end
+  if git.commit then
+    base = base .. "\nGit commit: " .. git.commit
+  end
+  if git.remote then
+    base = base .. "\nGit remote: " .. git.remote
+  end
+
+  return base
+end
+
+return {
+  load_claude_md = load_claude_md,
+  load_system_prompt = load_system_prompt,
+}

--- a/lib/ah/sessions.tl
+++ b/lib/ah/sessions.tl
@@ -1,0 +1,203 @@
+-- ah/sessions.tl: session listing, resolution, and usage display
+local fs = require("cosmic.fs")
+local db = require("ah.db")
+local ulid = require("ulid")
+local cli = require("ah.cli")
+
+-- Session record for listing
+local record Session
+  ulid: string
+  db_path: string
+  msg_count: integer
+  first_prompt: string
+  timestamp: number
+  name: string
+end
+
+-- List session files from .ah/*.db with valid ULID names
+local function list_sessions(cwd?: string): {Session}
+  cwd = cwd or fs.getcwd()
+  local ah_dir = fs.join(cwd, ".ah")
+  local sessions: {Session} = {}
+
+  local dir = fs.opendir(ah_dir)
+  if not dir then
+    return sessions
+  end
+
+  while true do
+    local name = dir:read()
+    if not name then break end
+
+    -- Check if it's a .db file with ULID name
+    if name:match("%.db$") then
+      local session_ulid = name:sub(1, -4) -- remove .db
+      -- Validate ULID by checking length and trying to parse timestamp
+      if #session_ulid == 26 then
+        local ts = ulid.timestamp(session_ulid)
+        if ts then
+          local db_path = fs.join(ah_dir, name)
+          local d = db.open(db_path)
+          if d then
+            table.insert(sessions, {
+                ulid = session_ulid,
+                db_path = db_path,
+                msg_count = db.get_message_count(d),
+                first_prompt = db.get_first_user_prompt(d),
+                timestamp = ts,
+                name = db.get_context(d, "session_name"),
+              })
+            db.close(d)
+          end
+        end
+      end
+    end
+  end
+  dir:close()
+
+  -- Sort by ULID descending (most recent first - ULID encodes timestamp)
+  table.sort(sessions, function(a: Session, b: Session): boolean
+      return a.ulid > b.ulid
+    end)
+
+  return sessions
+end
+
+-- Resolve session by name or partial ULID prefix
+local function resolve_session(cwd: string, prefix: string): string, string
+  local sessions = list_sessions(cwd)
+
+  -- First pass: exact name match
+  local name_matches: {string} = {}
+  for _, s in ipairs(sessions) do
+    if s.name and s.name == prefix then
+      table.insert(name_matches, s.ulid)
+    end
+  end
+
+  if #name_matches == 1 then
+    return name_matches[1], nil
+  elseif #name_matches > 1 then
+    return nil, "ambiguous name: " .. prefix .. " matches " .. #name_matches .. " sessions"
+  end
+
+  -- Second pass: ULID prefix match
+  local matches: {string} = {}
+
+  for _, s in ipairs(sessions) do
+    if s.ulid:sub(1, #prefix) == prefix then
+      table.insert(matches, s.ulid)
+    end
+  end
+
+  if #matches == 0 then
+    return nil, "no session matches: " .. prefix
+  elseif #matches > 1 then
+    return nil, "ambiguous prefix: " .. prefix .. " matches " .. #matches .. " sessions"
+  end
+
+  return matches[1], nil
+end
+
+-- List all sessions
+local function cmd_sessions(cwd: string, current_ulid: string)
+  local sessions = list_sessions(cwd)
+  if #sessions == 0 then
+    io.stderr:write("no sessions\n")
+    return
+  end
+
+  for _, s in ipairs(sessions) do
+    local marker = s.ulid == current_ulid and ">" or " "
+    local decoded = ulid.decode(s.ulid)
+    local time_str = decoded and decoded.time or "unknown"
+    local short_ulid = s.ulid:sub(1, 11)
+    local name_str = s.name and string.format("  [%s]", s.name) or ""
+    local preview = s.first_prompt:gsub("\n", " "):sub(1, 40)
+    if #s.first_prompt > 40 then
+      preview = preview .. "..."
+    end
+    io.write(string.format("%s %s  %s  %2d msgs%s  %s\n",
+        marker, short_ulid, time_str, s.msg_count, name_str, preview))
+  end
+end
+
+-- Extract short model alias from full model name
+local function short_model(name: string): string
+  if not name then return "unknown" end
+  if name:match("sonnet") then return "sonnet"
+  elseif name:match("opus") then return "opus"
+  elseif name:match("haiku") then return "haiku"
+  else return name
+  end
+end
+
+-- Token usage summary for a session
+local function cmd_usage(d: db.DB)
+  local json = require("cosmic.json")
+  local ev = db.get_events(d, "api_call_end")
+
+  local total_input = 0
+  local total_output = 0
+  local total_cache_read = 0
+  local total_cache_create = 0
+  local api_calls = 0
+
+  local record CallInfo
+    input: integer
+    output: integer
+    latency: integer
+    model: string
+  end
+  local calls: {CallInfo} = {}
+
+  for _, e in ipairs(ev) do
+    if e.details then
+      local detail = json.decode(e.details) as {string: any}
+      if detail then
+        local inp = (detail.input_tokens or 0) as integer
+        local out = (detail.output_tokens or 0) as integer
+        local lat = (detail.api_latency_ms or 0) as integer
+        local mdl = (detail.model or "unknown") as string
+        total_input = total_input + inp
+        total_output = total_output + out
+        total_cache_read = total_cache_read + ((detail.cache_read_input_tokens or 0) as integer)
+        total_cache_create = total_cache_create + ((detail.cache_creation_input_tokens or 0) as integer)
+        api_calls = api_calls + 1
+        table.insert(calls, {input = inp, output = out, latency = lat, model = mdl})
+      end
+    end
+  end
+
+  local total = total_input + total_output
+
+  io.write(string.format("api calls:     %d\n", api_calls))
+  io.write(string.format("input:         %s\n", cli.format_tokens(total_input)))
+  io.write(string.format("output:        %s\n", cli.format_tokens(total_output)))
+  io.write(string.format("total:         %s\n", cli.format_tokens(total)))
+  io.write(string.format("cache read:    %s\n", cli.format_tokens(total_cache_read)))
+  io.write(string.format("cache write:   %s\n", cli.format_tokens(total_cache_create)))
+  if total_input > 0 then
+    local cache_pct = math.floor(total_cache_read * 100 / total_input)
+    io.write(string.format("cache hit:     %d%%\n", cache_pct))
+  end
+
+  -- Per-call breakdown
+  if #calls > 0 then
+    io.write("\ncalls:\n")
+    for i, c in ipairs(calls) do
+      io.write(string.format("  #%-3d +%-6s in  +%-6s out  %4dms  %s\n",
+          i, cli.format_tokens(c.input), cli.format_tokens(c.output),
+          c.latency, short_model(c.model)))
+    end
+  end
+end
+
+return {
+  Session = Session,
+  list_sessions = list_sessions,
+  resolve_session = resolve_session,
+  cmd_sessions = cmd_sessions,
+  cmd_usage = cmd_usage,
+  short_model = short_model,
+}

--- a/lib/ah/test_args.tl
+++ b/lib/ah/test_args.tl
@@ -1,0 +1,364 @@
+#!/usr/bin/env cosmic
+-- test_args.tl: tests for CLI argument parsing
+local args_mod = require("ah.args")
+
+-- Also test backward-compatible access through init
+local init = require("ah.init")
+
+local function test_parse_args_help()
+  local parsed, err = args_mod.parse_args({"-h"})
+  assert(not parsed, "help should return nil")
+  assert(err == "help", "err should be 'help', got: " .. tostring(err))
+end
+test_parse_args_help()
+
+local function test_parse_args_long_help()
+  local parsed, err = args_mod.parse_args({"--help"})
+  assert(not parsed, "--help should return nil")
+  assert(err == "help", "err should be 'help', got: " .. tostring(err))
+end
+test_parse_args_long_help()
+
+local function test_parse_args_model()
+  local parsed = args_mod.parse_args({"-m", "opus"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.model == "opus", "model should be opus, got: " .. tostring(parsed.model))
+end
+test_parse_args_model()
+
+local function test_parse_args_unknown_option()
+  local parsed, err = args_mod.parse_args({"--bogus"})
+  assert(not parsed, "unknown option should return nil")
+  assert(err == "unknown", "err should be 'unknown', got: " .. tostring(err))
+end
+test_parse_args_unknown_option()
+
+local function test_parse_args_work_subcommand_flags()
+  local parsed, err = args_mod.parse_args({"work", "--repo", "owner/repo", "--prompt", "update-docs"})
+  assert(parsed, "work subcommand args should not be rejected, got err: " .. tostring(err))
+  assert(parsed.remaining[1] == "work", "first remaining should be 'work'")
+  assert(parsed.remaining[2] == "--repo", "second remaining should be '--repo'")
+  assert(parsed.remaining[3] == "owner/repo", "third remaining should be 'owner/repo'")
+  assert(parsed.remaining[4] == "--prompt", "fourth remaining should be '--prompt'")
+  assert(parsed.remaining[5] == "update-docs", "fifth remaining should be 'update-docs'")
+end
+test_parse_args_work_subcommand_flags()
+
+local function test_parse_args_top_level_opts_before_work()
+  local parsed, err = args_mod.parse_args({"-m", "opus", "work", "--repo", "owner/repo"})
+  assert(parsed, "should parse successfully, got err: " .. tostring(err))
+  assert(parsed.model == "opus", "model should be opus")
+  assert(parsed.remaining[1] == "work", "first remaining should be 'work'")
+end
+test_parse_args_top_level_opts_before_work()
+
+local function test_parse_args_work_with_issue()
+  local parsed, err = args_mod.parse_args({"work", "--repo", "owner/repo", "--issue", "42"})
+  assert(parsed, "should parse successfully, got err: " .. tostring(err))
+  assert(parsed.remaining[1] == "work", "first remaining should be 'work'")
+  assert(parsed.remaining[4] == "--issue", "--issue should be in remaining")
+  assert(parsed.remaining[5] == "42", "issue number should be in remaining")
+end
+test_parse_args_work_with_issue()
+
+local function test_parse_args_cd()
+  local parsed = args_mod.parse_args({"--cd", "/path/to/project", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.cd_path == "/path/to/project", "cd_path should be /path/to/project")
+  assert(parsed.remaining[1] == "hello", "prompt should be in remaining")
+end
+test_parse_args_cd()
+
+-- Sandbox protect-dirs parsing
+
+local function test_parse_protect_dirs_single()
+  local dirs = args_mod.parse_protect_dirs("o/work/plan")
+  assert(#dirs == 1, "should have 1 dir, got: " .. #dirs)
+  assert(dirs[1] == "o/work/plan", "dir should match")
+end
+test_parse_protect_dirs_single()
+
+local function test_parse_protect_dirs_multiple()
+  local dirs = args_mod.parse_protect_dirs("o/work/plan:o/work/do")
+  assert(#dirs == 2, "should have 2 dirs, got: " .. #dirs)
+  assert(dirs[1] == "o/work/plan", "first dir")
+  assert(dirs[2] == "o/work/do", "second dir")
+end
+test_parse_protect_dirs_multiple()
+
+local function test_parse_protect_dirs_nil()
+  local dirs = args_mod.parse_protect_dirs(nil)
+  assert(#dirs == 0, "nil should return empty table")
+end
+test_parse_protect_dirs_nil()
+
+local function test_parse_protect_dirs_empty()
+  local dirs = args_mod.parse_protect_dirs("")
+  assert(#dirs == 0, "empty string should return empty table")
+end
+test_parse_protect_dirs_empty()
+
+-- Sandbox CLI flag parsing
+
+local function test_parse_args_sandbox()
+  local parsed = args_mod.parse_args({"--sandbox", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.sandbox == true, "sandbox should be true")
+end
+test_parse_args_sandbox()
+
+local function test_parse_args_timeout()
+  local parsed = args_mod.parse_args({"--timeout", "300", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.timeout == 300, "timeout should be 300")
+end
+test_parse_args_timeout()
+
+local function test_parse_args_allow_host_single()
+  local parsed = args_mod.parse_args({"--sandbox", "--allow-host", "api.example.com:443", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(#parsed.allow_hosts == 1, "should have 1 host")
+  assert(parsed.allow_hosts[1] == "api.example.com:443", "host mismatch")
+end
+test_parse_args_allow_host_single()
+
+local function test_parse_args_allow_host_multiple()
+  local parsed = args_mod.parse_args({"--sandbox", "--allow-host", "api.example.com:443", "--allow-host", "hooks.slack.com:443", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(#parsed.allow_hosts == 2, "should have 2 hosts")
+end
+test_parse_args_allow_host_multiple()
+
+local function test_parse_args_unveil_single()
+  local parsed = args_mod.parse_args({"--sandbox", "--unveil", "o/work/plan:r", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(#parsed.unveil_dirs == 1, "should have 1 unveil")
+end
+test_parse_args_unveil_single()
+
+local function test_parse_args_unveil_multiple()
+  local parsed = args_mod.parse_args({"--sandbox", "--unveil", "o/work/plan:r", "--unveil", "o/work/do:rw", "hello"})
+  assert(parsed, "should parse successfully")
+  assert(#parsed.unveil_dirs == 2, "should have 2 unveils")
+end
+test_parse_args_unveil_multiple()
+
+local function test_parse_args_sandbox_combined()
+  local parsed = args_mod.parse_args({
+      "--sandbox", "--timeout", "180",
+      "--allow-host", "hooks.slack.com:443",
+      "--unveil", "o/work/plan:r",
+      "-m", "opus", "--db", "test.db",
+      "do the thing"
+    })
+  assert(parsed, "should parse successfully")
+  assert(parsed.sandbox == true, "sandbox should be true")
+  assert(parsed.timeout == 180, "timeout should be 180")
+  assert(#parsed.allow_hosts == 1, "should have 1 allow-host")
+  assert(#parsed.unveil_dirs == 1, "should have 1 unveil")
+  assert(parsed.model == "opus", "model should be opus")
+  assert(parsed.db_path == "test.db", "db should be test.db")
+end
+test_parse_args_sandbox_combined()
+
+local function test_parse_args_sandbox_with_work()
+  local parsed = args_mod.parse_args({"--sandbox", "work", "--repo", "owner/repo"})
+  assert(parsed, "should parse successfully")
+  assert(parsed.sandbox == true, "sandbox should be true")
+  assert(parsed.remaining[1] == "work", "work in remaining")
+end
+test_parse_args_sandbox_with_work()
+
+local function test_parse_args_no_sandbox_defaults()
+  local parsed = args_mod.parse_args({"hello"})
+  assert(parsed, "should parse successfully")
+  assert(not parsed.sandbox, "sandbox should be false by default")
+end
+test_parse_args_no_sandbox_defaults()
+
+-- parse_unveil helper tests
+
+local function test_parse_unveil_entry()
+  local path, perms = args_mod.parse_unveil_entry("o/work/plan:r")
+  assert(path == "o/work/plan", "path should be o/work/plan")
+  assert(perms == "r", "perms should be r")
+end
+test_parse_unveil_entry()
+
+local function test_parse_unveil_entry_rw()
+  local path, perms = args_mod.parse_unveil_entry("src:rwc")
+  assert(path == "src", "path should be src")
+  assert(perms == "rwc", "perms should be rwc")
+end
+test_parse_unveil_entry_rw()
+
+local function test_parse_unveil_entry_absolute()
+  local path, perms = args_mod.parse_unveil_entry("/tmp:rwxc")
+  assert(path == "/tmp", "path should be /tmp")
+  assert(perms == "rwxc", "perms should be rwxc")
+end
+test_parse_unveil_entry_absolute()
+
+local function test_parse_unveil_entry_no_perms()
+  local path, perms = args_mod.parse_unveil_entry("o/work/plan")
+  assert(path == "o/work/plan", "path should be o/work/plan")
+  assert(perms == "r", "perms should default to r")
+end
+test_parse_unveil_entry_no_perms()
+
+-- Help text completeness
+
+local function get_help_text(): string
+  local ah_bin = os.getenv("AH_BIN")
+  assert(ah_bin, "AH_BIN not set — need built binary")
+  local f = io.popen(ah_bin .. " --help 2>&1")
+  assert(f, "failed to run ah --help")
+  local help = f:read("*a") as string
+  f:close()
+  return help
+end
+
+local function test_usage_text_contains_all_options()
+  local help = get_help_text()
+  assert(#help > 0, "ah --help should produce output")
+  local defined_options = {
+    "help", "new", "session", "name", "db", "model", "output", "cd",
+    "steer", "followup", "max-tokens", "sandbox", "timeout",
+    "allow-host", "unveil", "skill", "must-produce",
+  }
+  for _, opt in ipairs(defined_options) do
+    assert(help:find("--" .. opt, 1, true), "help text missing option: --" .. opt)
+  end
+end
+test_usage_text_contains_all_options()
+
+local function test_usage_text_contains_short_options()
+  local help = get_help_text()
+  local short_options = {"-h", "-n", "-S", "-m", "-o"}
+  for _, opt in ipairs(short_options) do
+    assert(help:find(opt, 1, true), "help text missing short option: " .. opt)
+  end
+end
+test_usage_text_contains_short_options()
+
+local function test_parse_args_tool()
+  local parsed = args_mod.parse_args({"--tool", "foo=/usr/bin/foo", "-t", "bar=/tmp/bar", "hello"})
+  assert(parsed, "should parse --tool args")
+  assert(#parsed.tool_overrides == 2, "should have 2 tool overrides")
+  assert(parsed.tool_overrides[1] == "foo=/usr/bin/foo", "first override")
+  assert(parsed.tool_overrides[2] == "bar=/tmp/bar", "second override")
+end
+test_parse_args_tool()
+
+-- Sandbox sub-option validation
+
+local function test_parse_args_unveil_without_sandbox()
+  local parsed, err = args_mod.parse_args({"--unveil", "/tmp:r", "hello"})
+  assert(not parsed, "--unveil without --sandbox should fail")
+  assert(err == "error: --unveil requires --sandbox", "err mismatch: " .. tostring(err))
+end
+test_parse_args_unveil_without_sandbox()
+
+local function test_parse_args_allow_host_without_sandbox()
+  local parsed, err = args_mod.parse_args({"--allow-host", "example.com:443", "hello"})
+  assert(not parsed, "--allow-host without --sandbox should fail")
+  assert(err == "error: --allow-host requires --sandbox", "err mismatch: " .. tostring(err))
+end
+test_parse_args_allow_host_without_sandbox()
+
+local function test_parse_args_sandbox_with_unveil()
+  local parsed = args_mod.parse_args({"--sandbox", "--unveil", "/tmp:r", "hello"})
+  assert(parsed, "--sandbox --unveil should succeed")
+  assert(parsed.sandbox == true, "sandbox should be true")
+end
+test_parse_args_sandbox_with_unveil()
+
+local function test_parse_args_sandbox_with_allow_host()
+  local parsed = args_mod.parse_args({"--sandbox", "--allow-host", "example.com:443", "hello"})
+  assert(parsed, "--sandbox --allow-host should succeed")
+  assert(parsed.sandbox == true, "sandbox should be true")
+end
+test_parse_args_sandbox_with_allow_host()
+
+-- parse_subcommand_options tests
+
+local function test_parse_subcommand_options_long_flag()
+  local opts: {args_mod.OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
+  local result = args_mod.parse_subcommand_options({"--output", "o/bin/ah"}, opts)
+  assert(result.output == "o/bin/ah", "expected 'o/bin/ah', got: " .. tostring(result.output))
+end
+test_parse_subcommand_options_long_flag()
+
+local function test_parse_subcommand_options_short_flag()
+  local opts: {args_mod.OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
+  local result = args_mod.parse_subcommand_options({"-o", "o/bin/ah"}, opts)
+  assert(result.output == "o/bin/ah", "expected 'o/bin/ah'")
+end
+test_parse_subcommand_options_short_flag()
+
+local function test_parse_subcommand_options_short_no_space()
+  local opts: {args_mod.OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
+  local result = args_mod.parse_subcommand_options({"-oo/bin/ah"}, opts)
+  assert(result.output == "o/bin/ah", "expected 'o/bin/ah'")
+end
+test_parse_subcommand_options_short_no_space()
+
+local function test_parse_subcommand_options_none()
+  local opts: {args_mod.OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
+  local result = args_mod.parse_subcommand_options({"somefile"}, opts)
+  assert(result.output == nil, "expected nil")
+end
+test_parse_subcommand_options_none()
+
+local function test_parse_subcommand_options_empty()
+  local opts: {args_mod.OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
+  local result = args_mod.parse_subcommand_options({}, opts)
+  assert(result.output == nil, "expected nil for empty args")
+end
+test_parse_subcommand_options_empty()
+
+local function test_parse_subcommand_options_last_wins()
+  local opts: {args_mod.OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
+  local result = args_mod.parse_subcommand_options({"--output", "first", "--output", "second"}, opts)
+  assert(result.output == "second", "expected 'second'")
+end
+test_parse_subcommand_options_last_wins()
+
+local function test_parse_subcommand_options_multiple()
+  local opts: {args_mod.OptionDef} = {
+    {name = "output", short = "o", has_arg = "required"},
+    {name = "verbose", short = "v", has_arg = "none"}
+  }
+  local result = args_mod.parse_subcommand_options({"-v", "--output", "out.bin"}, opts)
+  assert(result.verbose == "true", "expected verbose='true'")
+  assert(result.output == "out.bin", "expected output='out.bin'")
+end
+test_parse_subcommand_options_multiple()
+
+local function test_parse_subcommand_options_flag_no_arg()
+  local opts: {args_mod.OptionDef} = {{name = "verbose", short = "v", has_arg = "none"}}
+  local result = args_mod.parse_subcommand_options({"-v", "otherarg"}, opts)
+  assert(result.verbose == "true", "expected verbose='true'")
+end
+test_parse_subcommand_options_flag_no_arg()
+
+local function test_parse_args_embed_remaining_contains_output()
+  local parsed = args_mod.parse_args({"embed", "mydir", "--output", "o/bin/ah"})
+  assert(parsed.remaining[1] == "embed", "remaining[1] should be 'embed'")
+  assert(parsed.remaining[2] == "mydir", "remaining[2] should be 'mydir'")
+  assert(parsed.remaining[3] == "--output", "remaining[3] should be '--output'")
+  assert(parsed.remaining[4] == "o/bin/ah", "remaining[4] should be 'o/bin/ah'")
+  assert(parsed.output_path == nil, "top-level output_path should be nil")
+end
+test_parse_args_embed_remaining_contains_output()
+
+-- Verify backward-compatible access through init module
+
+local function test_backward_compat_init_parse_args()
+  local parsed = init.parse_args({"-m", "opus"})
+  assert(parsed, "init.parse_args should still work")
+  assert(parsed.model == "opus", "should parse model through init")
+end
+test_backward_compat_init_parse_args()
+
+print("all args tests passed")

--- a/lib/ah/test_cli.tl
+++ b/lib/ah/test_cli.tl
@@ -1,0 +1,231 @@
+#!/usr/bin/env cosmic
+-- test_cli.tl: tests for CLI display handler and output formatting
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local cli = require("ah.cli")
+local events = require("ah.events")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+-- Diff colorization tests
+
+local function test_colorize_diff_line_plus()
+  local result = cli.colorize_diff_line("+added line")
+  assert(result == "\27[34m+added line\27[0m", "plus line should be blue, got: " .. result)
+end
+test_colorize_diff_line_plus()
+
+local function test_colorize_diff_line_minus()
+  local result = cli.colorize_diff_line("-removed line")
+  assert(result == "\27[33m-removed line\27[0m", "minus line should be yellow, got: " .. result)
+end
+test_colorize_diff_line_minus()
+
+local function test_colorize_diff_line_hunk()
+  local result = cli.colorize_diff_line("@@ -1,3 +1,4 @@")
+  assert(result == "\27[36m@@ -1,3 +1,4 @@\27[0m", "hunk header should be cyan, got: " .. result)
+end
+test_colorize_diff_line_hunk()
+
+local function test_colorize_diff_line_header_plus()
+  local result = cli.colorize_diff_line("+++ b/file.txt")
+  assert(result == "\27[1m+++ b/file.txt\27[0m", "+++ header should be bold, got: " .. result)
+end
+test_colorize_diff_line_header_plus()
+
+local function test_colorize_diff_line_header_minus()
+  local result = cli.colorize_diff_line("--- a/file.txt")
+  assert(result == "\27[1m--- a/file.txt\27[0m", "--- header should be bold, got: " .. result)
+end
+test_colorize_diff_line_header_minus()
+
+local function test_colorize_diff_line_plain()
+  local result = cli.colorize_diff_line(" context line")
+  assert(result == " context line", "context line should be unchanged, got: " .. result)
+end
+test_colorize_diff_line_plain()
+
+-- Tool output colorization tests
+
+local function test_colorize_tool_line_pass()
+  local result, colored = cli.colorize_tool_line("PASS test_foo")
+  assert(colored == true, "PASS should be colored")
+  assert(result == "\27[1;34mPASS test_foo\27[0m", "PASS should be blue+bold, got: " .. result)
+end
+test_colorize_tool_line_pass()
+
+local function test_colorize_tool_line_pass_prefix()
+  local result, colored = cli.colorize_tool_line("PASSING all tests")
+  assert(colored == true, "PASSING should be colored")
+  assert(result:find("\27%[1;34m"), "PASSING should be blue+bold")
+end
+test_colorize_tool_line_pass_prefix()
+
+local function test_colorize_tool_line_fail()
+  local result, colored = cli.colorize_tool_line("FAIL test_bar")
+  assert(colored == true, "FAIL should be colored")
+  assert(result == "\27[1;33mFAIL test_bar\27[0m", "FAIL should be yellow+bold, got: " .. result)
+end
+test_colorize_tool_line_fail()
+
+local function test_colorize_tool_line_failure_prefix()
+  local result, colored = cli.colorize_tool_line("FAILURE in module X")
+  assert(colored == true, "FAILURE should be colored")
+  assert(result:find("\27%[1;33m"), "FAILURE should be yellow+bold")
+end
+test_colorize_tool_line_failure_prefix()
+
+local function test_colorize_tool_line_error_lower()
+  local result, colored = cli.colorize_tool_line("error: something broke")
+  assert(colored == true, "error: should be colored")
+  assert(result == "\27[1;33merror: something broke\27[0m", "error: should be yellow+bold, got: " .. result)
+end
+test_colorize_tool_line_error_lower()
+
+local function test_colorize_tool_line_error_upper()
+  local result, colored = cli.colorize_tool_line("Error: compilation failed")
+  assert(colored == true, "Error: should be colored")
+  assert(result == "\27[1;33mError: compilation failed\27[0m", "Error: should be yellow+bold, got: " .. result)
+end
+test_colorize_tool_line_error_upper()
+
+local function test_colorize_tool_line_exit_code()
+  local result, colored = cli.colorize_tool_line("exit code: 1")
+  assert(colored == true, "exit code: should be colored")
+  assert(result == "\27[1;33mexit code: 1\27[0m", "exit code: should be yellow+bold, got: " .. result)
+end
+test_colorize_tool_line_exit_code()
+
+local function test_colorize_tool_line_no_match()
+  local result, colored = cli.colorize_tool_line("just a normal line")
+  assert(colored == false, "normal line should not be colored")
+  assert(result == "just a normal line", "normal line should be unchanged, got: " .. result)
+end
+test_colorize_tool_line_no_match()
+
+local function test_colorize_tool_line_lowercase_pass()
+  local result, colored = cli.colorize_tool_line("passed all tests")
+  assert(colored == false, "lowercase 'passed' should not be colored")
+  assert(result == "passed all tests", "lowercase 'passed' should be unchanged")
+end
+test_colorize_tool_line_lowercase_pass()
+
+local function test_colorize_tool_line_empty()
+  local result, colored = cli.colorize_tool_line("")
+  assert(colored == false, "empty line should not be colored")
+  assert(result == "", "empty line should be unchanged")
+end
+test_colorize_tool_line_empty()
+
+-- format_tokens tests
+
+local function test_format_tokens_zero()
+  local result = cli.format_tokens(0)
+  assert(result == "0", "0 should format as '0', got: " .. result)
+end
+test_format_tokens_zero()
+
+local function test_format_tokens_small()
+  local result = cli.format_tokens(999)
+  assert(result == "999", "999 should format as '999', got: " .. result)
+end
+test_format_tokens_small()
+
+local function test_format_tokens_exact_thousand()
+  local result = cli.format_tokens(1000)
+  assert(result == "1.0k", "1000 should format as '1.0k', got: " .. result)
+end
+test_format_tokens_exact_thousand()
+
+local function test_format_tokens_thousands()
+  local result = cli.format_tokens(1200)
+  assert(result == "1.2k", "1200 should format as '1.2k', got: " .. result)
+end
+test_format_tokens_thousands()
+
+local function test_format_tokens_millions()
+  local result = cli.format_tokens(1200000)
+  assert(result == "1.2m", "1200000 should format as '1.2m', got: " .. result)
+end
+test_format_tokens_millions()
+
+-- make_cli_handler integration tests
+
+local function capture_stderr(fn: function()): string
+  local tmpfile = fs.join(TEST_TMPDIR, "test_stderr_" .. tostring(os.time()) .. ".txt")
+  local old_stderr = io.stderr
+  local new_stderr = io.open(tmpfile, "w")
+  io.stderr = new_stderr
+  fn()
+  io.stderr:close()
+  io.stderr = old_stderr
+  local output = cio.slurp(tmpfile) or ""
+  os.remove(tmpfile)
+  return output
+end
+
+local function test_make_cli_handler_agent_end_shows_percentage()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({event_type = "agent_start", model = "claude-opus-4-5-20251101"} as events.EventData)
+      handler({
+          event_type = "agent_end",
+          total_input_tokens = 100000,
+          total_output_tokens = 0,
+          total_cache_read_tokens = 0,
+        } as events.EventData)
+    end)
+  assert(output:match("%%"), "agent_end output should contain '%', got: " .. output)
+  assert(output:match("200%.0k"), "agent_end output should contain '200.0k' budget, got: " .. output)
+  assert(output:match("100%.0k"), "agent_end output should contain '100.0k' input, got: " .. output)
+end
+test_make_cli_handler_agent_end_shows_percentage()
+
+local function test_make_cli_handler_budget_exceeded_shows_percentage()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({event_type = "agent_start", model = "claude-opus-4-5-20251101"} as events.EventData)
+      handler({
+          event_type = "budget_exceeded",
+          total_input_tokens = 180000,
+          total_output_tokens = 10000,
+          max_tokens = 200000,
+        } as events.EventData)
+    end)
+  assert(output:match("token budget exceeded"), "should say 'token budget exceeded', got: " .. output)
+  assert(output:match("%%"), "budget_exceeded output should contain '%', got: " .. output)
+  assert(output:match("190%.0k"), "budget_exceeded output should contain '190.0k' total, got: " .. output)
+end
+test_make_cli_handler_budget_exceeded_shows_percentage()
+
+local function test_make_cli_handler_agent_end_nil_model_uses_default()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({
+          event_type = "agent_end",
+          total_input_tokens = 1000,
+          total_output_tokens = 200,
+          total_cache_read_tokens = 0,
+        } as events.EventData)
+    end)
+  assert(output:match("200%.0k"), "nil model should fall back to 200.0k budget, got: " .. output)
+  assert(output:match("%%"), "output should contain '%', got: " .. output)
+end
+test_make_cli_handler_agent_end_nil_model_uses_default()
+
+local function test_make_cli_handler_agent_end_no_tokens_no_output()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({
+          event_type = "agent_end",
+          total_input_tokens = 0,
+          total_output_tokens = 0,
+          total_cache_read_tokens = 0,
+        } as events.EventData)
+    end)
+  assert(not output:match("%%"), "zero tokens should produce no token line, got: " .. output)
+  assert(not output:match("total"), "zero tokens should produce no total line, got: " .. output)
+end
+test_make_cli_handler_agent_end_no_tokens_no_output()
+
+print("all cli tests passed")

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -1,19 +1,21 @@
 #!/usr/bin/env cosmic
--- test_init.tl: tests for init module (system prompt loading)
+-- test_init.tl: tests for prompt loading and session management
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local init = require("ah.init")
 local db = require("ah.db")
+local prompt_mod = require("ah.prompt")
+local sessions_mod = require("ah.sessions")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
 
+-- Prompt loading tests
+
 local function test_load_system_prompt_default()
-  -- No files exist, should still contain runtime context (datetime and cwd)
-  -- but no git info (not a git repo)
   local empty_dir = fs.join(TEST_TMPDIR, "empty")
   fs.makedirs(empty_dir)
 
-  local prompt = init.load_system_prompt(empty_dir)
+  local prompt = prompt_mod.load_system_prompt(empty_dir)
   assert(prompt:match("Current date: %d%d%d%d%-%d%d%-%d%d"), "should contain current date")
   assert(prompt:match("Working directory: "), "should contain working directory")
   assert(not prompt:match("Git branch:"), "should not contain git branch in non-repo dir")
@@ -25,7 +27,7 @@ local function test_load_claude_md()
   fs.makedirs(cwd)
   cio.barf(fs.join(cwd, "CLAUDE.md"), "# Project\nThis is context")
 
-  local claude_content = init.load_claude_md(cwd)
+  local claude_content = prompt_mod.load_claude_md(cwd)
   assert(claude_content:match("Project Context"), "should have header")
   assert(claude_content:match("This is context"), "should include CLAUDE.md content")
 end
@@ -35,7 +37,7 @@ local function test_load_claude_md_missing()
   local cwd = fs.join(TEST_TMPDIR, "no_claude")
   fs.makedirs(cwd)
 
-  local claude_content = init.load_claude_md(cwd)
+  local claude_content = prompt_mod.load_claude_md(cwd)
   assert(claude_content == "", "should return empty string when no CLAUDE.md")
 end
 test_load_claude_md_missing()
@@ -45,38 +47,47 @@ local function test_load_agents_md()
   fs.makedirs(cwd)
   cio.barf(fs.join(cwd, "AGENTS.md"), "# Agents\nDo things this way")
 
-  local content = init.load_claude_md(cwd)
+  local content = prompt_mod.load_claude_md(cwd)
   assert(content:match("Agent Context"), "should have AGENTS.md header")
   assert(content:match("Do things this way"), "should include AGENTS.md content")
 end
 test_load_agents_md()
 
 local function test_load_both_claude_and_agents_md()
-  -- CLAUDE.md supersedes AGENTS.md when both exist
   local cwd = fs.join(TEST_TMPDIR, "cwd_both")
   fs.makedirs(cwd)
   cio.barf(fs.join(cwd, "CLAUDE.md"), "claude context")
   cio.barf(fs.join(cwd, "AGENTS.md"), "agents context")
 
-  local content = init.load_claude_md(cwd)
+  local content = prompt_mod.load_claude_md(cwd)
   assert(content:match("Project Context"), "should have CLAUDE.md header")
   assert(content:match("claude context"), "should include CLAUDE.md content")
   assert(not content:match("Agent Context"), "should NOT have AGENTS.md header")
-  assert(not content:match("agents context"), "should NOT include AGENTS.md content")
 end
 test_load_both_claude_and_agents_md()
 
 local function test_load_system_prompt_with_claude_md()
   local cwd = fs.join(TEST_TMPDIR, "cwd_with_claude")
   fs.makedirs(cwd)
-
   cio.barf(fs.join(cwd, "CLAUDE.md"), "This is my project context")
 
-  local prompt = init.load_system_prompt(cwd)
+  local prompt = prompt_mod.load_system_prompt(cwd)
   assert(prompt:match("Project Context"), "should have CLAUDE.md header")
   assert(prompt:match("This is my project context"), "should append CLAUDE.md content")
 end
 test_load_system_prompt_with_claude_md()
+
+-- Backward compatibility: test through init module
+
+local function test_backward_compat_load_claude_md()
+  local cwd = fs.join(TEST_TMPDIR, "compat_claude")
+  fs.makedirs(cwd)
+  cio.barf(fs.join(cwd, "CLAUDE.md"), "compat test")
+
+  local content = init.load_claude_md(cwd)
+  assert(content:match("compat test"), "init.load_claude_md should still work")
+end
+test_backward_compat_load_claude_md()
 
 -- Session management tests
 
@@ -84,7 +95,7 @@ local function test_list_sessions_empty()
   local cwd = fs.join(TEST_TMPDIR, "sessions_empty")
   fs.makedirs(fs.join(cwd, ".ah"))
 
-  local sessions = init.list_sessions(cwd)
+  local sessions = sessions_mod.list_sessions(cwd)
   assert(#sessions == 0, "empty .ah should have 0 sessions")
 end
 test_list_sessions_empty()
@@ -94,10 +105,8 @@ local function test_list_sessions()
   local ah_dir = fs.join(cwd, ".ah")
   fs.makedirs(ah_dir)
 
-  -- Create two session dbs with different ULIDs (26 chars each)
-  -- Use ULIDs that sort predictably (earlier timestamp = lexically smaller)
-  local ulid1 = "01KGW111111111111111111111" -- earlier (26 chars)
-  local ulid2 = "01KGW222222222222222222222" -- later (26 chars)
+  local ulid1 = "01KGW111111111111111111111"
+  local ulid2 = "01KGW222222222222222222222"
 
   local d1 = db.open(fs.join(ah_dir, ulid1 .. ".db"))
   local msg1 = db.create_message(d1, "user")
@@ -113,15 +122,12 @@ local function test_list_sessions()
   db.add_content_block(d2, msg2c.id, "text", {content = "Thanks"})
   db.close(d2)
 
-  local sessions = init.list_sessions(cwd)
+  local sessions = sessions_mod.list_sessions(cwd)
   assert(#sessions == 2, "should have 2 sessions, got " .. #sessions)
-  -- Sorted by ULID descending (most recent first)
   assert(sessions[1].ulid == ulid2, "first should be ulid2 (most recent)")
   assert(sessions[2].ulid == ulid1, "second should be ulid1")
-
   assert(sessions[1].msg_count == 3, "session 2 should have 3 messages")
   assert(sessions[1].first_prompt == "Fix the login bug", "session 2 first prompt mismatch")
-
   assert(sessions[2].msg_count == 1, "session 1 should have 1 message")
   assert(sessions[2].first_prompt == "Hello world", "session 1 first prompt mismatch")
 end
@@ -132,13 +138,12 @@ local function test_resolve_session_exact()
   local ah_dir = fs.join(cwd, ".ah")
   fs.makedirs(ah_dir)
 
-  local ulid1 = "01KGWAAAAAAAAAAAAAAAAAAAAA" -- 26 chars
+  local ulid1 = "01KGWAAAAAAAAAAAAAAAAAAAAA"
   local d1 = db.open(fs.join(ah_dir, ulid1 .. ".db"))
   db.create_message(d1, "user")
   db.close(d1)
 
-  -- Exact match
-  local resolved, err = init.resolve_session(cwd, ulid1)
+  local resolved, err = sessions_mod.resolve_session(cwd, ulid1)
   assert(resolved == ulid1, "exact match should work: " .. tostring(err))
 end
 test_resolve_session_exact()
@@ -148,13 +153,12 @@ local function test_resolve_session_prefix()
   local ah_dir = fs.join(cwd, ".ah")
   fs.makedirs(ah_dir)
 
-  local ulid1 = "01KGWBBBBBBBBBBBBBBBBBBBBB" -- 26 chars
+  local ulid1 = "01KGWBBBBBBBBBBBBBBBBBBBBB"
   local d1 = db.open(fs.join(ah_dir, ulid1 .. ".db"))
   db.create_message(d1, "user")
   db.close(d1)
 
-  -- Prefix match
-  local resolved, err = init.resolve_session(cwd, "01KGWB")
+  local resolved, err = sessions_mod.resolve_session(cwd, "01KGWB")
   assert(resolved == ulid1, "prefix match should work: " .. tostring(err))
 end
 test_resolve_session_prefix()
@@ -164,8 +168,8 @@ local function test_resolve_session_ambiguous()
   local ah_dir = fs.join(cwd, ".ah")
   fs.makedirs(ah_dir)
 
-  local ulid1 = "01KGWCCCCC1111111111111111" -- 26 chars
-  local ulid2 = "01KGWCCCCC2222222222222222" -- 26 chars
+  local ulid1 = "01KGWCCCCC1111111111111111"
+  local ulid2 = "01KGWCCCCC2222222222222222"
   local d1 = db.open(fs.join(ah_dir, ulid1 .. ".db"))
   db.create_message(d1, "user")
   db.close(d1)
@@ -173,10 +177,9 @@ local function test_resolve_session_ambiguous()
   db.create_message(d2, "user")
   db.close(d2)
 
-  -- Ambiguous prefix
-  local resolved, err = init.resolve_session(cwd, "01KGWCCCCC")
+  local resolved, err = sessions_mod.resolve_session(cwd, "01KGWCCCCC")
   assert(not resolved, "ambiguous prefix should fail")
-  assert(err:match("ambiguous"), "error should mention ambiguous: " .. tostring(err))
+  assert(err:match("ambiguous"), "error should mention ambiguous")
 end
 test_resolve_session_ambiguous()
 
@@ -185,662 +188,10 @@ local function test_resolve_session_not_found()
   local ah_dir = fs.join(cwd, ".ah")
   fs.makedirs(ah_dir)
 
-  local resolved, err = init.resolve_session(cwd, "NOTEXIST")
+  local resolved, err = sessions_mod.resolve_session(cwd, "NOTEXIST")
   assert(not resolved, "non-existent should fail")
-  assert(err:match("no session"), "error should mention no session: " .. tostring(err))
+  assert(err:match("no session"), "error should mention no session")
 end
 test_resolve_session_not_found()
-
--- Arg parsing tests
-
-local function test_parse_args_help()
-  local parsed, err = init.parse_args({"-h"})
-  assert(not parsed, "help should return nil")
-  assert(err == "help", "err should be 'help', got: " .. tostring(err))
-end
-test_parse_args_help()
-
-local function test_parse_args_long_help()
-  local parsed, err = init.parse_args({"--help"})
-  assert(not parsed, "--help should return nil")
-  assert(err == "help", "err should be 'help', got: " .. tostring(err))
-end
-test_parse_args_long_help()
-
-local function test_parse_args_model()
-  local parsed = init.parse_args({"-m", "opus"})
-  assert(parsed, "should parse successfully")
-  assert(parsed.model == "opus", "model should be opus, got: " .. tostring(parsed.model))
-end
-test_parse_args_model()
-
-local function test_parse_args_unknown_option()
-  local parsed, err = init.parse_args({"--bogus"})
-  assert(not parsed, "unknown option should return nil")
-  assert(err == "unknown", "err should be 'unknown', got: " .. tostring(err))
-end
-test_parse_args_unknown_option()
-
-local function test_parse_args_work_subcommand_flags()
-  -- This is the failing case from the workflow:
-  -- ah work --repo owner/repo --prompt update-docs
-  -- The top-level parser must NOT reject --repo and --prompt as unknown options.
-  -- Instead, it should stop at "work" and pass everything after to the subcommand.
-  local parsed, err = init.parse_args({"work", "--repo", "owner/repo", "--prompt", "update-docs"})
-  assert(parsed, "work subcommand args should not be rejected, got err: " .. tostring(err))
-  assert(parsed.remaining[1] == "work", "first remaining should be 'work', got: " .. tostring(parsed.remaining[1]))
-  assert(parsed.remaining[2] == "--repo", "second remaining should be '--repo', got: " .. tostring(parsed.remaining[2]))
-  assert(parsed.remaining[3] == "owner/repo", "third remaining should be 'owner/repo', got: " .. tostring(parsed.remaining[3]))
-  assert(parsed.remaining[4] == "--prompt", "fourth remaining should be '--prompt', got: " .. tostring(parsed.remaining[4]))
-  assert(parsed.remaining[5] == "update-docs", "fifth remaining should be 'update-docs', got: " .. tostring(parsed.remaining[5]))
-end
-test_parse_args_work_subcommand_flags()
-
-local function test_parse_args_top_level_opts_before_work()
-  -- ah -m opus work --repo owner/repo
-  -- Top-level -m should be parsed, work and its args should be in remaining.
-  local parsed, err = init.parse_args({"-m", "opus", "work", "--repo", "owner/repo"})
-  assert(parsed, "should parse successfully, got err: " .. tostring(err))
-  assert(parsed.model == "opus", "model should be opus, got: " .. tostring(parsed.model))
-  assert(parsed.remaining[1] == "work", "first remaining should be 'work', got: " .. tostring(parsed.remaining[1]))
-  assert(parsed.remaining[2] == "--repo", "second remaining should be '--repo', got: " .. tostring(parsed.remaining[2]))
-  assert(parsed.remaining[3] == "owner/repo", "third remaining should be 'owner/repo', got: " .. tostring(parsed.remaining[3]))
-end
-test_parse_args_top_level_opts_before_work()
-
-local function test_parse_args_work_with_issue()
-  -- ah work --repo owner/repo --issue 42
-  local parsed, err = init.parse_args({"work", "--repo", "owner/repo", "--issue", "42"})
-  assert(parsed, "should parse successfully, got err: " .. tostring(err))
-  assert(parsed.remaining[1] == "work", "first remaining should be 'work'")
-  assert(parsed.remaining[2] == "--repo", "--repo should be in remaining")
-  assert(parsed.remaining[3] == "owner/repo", "repo value should be in remaining")
-  assert(parsed.remaining[4] == "--issue", "--issue should be in remaining")
-  assert(parsed.remaining[5] == "42", "issue number should be in remaining")
-end
-test_parse_args_work_with_issue()
-
-local function test_parse_args_cd()
-  local parsed = init.parse_args({"--cd", "/path/to/project", "hello"})
-  assert(parsed, "should parse successfully")
-  assert(parsed.cd_path == "/path/to/project", "cd_path should be /path/to/project, got: " .. tostring(parsed.cd_path))
-  assert(parsed.remaining[1] == "hello", "prompt should be in remaining")
-end
-test_parse_args_cd()
-
--- Sandbox protect-dirs parsing
-
-local record InitSandbox
-  parse_protect_dirs: function(string): {string}
-end
-local init_sandbox = require("ah.init") as InitSandbox
-
-local function test_parse_protect_dirs_single()
-  local dirs = init_sandbox.parse_protect_dirs("o/work/plan")
-  assert(#dirs == 1, "should have 1 dir, got: " .. #dirs)
-  assert(dirs[1] == "o/work/plan", "dir should match, got: " .. dirs[1])
-end
-test_parse_protect_dirs_single()
-
-local function test_parse_protect_dirs_multiple()
-  local dirs = init_sandbox.parse_protect_dirs("o/work/plan:o/work/do")
-  assert(#dirs == 2, "should have 2 dirs, got: " .. #dirs)
-  assert(dirs[1] == "o/work/plan", "first dir, got: " .. dirs[1])
-  assert(dirs[2] == "o/work/do", "second dir, got: " .. dirs[2])
-end
-test_parse_protect_dirs_multiple()
-
-local function test_parse_protect_dirs_nil()
-  local dirs = init_sandbox.parse_protect_dirs(nil)
-  assert(#dirs == 0, "nil should return empty table, got: " .. #dirs)
-end
-test_parse_protect_dirs_nil()
-
-local function test_parse_protect_dirs_empty()
-  local dirs = init_sandbox.parse_protect_dirs("")
-  assert(#dirs == 0, "empty string should return empty table, got: " .. #dirs)
-end
-test_parse_protect_dirs_empty()
-
--- Sandbox CLI flag parsing tests
-
-local function test_parse_args_sandbox()
-  local parsed = init.parse_args({"--sandbox", "hello"})
-  assert(parsed, "should parse successfully")
-  assert(parsed.sandbox == true, "sandbox should be true")
-  assert(parsed.remaining[1] == "hello", "prompt should be in remaining")
-end
-test_parse_args_sandbox()
-
-local function test_parse_args_timeout()
-  local parsed = init.parse_args({"--timeout", "300", "hello"})
-  assert(parsed, "should parse successfully")
-  assert(parsed.timeout == 300, "timeout should be 300, got: " .. tostring(parsed.timeout))
-  assert(parsed.remaining[1] == "hello", "prompt should be in remaining")
-end
-test_parse_args_timeout()
-
-local function test_parse_args_allow_host_single()
-  local parsed = init.parse_args({"--sandbox", "--allow-host", "api.example.com:443", "hello"})
-  assert(parsed, "should parse successfully")
-  assert(parsed.allow_hosts, "allow_hosts should be set")
-  assert(#parsed.allow_hosts == 1, "should have 1 host, got: " .. #parsed.allow_hosts)
-  assert(parsed.allow_hosts[1] == "api.example.com:443", "host mismatch, got: " .. parsed.allow_hosts[1])
-end
-test_parse_args_allow_host_single()
-
-local function test_parse_args_allow_host_multiple()
-  local parsed = init.parse_args({"--sandbox", "--allow-host", "api.example.com:443", "--allow-host", "hooks.slack.com:443", "hello"})
-  assert(parsed, "should parse successfully")
-  assert(#parsed.allow_hosts == 2, "should have 2 hosts, got: " .. #parsed.allow_hosts)
-  assert(parsed.allow_hosts[1] == "api.example.com:443", "first host")
-  assert(parsed.allow_hosts[2] == "hooks.slack.com:443", "second host")
-end
-test_parse_args_allow_host_multiple()
-
-local function test_parse_args_unveil_single()
-  local parsed = init.parse_args({"--sandbox", "--unveil", "o/work/plan:r", "hello"})
-  assert(parsed, "should parse successfully")
-  assert(parsed.unveil_dirs, "unveil_dirs should be set")
-  assert(#parsed.unveil_dirs == 1, "should have 1 unveil, got: " .. #parsed.unveil_dirs)
-  assert(parsed.unveil_dirs[1] == "o/work/plan:r", "unveil mismatch, got: " .. parsed.unveil_dirs[1])
-end
-test_parse_args_unveil_single()
-
-local function test_parse_args_unveil_multiple()
-  local parsed = init.parse_args({"--sandbox", "--unveil", "o/work/plan:r", "--unveil", "o/work/do:rw", "hello"})
-  assert(parsed, "should parse successfully")
-  assert(#parsed.unveil_dirs == 2, "should have 2 unveils, got: " .. #parsed.unveil_dirs)
-  assert(parsed.unveil_dirs[1] == "o/work/plan:r", "first unveil")
-  assert(parsed.unveil_dirs[2] == "o/work/do:rw", "second unveil")
-end
-test_parse_args_unveil_multiple()
-
-local function test_parse_args_sandbox_combined()
-  local parsed = init.parse_args({
-      "--sandbox", "--timeout", "180",
-      "--allow-host", "hooks.slack.com:443",
-      "--unveil", "o/work/plan:r",
-      "-m", "opus", "--db", "test.db",
-      "do the thing"
-    })
-  assert(parsed, "should parse successfully")
-  assert(parsed.sandbox == true, "sandbox should be true")
-  assert(parsed.timeout == 180, "timeout should be 180")
-  assert(#parsed.allow_hosts == 1, "should have 1 allow-host")
-  assert(parsed.allow_hosts[1] == "hooks.slack.com:443", "allow-host value")
-  assert(#parsed.unveil_dirs == 1, "should have 1 unveil")
-  assert(parsed.unveil_dirs[1] == "o/work/plan:r", "unveil value")
-  assert(parsed.model == "opus", "model should be opus")
-  assert(parsed.db_path == "test.db", "db should be test.db")
-  assert(parsed.remaining[1] == "do the thing", "prompt in remaining")
-end
-test_parse_args_sandbox_combined()
-
-local function test_parse_args_sandbox_with_work()
-  -- --sandbox before work subcommand shouldn't interfere
-  local parsed = init.parse_args({"--sandbox", "work", "--repo", "owner/repo"})
-  assert(parsed, "should parse successfully")
-  assert(parsed.sandbox == true, "sandbox should be true")
-  assert(parsed.remaining[1] == "work", "work in remaining")
-  assert(parsed.remaining[2] == "--repo", "--repo in remaining")
-  assert(parsed.remaining[3] == "owner/repo", "repo value in remaining")
-end
-test_parse_args_sandbox_with_work()
-
-local function test_parse_args_no_sandbox_defaults()
-  local parsed = init.parse_args({"hello"})
-  assert(parsed, "should parse successfully")
-  assert(not parsed.sandbox, "sandbox should be nil/false by default")
-  assert(not parsed.timeout, "timeout should be nil by default")
-  assert(not parsed.allow_hosts or #parsed.allow_hosts == 0, "allow_hosts should be empty by default")
-  assert(not parsed.unveil_dirs or #parsed.unveil_dirs == 0, "unveil_dirs should be empty by default")
-end
-test_parse_args_no_sandbox_defaults()
-
--- parse_unveil helper tests
-
-local function test_parse_unveil_entry()
-  local path, perms = init.parse_unveil_entry("o/work/plan:r")
-  assert(path == "o/work/plan", "path should be o/work/plan, got: " .. tostring(path))
-  assert(perms == "r", "perms should be r, got: " .. tostring(perms))
-end
-test_parse_unveil_entry()
-
-local function test_parse_unveil_entry_rw()
-  local path, perms = init.parse_unveil_entry("src:rwc")
-  assert(path == "src", "path should be src")
-  assert(perms == "rwc", "perms should be rwc, got: " .. tostring(perms))
-end
-test_parse_unveil_entry_rw()
-
-local function test_parse_unveil_entry_absolute()
-  local path, perms = init.parse_unveil_entry("/tmp:rwxc")
-  assert(path == "/tmp", "path should be /tmp")
-  assert(perms == "rwxc", "perms should be rwxc")
-end
-test_parse_unveil_entry_absolute()
-
-local function test_parse_unveil_entry_no_perms()
-  local path, perms = init.parse_unveil_entry("o/work/plan")
-  assert(path == "o/work/plan", "path should be o/work/plan")
-  assert(perms == "r", "perms should default to r, got: " .. tostring(perms))
-end
-test_parse_unveil_entry_no_perms()
-
--- Help text completeness: run the built binary and check --help output
-
-local function get_help_text(): string
-  local ah_bin = os.getenv("AH_BIN")
-  assert(ah_bin, "AH_BIN not set — need built binary")
-  local f = io.popen(ah_bin .. " --help 2>&1")
-  assert(f, "failed to run ah --help")
-  local help = f:read("*a") as string
-  f:close()
-  return help
-end
-
-local function test_usage_text_contains_all_options()
-  local help = get_help_text()
-  assert(#help > 0, "ah --help should produce output")
-
-  -- every long option defined in the parser must appear as --name in help
-  local defined_options = {
-    "help", "new", "session", "name", "db", "model", "output", "cd",
-    "steer", "followup", "max-tokens", "sandbox", "timeout",
-    "allow-host", "unveil", "skill", "must-produce",
-  }
-  for _, opt in ipairs(defined_options) do
-    assert(help:find("--" .. opt, 1, true),
-      "help text missing option: --" .. opt)
-  end
-end
-test_usage_text_contains_all_options()
-
-local function test_usage_text_contains_short_options()
-  local help = get_help_text()
-  local short_options = {"-h", "-n", "-S", "-m", "-o"}
-  for _, opt in ipairs(short_options) do
-    assert(help:find(opt, 1, true),
-      "help text missing short option: " .. opt)
-  end
-end
-test_usage_text_contains_short_options()
-
-local function test_parse_args_tool()
-  local parsed = init.parse_args({"--tool", "foo=/usr/bin/foo", "-t", "bar=/tmp/bar", "hello"})
-  assert(parsed, "should parse --tool args")
-  assert(#parsed.tool_overrides == 2, "should have 2 tool overrides: " .. tostring(#parsed.tool_overrides))
-  assert(parsed.tool_overrides[1] == "foo=/usr/bin/foo", "first override: " .. parsed.tool_overrides[1])
-  assert(parsed.tool_overrides[2] == "bar=/tmp/bar", "second override: " .. parsed.tool_overrides[2])
-  assert(parsed.remaining[1] == "hello", "remaining should be prompt")
-end
-test_parse_args_tool()
-
--- Sandbox sub-option validation tests
-
-local function test_parse_args_unveil_without_sandbox()
-  local parsed, err = init.parse_args({"--unveil", "/tmp:r", "hello"})
-  assert(not parsed, "--unveil without --sandbox should fail")
-  assert(err == "error: --unveil requires --sandbox", "err should mention --unveil requires --sandbox, got: " .. tostring(err))
-end
-test_parse_args_unveil_without_sandbox()
-
-local function test_parse_args_allow_host_without_sandbox()
-  local parsed, err = init.parse_args({"--allow-host", "example.com:443", "hello"})
-  assert(not parsed, "--allow-host without --sandbox should fail")
-  assert(err == "error: --allow-host requires --sandbox", "err should mention --allow-host requires --sandbox, got: " .. tostring(err))
-end
-test_parse_args_allow_host_without_sandbox()
-
-local function test_parse_args_sandbox_with_unveil()
-  local parsed = init.parse_args({"--sandbox", "--unveil", "/tmp:r", "hello"})
-  assert(parsed, "--sandbox --unveil should succeed")
-  assert(parsed.sandbox == true, "sandbox should be true")
-  assert(#parsed.unveil_dirs == 1, "should have 1 unveil")
-end
-test_parse_args_sandbox_with_unveil()
-
-local function test_parse_args_sandbox_with_allow_host()
-  local parsed = init.parse_args({"--sandbox", "--allow-host", "example.com:443", "hello"})
-  assert(parsed, "--sandbox --allow-host should succeed")
-  assert(parsed.sandbox == true, "sandbox should be true")
-  assert(#parsed.allow_hosts == 1, "should have 1 allow-host")
-end
-test_parse_args_sandbox_with_allow_host()
-
--- Diff colorization tests
-
-local record InitDiff
-  colorize_diff_line: function(string): string
-end
-local init_diff = require("ah.init") as InitDiff
-
-local function test_colorize_diff_line_plus()
-  local result = init_diff.colorize_diff_line("+added line")
-  assert(result == "\27[34m+added line\27[0m", "plus line should be blue, got: " .. result)
-end
-test_colorize_diff_line_plus()
-
-local function test_colorize_diff_line_minus()
-  local result = init_diff.colorize_diff_line("-removed line")
-  assert(result == "\27[33m-removed line\27[0m", "minus line should be yellow, got: " .. result)
-end
-test_colorize_diff_line_minus()
-
-local function test_colorize_diff_line_hunk()
-  local result = init_diff.colorize_diff_line("@@ -1,3 +1,4 @@")
-  assert(result == "\27[36m@@ -1,3 +1,4 @@\27[0m", "hunk header should be cyan, got: " .. result)
-end
-test_colorize_diff_line_hunk()
-
-local function test_colorize_diff_line_header_plus()
-  local result = init_diff.colorize_diff_line("+++ b/file.txt")
-  assert(result == "\27[1m+++ b/file.txt\27[0m", "+++ header should be bold, got: " .. result)
-end
-test_colorize_diff_line_header_plus()
-
-local function test_colorize_diff_line_header_minus()
-  local result = init_diff.colorize_diff_line("--- a/file.txt")
-  assert(result == "\27[1m--- a/file.txt\27[0m", "--- header should be bold, got: " .. result)
-end
-test_colorize_diff_line_header_minus()
-
-local function test_colorize_diff_line_plain()
-  local result = init_diff.colorize_diff_line(" context line")
-  assert(result == " context line", "context line should be unchanged, got: " .. result)
-end
-test_colorize_diff_line_plain()
-
--- Tool output colorization tests
-
-local record ParsedArgsView
-  remaining: {string}
-  output_path: string
-end
-
-local enum OptionArgType
-  "required"
-  "none"
-end
-
-local record OptionDef
-  name: string
-  short: string
-  has_arg: OptionArgType
-end
-
-local record InitTool
-  colorize_tool_line: function(string): string, boolean
-  parse_subcommand_options: function({string}, {OptionDef}): {string: string}
-  parse_args: function({string}): ParsedArgsView, string
-end
-local init_tool = require("ah.init") as InitTool
-
-local function test_colorize_tool_line_pass()
-  local result, colored = init_tool.colorize_tool_line("PASS test_foo")
-  assert(colored == true, "PASS should be colored")
-  assert(result == "\27[1;34mPASS test_foo\27[0m", "PASS should be blue+bold, got: " .. result)
-end
-test_colorize_tool_line_pass()
-
-local function test_colorize_tool_line_pass_prefix()
-  -- "PASSING" should also match (prefix match)
-  local result, colored = init_tool.colorize_tool_line("PASSING all tests")
-  assert(colored == true, "PASSING should be colored")
-  assert(result:find("\27%[1;34m"), "PASSING should be blue+bold")
-end
-test_colorize_tool_line_pass_prefix()
-
-local function test_colorize_tool_line_fail()
-  local result, colored = init_tool.colorize_tool_line("FAIL test_bar")
-  assert(colored == true, "FAIL should be colored")
-  assert(result == "\27[1;33mFAIL test_bar\27[0m", "FAIL should be yellow+bold, got: " .. result)
-end
-test_colorize_tool_line_fail()
-
-local function test_colorize_tool_line_failure_prefix()
-  -- "FAILURE" should also match (prefix match)
-  local result, colored = init_tool.colorize_tool_line("FAILURE in module X")
-  assert(colored == true, "FAILURE should be colored")
-  assert(result:find("\27%[1;33m"), "FAILURE should be yellow+bold")
-end
-test_colorize_tool_line_failure_prefix()
-
-local function test_colorize_tool_line_error_lower()
-  local result, colored = init_tool.colorize_tool_line("error: something broke")
-  assert(colored == true, "error: should be colored")
-  assert(result == "\27[1;33merror: something broke\27[0m", "error: should be yellow+bold, got: " .. result)
-end
-test_colorize_tool_line_error_lower()
-
-local function test_colorize_tool_line_error_upper()
-  local result, colored = init_tool.colorize_tool_line("Error: compilation failed")
-  assert(colored == true, "Error: should be colored")
-  assert(result == "\27[1;33mError: compilation failed\27[0m", "Error: should be yellow+bold, got: " .. result)
-end
-test_colorize_tool_line_error_upper()
-
-local function test_colorize_tool_line_exit_code()
-  local result, colored = init_tool.colorize_tool_line("exit code: 1")
-  assert(colored == true, "exit code: should be colored")
-  assert(result == "\27[1;33mexit code: 1\27[0m", "exit code: should be yellow+bold, got: " .. result)
-end
-test_colorize_tool_line_exit_code()
-
-local function test_colorize_tool_line_no_match()
-  local result, colored = init_tool.colorize_tool_line("just a normal line")
-  assert(colored == false, "normal line should not be colored")
-  assert(result == "just a normal line", "normal line should be unchanged, got: " .. result)
-end
-test_colorize_tool_line_no_match()
-
-local function test_colorize_tool_line_lowercase_pass()
-  -- "passed" (lowercase) should NOT match
-  local result, colored = init_tool.colorize_tool_line("passed all tests")
-  assert(colored == false, "lowercase 'passed' should not be colored")
-  assert(result == "passed all tests", "lowercase 'passed' should be unchanged")
-end
-test_colorize_tool_line_lowercase_pass()
-
-local function test_colorize_tool_line_empty()
-  local result, colored = init_tool.colorize_tool_line("")
-  assert(colored == false, "empty line should not be colored")
-  assert(result == "", "empty line should be unchanged")
-end
-test_colorize_tool_line_empty()
-
--- parse_embed_output tests
-local function test_parse_subcommand_options_long_flag()
-  local opts: {OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
-  local result = init_tool.parse_subcommand_options({"--output", "o/bin/ah"}, opts)
-  assert(result.output == "o/bin/ah", "expected 'o/bin/ah', got: " .. tostring(result.output))
-end
-test_parse_subcommand_options_long_flag()
-
-local function test_parse_subcommand_options_short_flag()
-  local opts: {OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
-  local result = init_tool.parse_subcommand_options({"-o", "o/bin/ah"}, opts)
-  assert(result.output == "o/bin/ah", "expected 'o/bin/ah', got: " .. tostring(result.output))
-end
-test_parse_subcommand_options_short_flag()
-
-local function test_parse_subcommand_options_short_no_space()
-  local opts: {OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
-  local result = init_tool.parse_subcommand_options({"-oo/bin/ah"}, opts)
-  assert(result.output == "o/bin/ah", "expected 'o/bin/ah', got: " .. tostring(result.output))
-end
-test_parse_subcommand_options_short_no_space()
-
-local function test_parse_subcommand_options_none()
-  local opts: {OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
-  local result = init_tool.parse_subcommand_options({"somefile"}, opts)
-  assert(result.output == nil, "expected nil, got: " .. tostring(result.output))
-end
-test_parse_subcommand_options_none()
-
-local function test_parse_subcommand_options_empty()
-  local opts: {OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
-  local result = init_tool.parse_subcommand_options({}, opts)
-  assert(result.output == nil, "expected nil for empty args, got: " .. tostring(result.output))
-end
-test_parse_subcommand_options_empty()
-
-local function test_parse_subcommand_options_last_wins()
-  local opts: {OptionDef} = {{name = "output", short = "o", has_arg = "required"}}
-  local result = init_tool.parse_subcommand_options({"--output", "first", "--output", "second"}, opts)
-  assert(result.output == "second", "expected 'second', got: " .. tostring(result.output))
-end
-test_parse_subcommand_options_last_wins()
-
-local function test_parse_subcommand_options_multiple()
-  local opts: {OptionDef} = {
-    {name = "output", short = "o", has_arg = "required"},
-    {name = "verbose", short = "v", has_arg = "none"}
-  }
-  local result = init_tool.parse_subcommand_options({"-v", "--output", "out.bin"}, opts)
-  assert(result.verbose == "true", "expected verbose='true', got: " .. tostring(result.verbose))
-  assert(result.output == "out.bin", "expected output='out.bin', got: " .. tostring(result.output))
-end
-test_parse_subcommand_options_multiple()
-
-local function test_parse_subcommand_options_flag_no_arg()
-  local opts: {OptionDef} = {{name = "verbose", short = "v", has_arg = "none"}}
-  local result = init_tool.parse_subcommand_options({"-v", "otherarg"}, opts)
-  assert(result.verbose == "true", "expected verbose='true', got: " .. tostring(result.verbose))
-end
-test_parse_subcommand_options_flag_no_arg()
-
-local function test_parse_args_embed_remaining_contains_output()
-  -- parse_args with POSIX mode: --output after embed lands in remaining
-  local parsed = init_tool.parse_args({"embed", "mydir", "--output", "o/bin/ah"})
-  assert(parsed.remaining[1] == "embed", "remaining[1] should be 'embed'")
-  assert(parsed.remaining[2] == "mydir", "remaining[2] should be 'mydir'")
-  assert(parsed.remaining[3] == "--output", "remaining[3] should be '--output'")
-  assert(parsed.remaining[4] == "o/bin/ah", "remaining[4] should be 'o/bin/ah'")
-  assert(parsed.output_path == nil, "top-level output_path should be nil")
-end
-test_parse_args_embed_remaining_contains_output()
-
--- format_tokens and make_cli_handler tests
-
-local record InitTokens
-  format_tokens: function(integer): string
-  make_cli_handler: function(string): function(any)
-end
-local init_tokens = require("ah.init") as InitTokens
-
-local function test_format_tokens_zero()
-  local result = init_tokens.format_tokens(0)
-  assert(result == "0", "0 should format as '0', got: " .. result)
-end
-test_format_tokens_zero()
-
-local function test_format_tokens_small()
-  local result = init_tokens.format_tokens(999)
-  assert(result == "999", "999 should format as '999', got: " .. result)
-end
-test_format_tokens_small()
-
-local function test_format_tokens_exact_thousand()
-  local result = init_tokens.format_tokens(1000)
-  assert(result == "1.0k", "1000 should format as '1.0k', got: " .. result)
-end
-test_format_tokens_exact_thousand()
-
-local function test_format_tokens_thousands()
-  local result = init_tokens.format_tokens(1200)
-  assert(result == "1.2k", "1200 should format as '1.2k', got: " .. result)
-end
-test_format_tokens_thousands()
-
-local function test_format_tokens_millions()
-  local result = init_tokens.format_tokens(1200000)
-  assert(result == "1.2m", "1200000 should format as '1.2m', got: " .. result)
-end
-test_format_tokens_millions()
-
--- make_cli_handler integration tests (stderr redirected to tmpfile)
-
-local function capture_stderr(fn: function()): string
-  local tmpfile = fs.join(TEST_TMPDIR, "test_stderr_" .. tostring(os.time()) .. ".txt")
-  local old_stderr = io.stderr
-  local new_stderr = io.open(tmpfile, "w")
-  io.stderr = new_stderr
-  fn()
-  io.stderr:close()
-  io.stderr = old_stderr
-  local output = cio.slurp(tmpfile) or ""
-  os.remove(tmpfile)
-  return output
-end
-
-local function test_make_cli_handler_agent_end_shows_percentage()
-  local handler = init_tokens.make_cli_handler(nil)
-  local output = capture_stderr(function()
-      -- fire agent_start to set model
-      handler({event_type = "agent_start", model = "claude-opus-4-5-20251101"} as any)
-      -- fire agent_end with known token counts (200k input, 0 output → 100% of 200k)
-      handler({
-          event_type = "agent_end",
-          total_input_tokens = 100000,
-          total_output_tokens = 0,
-          total_cache_read_tokens = 0,
-        } as any)
-    end)
-  assert(output:match("%%"), "agent_end output should contain '%', got: " .. output)
-  assert(output:match("200%.0k"), "agent_end output should contain '200.0k' budget, got: " .. output)
-  assert(output:match("100%.0k"), "agent_end output should contain '100.0k' input, got: " .. output)
-end
-test_make_cli_handler_agent_end_shows_percentage()
-
-local function test_make_cli_handler_budget_exceeded_shows_percentage()
-  local handler = init_tokens.make_cli_handler(nil)
-  local output = capture_stderr(function()
-      handler({event_type = "agent_start", model = "claude-opus-4-5-20251101"} as any)
-      handler({
-          event_type = "budget_exceeded",
-          total_input_tokens = 180000,
-          total_output_tokens = 10000,
-          max_tokens = 200000,
-        } as any)
-    end)
-  assert(output:match("token budget exceeded"), "should say 'token budget exceeded', got: " .. output)
-  assert(output:match("%%"), "budget_exceeded output should contain '%', got: " .. output)
-  assert(output:match("190%.0k"), "budget_exceeded output should contain '190.0k' total, got: " .. output)
-end
-test_make_cli_handler_budget_exceeded_shows_percentage()
-
-local function test_make_cli_handler_agent_end_nil_model_uses_default()
-  -- No agent_start fired — captured_model is nil, should default to 200k
-  local handler = init_tokens.make_cli_handler(nil)
-  local output = capture_stderr(function()
-      handler({
-          event_type = "agent_end",
-          total_input_tokens = 1000,
-          total_output_tokens = 200,
-          total_cache_read_tokens = 0,
-        } as any)
-    end)
-  assert(output:match("200%.0k"), "nil model should fall back to 200.0k budget, got: " .. output)
-  assert(output:match("%%"), "output should contain '%', got: " .. output)
-end
-test_make_cli_handler_agent_end_nil_model_uses_default()
-
-local function test_make_cli_handler_agent_end_no_tokens_no_output()
-  -- Zero tokens: no token line should be written
-  local handler = init_tokens.make_cli_handler(nil)
-  local output = capture_stderr(function()
-      handler({
-          event_type = "agent_end",
-          total_input_tokens = 0,
-          total_output_tokens = 0,
-          total_cache_read_tokens = 0,
-        } as any)
-    end)
-  assert(not output:match("%%"), "zero tokens should produce no token line, got: " .. output)
-  assert(not output:match("total"), "zero tokens should produce no total line, got: " .. output)
-end
-test_make_cli_handler_agent_end_no_tokens_no_output()
 
 print("all init tests passed")

--- a/lib/ah/test_toolload.tl
+++ b/lib/ah/test_toolload.tl
@@ -1,0 +1,396 @@
+#!/usr/bin/env cosmic
+-- test_toolload.tl: tests for tool loading infrastructure (AST guard, file loading, dir scanning)
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local tools = require("ah.tools")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+-- is_valid_tool tests
+
+local function test_is_valid_tool()
+  assert(not tools.is_valid_tool(nil), "nil should be invalid")
+  assert(not tools.is_valid_tool("string"), "string should be invalid")
+  assert(not tools.is_valid_tool({}), "empty table should be invalid")
+  assert(not tools.is_valid_tool({name = "foo"}), "missing fields should be invalid")
+
+  local valid = {
+    name = "test",
+    description = "A test tool",
+    input_schema = {type = "object", properties = {}, required = {}},
+    execute = function(_: {string: any}): string, boolean return "ok", false end,
+  }
+  assert(tools.is_valid_tool(valid), "valid tool should pass validation")
+  print("✓ is_valid_tool works")
+end
+test_is_valid_tool()
+
+-- load_custom_tools_from_dir tests
+
+local function test_load_custom_tools_empty_dir()
+  local empty_dir = fs.join(TEST_TMPDIR, "empty_tools")
+  fs.makedirs(empty_dir)
+  local loaded = tools.load_custom_tools_from_dir(empty_dir)
+  assert(#loaded == 0, "should load 0 tools from empty dir")
+  print("✓ load_custom_tools handles empty directory")
+end
+test_load_custom_tools_empty_dir()
+
+local function test_load_custom_tools_nonexistent()
+  local loaded = tools.load_custom_tools_from_dir("/nonexistent/dir")
+  assert(#loaded == 0, "should return empty for nonexistent dir")
+  print("✓ load_custom_tools handles nonexistent directory")
+end
+test_load_custom_tools_nonexistent()
+
+local function test_load_custom_tool()
+  local tool_dir = fs.join(TEST_TMPDIR, "custom_tools_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "hello.lua"), [[
+return {
+  name = "hello",
+  description = "Say hello",
+  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {}},
+  execute = function(input)
+    local name = input.name or "world"
+    return "hello, " .. name .. "!", false
+  end,
+}
+]])
+
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 1, "should load 1 tool")
+  assert(loaded[1].name == "hello", "tool name should be hello")
+  local result, is_error = loaded[1].execute({name = "test"})
+  assert(result == "hello, test!", "execute should work: " .. result)
+  assert(not is_error, "should not be error")
+  print("✓ load_custom_tools loads valid tool")
+end
+test_load_custom_tool()
+
+local function test_invalid_tool_skipped()
+  local tool_dir = fs.join(TEST_TMPDIR, "invalid_tools_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "bad.lua"), "return nil")
+  cio.barf(fs.join(tool_dir, "also_bad.lua"), "return {}")
+  cio.barf(fs.join(tool_dir, "good.lua"), [[
+return {
+  name = "good",
+  description = "Good tool",
+  input_schema = {type = "object", properties = {}, required = {}},
+  execute = function() return "ok", false end,
+}
+]])
+
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 1, "should only load valid tool")
+  assert(loaded[1].name == "good", "should load good tool")
+  print("✓ invalid tools are skipped")
+end
+test_invalid_tool_skipped()
+
+-- Teal tool loading
+
+local function test_teal_tool_loading()
+  local project = fs.join(TEST_TMPDIR, "teal_tool_load")
+  local project_tools = fs.join(project, "tools")
+  fs.makedirs(project_tools)
+  cio.barf(fs.join(project_tools, "greet.tl"), [[
+return {
+  name = "greet",
+  description = "Greet in teal",
+  system_prompt = "Always greet warmly.",
+  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}},
+  execute = function(input: {string:any}): string, boolean, any
+    local who = (input.name as string) or "world"
+    return "hello, " .. who, false
+  end,
+}
+]])
+
+  tools.init_custom_tools(project)
+  local result, is_error = tools.execute_tool("greet", {name = "teal"})
+  assert(not is_error, "teal tool should execute")
+  assert(result == "hello, teal", "should run teal tool: " .. result)
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ .tl tools loaded from cwd/tools/")
+end
+test_teal_tool_loading()
+
+local function test_teal_overrides_lua()
+  local project = fs.join(TEST_TMPDIR, "tl_over_lua_load")
+  local project_tools = fs.join(project, "tools")
+  fs.makedirs(project_tools)
+
+  cio.barf(fs.join(project_tools, "dup.lua"), [[
+return {
+  name = "dup", description = "lua version",
+  input_schema = {type = "object", properties = {}, required = {}},
+  execute = function() return "from-lua", false end,
+}
+]])
+  cio.barf(fs.join(project_tools, "dup.tl"), [[
+return {
+  name = "dup", description = "teal version",
+  input_schema = {type = "object", properties = {}, required = {}},
+  execute = function(): string, boolean return "from-teal", false end,
+}
+]])
+
+  tools.init_custom_tools(project)
+  local result, is_error = tools.execute_tool("dup", {})
+  assert(not is_error, "should execute")
+  assert(result == "from-teal", ".tl should override .lua: " .. result)
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ .tl overrides .lua with same basename")
+end
+test_teal_overrides_lua()
+
+-- Require tests
+
+local function test_lua_tool_require_lua()
+  local tool_dir = fs.join(TEST_TMPDIR, "lua_require_lua_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "helper_load.lua"), [[
+return { greet = function(name) return "hello, " .. name end }
+]])
+  cio.barf(fs.join(tool_dir, "greeter_load.lua"), [[
+local helper_load = require("helper_load")
+return {
+  name = "greeter_load",
+  description = "Greet with helper",
+  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}},
+  execute = function(input) return helper_load.greet(input.name), false end,
+}
+]])
+
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 1, "should load 1 tool: " .. tostring(#loaded))
+  assert(loaded[1].name == "greeter_load", "should load greeter tool")
+  local result, is_error = loaded[1].execute({name = "world"})
+  assert(not is_error, "greeter should succeed")
+  assert(result == "hello, world", "should use helper module: " .. result)
+  package.loaded["helper_load"] = nil
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ lua tool can require sibling lua module")
+end
+test_lua_tool_require_lua()
+
+local function test_teal_tool_require_teal()
+  local tool_dir = fs.join(TEST_TMPDIR, "tl_require_tl_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "tl_helper_load.tl"), [[
+local record M
+  greet: function(string): string
+end
+function M.greet(name: string): string
+  return "hi, " .. name
+end
+return M
+]])
+  cio.barf(fs.join(tool_dir, "tl_greeter_load.tl"), [[
+local helper = require("tl_helper_load")
+return {
+  name = "tl_greeter_load",
+  description = "Greet with teal helper",
+  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}},
+  execute = function(input: {string:any}): string, boolean
+    local who = input.name as string
+    return helper.greet(who), false
+  end,
+}
+]])
+
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  local greeter: {string: any} = nil
+  for _, t in ipairs(loaded) do
+    if t.name == "tl_greeter_load" then greeter = t as {string: any} end
+  end
+  assert(greeter, "should load tl_greeter_load tool")
+  local exec = greeter.execute as function(input: {string: any}): string, boolean
+  local result, is_error = exec({name = "teal"})
+  assert(not is_error, "tl_greeter should succeed")
+  assert(result == "hi, teal", "should use teal helper module: " .. result)
+  package.loaded["tl_helper_load"] = nil
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ teal tool can require sibling teal module")
+end
+test_teal_tool_require_teal()
+
+-- looks_like_tool AST guard tests
+
+local function test_looks_like_tool_valid_lua()
+  local source = [[
+return {
+  name = "foo", description = "A test tool",
+  input_schema = {type = "object", properties = {}},
+  execute = function() return "ok", false end,
+}
+]]
+  assert(tools.looks_like_tool(source, true), "valid lua tool should pass")
+  print("✓ looks_like_tool accepts valid lua tool")
+end
+test_looks_like_tool_valid_lua()
+
+local function test_looks_like_tool_valid_teal()
+  local source = [[
+return {
+  name = "greet", description = "test",
+  input_schema = {type = "object", properties = {}},
+  execute = function(input: {string:any}): string, boolean return "ok", false end,
+}
+]]
+  assert(tools.looks_like_tool(source, false), "valid teal tool should pass")
+  print("✓ looks_like_tool accepts valid teal tool")
+end
+test_looks_like_tool_valid_teal()
+
+local function test_looks_like_tool_os_exit()
+  assert(not tools.looks_like_tool("os.exit(0)", true), "os.exit() script should be rejected")
+  print("✓ looks_like_tool rejects os.exit() script")
+end
+test_looks_like_tool_os_exit()
+
+local function test_looks_like_tool_no_return()
+  assert(not tools.looks_like_tool("print('hello')", true), "script without return should be rejected")
+  print("✓ looks_like_tool rejects script without return")
+end
+test_looks_like_tool_no_return()
+
+local function test_looks_like_tool_empty()
+  assert(not tools.looks_like_tool("", true), "empty source should be rejected")
+  print("✓ looks_like_tool rejects empty source")
+end
+test_looks_like_tool_empty()
+
+local function test_looks_like_tool_syntax_error()
+  assert(not tools.looks_like_tool("invalid !!!", true), "syntax error should be rejected")
+  print("✓ looks_like_tool rejects syntax errors")
+end
+test_looks_like_tool_syntax_error()
+
+local function test_looks_like_tool_missing_name()
+  local source = 'return { description = "no name", execute = function() end }'
+  assert(not tools.looks_like_tool(source, true), "table missing name should be rejected")
+  print("✓ looks_like_tool rejects table missing name key")
+end
+test_looks_like_tool_missing_name()
+
+local function test_looks_like_tool_missing_execute()
+  local source = 'return { name = "foo", description = "no execute" }'
+  assert(not tools.looks_like_tool(source, true), "table missing execute should be rejected")
+  print("✓ looks_like_tool rejects table missing execute key")
+end
+test_looks_like_tool_missing_execute()
+
+local function test_looks_like_tool_variable_return()
+  assert(tools.looks_like_tool("local t = {} ; t.name = 'foo' ; return t", true), "variable return should pass optimistically")
+  print("✓ looks_like_tool accepts variable return optimistically")
+end
+test_looks_like_tool_variable_return()
+
+local function test_looks_like_tool_function_call_return()
+  assert(tools.looks_like_tool("return require('foo').make_tool()", true), "function call return should pass optimistically")
+  print("✓ looks_like_tool accepts function call return optimistically")
+end
+test_looks_like_tool_function_call_return()
+
+local function test_looks_like_tool_return_nil()
+  assert(tools.looks_like_tool("return nil", true), "return nil should pass optimistically")
+  print("✓ looks_like_tool accepts return nil optimistically")
+end
+test_looks_like_tool_return_nil()
+
+-- Integration: os.exit() guard
+
+local function test_os_exit_in_tools_dir_skipped()
+  local tool_dir = fs.join(TEST_TMPDIR, "os_exit_tools_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "killer.lua"), "os.exit(1)")
+  cio.barf(fs.join(tool_dir, "safe.lua"), [[
+return {
+  name = "safe", description = "Safe tool",
+  input_schema = {type = "object", properties = {}, required = {}},
+  execute = function() return "safe", false end,
+}
+]])
+
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 1, "should load only the safe tool")
+  assert(loaded[1].name == "safe", "should load safe tool")
+  print("✓ os.exit() script in tools dir is skipped")
+end
+test_os_exit_in_tools_dir_skipped()
+
+local function test_os_exit_teal_skipped()
+  local tool_dir = fs.join(TEST_TMPDIR, "os_exit_teal_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "killer.tl"), "os.exit(1)")
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 0, "os.exit teal file should be skipped")
+  print("✓ os.exit() in .tl file is skipped")
+end
+test_os_exit_teal_skipped()
+
+local function test_override_os_exit_guarded()
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local defs_before = #tools.get_tool_definitions()
+  local tool_dir = fs.join(TEST_TMPDIR, "override_os_exit_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "bad.lua"), "os.exit(1)")
+  tools.add_tool_override("bad", fs.join(tool_dir, "bad.lua"))
+  assert(defs_before == #tools.get_tool_definitions(), "os.exit override should not be added")
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ add_tool_override guards against os.exit()")
+end
+test_override_os_exit_guarded()
+
+-- Graceful error handling
+
+local function test_teal_syntax_error_skipped()
+  local tool_dir = fs.join(TEST_TMPDIR, "teal_syntax_error_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "broken.tl"), "invalid syntax !!!")
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 0, "broken .tl should be skipped")
+  print("✓ .tl file with syntax error is skipped")
+end
+test_teal_syntax_error_skipped()
+
+local function test_lua_load_error_skipped()
+  local tool_dir = fs.join(TEST_TMPDIR, "lua_load_error_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "broken.lua"), "this is not lua !!!")
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 0, "broken .lua should be skipped")
+  print("✓ .lua file with load error is skipped")
+end
+test_lua_load_error_skipped()
+
+local function test_teal_runtime_error_at_load_skipped()
+  local tool_dir = fs.join(TEST_TMPDIR, "teal_runtime_error_load")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "throws.tl"), '-- valid teal\nerror("boom at load time")')
+  local loaded = tools.load_custom_tools_from_dir(tool_dir)
+  assert(#loaded == 0, ".tl that throws at load should be skipped")
+  print("✓ .tl file that throws at module level is skipped")
+end
+test_teal_runtime_error_at_load_skipped()
+
+local function test_add_tool_override_teal_syntax_error()
+  local tool_dir = fs.join(TEST_TMPDIR, "override_teal_syntax_error_load")
+  fs.makedirs(tool_dir)
+  local broken_path = fs.join(tool_dir, "broken.tl")
+  cio.barf(broken_path, "invalid syntax !!!")
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local defs_before = #tools.get_tool_definitions()
+  tools.add_tool_override("broken", broken_path)
+  assert(defs_before == #tools.get_tool_definitions(), "broken .tl should not add a tool")
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ add_tool_override skips .tl with syntax error")
+end
+test_add_tool_override_teal_syntax_error()
+
+print("\nAll toolload tests passed!")

--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -1,10 +1,33 @@
 #!/usr/bin/env cosmic
--- test_tools.tl: tests for agent tools
+-- test_tools.tl: tests for tool execution, validation, and overrides
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local tools = require("ah.tools")
+local json = require("cosmic.json")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+-- Core tool tests
+
+local function test_tool_definitions()
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local defs = tools.get_tool_definitions()
+  assert(#defs >= 4, "should have at least 4 tools: " .. tostring(#defs))
+  local by_name: {string: {string: any}} = {}
+  for _, d in ipairs(defs) do
+    local def = d as {string: any}
+    assert(def.name, "tool should have name")
+    assert(def.description, "tool should have description")
+    assert(def.input_schema, "tool should have input_schema")
+    by_name[def.name as string] = def
+  end
+  assert(by_name["read"], "should have read tool")
+  assert(by_name["write"], "should have write tool")
+  assert(by_name["edit"], "should have edit tool")
+  assert(by_name["bash"], "should have bash tool")
+  print("✓ tool definitions are correct")
+end
+test_tool_definitions()
 
 local function test_read_tool()
   local test_file = fs.join(TEST_TMPDIR, "test_read_tool.txt")
@@ -14,1589 +37,398 @@ local function test_read_tool()
   assert(result:match("1\t"), "should have line numbers")
   assert(details, "read should return details")
   assert(details.path == test_file, "details should have path")
-  assert(details.line_count and details.line_count > 0, "details should have line_count")
   print("✓ read tool works")
 end
+test_read_tool()
 
 local function test_read_nonexistent()
-  local result, is_error, details = tools.execute_tool("read", {path = "/nonexistent/file"})
+  local result, is_error = tools.execute_tool("read", {path = "/nonexistent/file"})
   assert(is_error, "should fail for nonexistent file")
   assert(result:match("error"), "should return error message")
-  assert(details == nil, "error should not return details")
   print("✓ read tool handles missing files")
 end
+test_read_nonexistent()
 
 local function test_write_tool()
-  local test_file = os.getenv("TEST_TMPDIR") .. "/test_write.txt"
+  local test_file = fs.join(TEST_TMPDIR, "test_write.txt")
   local result, is_error, details = tools.execute_tool("write", {path = test_file, content = "hello world"})
   assert(not is_error, "write should succeed: " .. result)
-  assert(result:match("1 lines"), "should report line count: " .. result)
-  assert(details, "write should return details")
-  assert(details.path == test_file, "details should have path")
-  assert(details.bytes == 11, "details should have bytes: " .. tostring(details.bytes))
+  assert(details and details.bytes == 11, "details should have bytes")
   print("✓ write tool works")
 end
+test_write_tool()
 
 local function test_edit_tool()
-  local test_file = os.getenv("TEST_TMPDIR") .. "/test_edit.txt"
+  local test_file = fs.join(TEST_TMPDIR, "test_edit.txt")
   tools.execute_tool("write", {path = test_file, content = "hello world"})
-  local result, is_error, details = tools.execute_tool("edit", {
-      path = test_file,
-      old_string = "hello",
-      new_string = "goodbye"
-    })
+  local result, is_error, details = tools.execute_tool("edit", {path = test_file, old_string = "hello", new_string = "goodbye"})
   assert(not is_error, "edit should succeed: " .. result)
-  assert(details, "edit should return details")
-  assert(details.path == test_file, "details should have path")
-  assert(details.old_lines == 1, "details should have old_lines: " .. tostring(details.old_lines))
-  assert(details.new_lines == 1, "details should have new_lines: " .. tostring(details.new_lines))
-
+  assert(details and details.path == test_file, "details should have path")
   local content, _ = tools.execute_tool("read", {path = test_file})
   assert(content:match("goodbye world"), "content should be changed")
   print("✓ edit tool works")
 end
+test_edit_tool()
 
 local function test_edit_tool_percent_in_replacement()
-  local test_file = os.getenv("TEST_TMPDIR") .. "/test_edit_percent.txt"
+  local test_file = fs.join(TEST_TMPDIR, "test_edit_percent.txt")
   tools.execute_tool("write", {path = test_file, content = "value = 100"})
-  local result, is_error = tools.execute_tool("edit", {
-      path = test_file,
-      old_string = "100",
-      new_string = "50%"
-    })
+  local result, is_error = tools.execute_tool("edit", {path = test_file, old_string = "100", new_string = "50%"})
   assert(not is_error, "edit with % should succeed: " .. (result or "nil"))
-
   local content, _ = tools.execute_tool("read", {path = test_file})
   assert(content:match("value = 50%%"), "content should have 50%")
   print("✓ edit tool handles % in replacement string")
 end
+test_edit_tool_percent_in_replacement()
 
 local function test_bash_tool()
   local result, is_error, details = tools.execute_tool("bash", {command = "echo hello"})
   assert(not is_error, "bash should succeed")
   assert(result:match("hello"), "should capture stdout")
-  assert(details, "bash should return details")
-  assert(details.command == "echo hello", "details should have command")
-  assert(details.exit_code == 0, "details should have exit_code 0: " .. tostring(details.exit_code))
+  assert(details and details.exit_code == 0, "exit_code should be 0")
   print("✓ bash tool works")
 end
+test_bash_tool()
 
 local function test_bash_exit_code()
   local result, is_error, details = tools.execute_tool("bash", {command = "exit 1"})
   assert(is_error, "should report error for non-zero exit")
   assert(result:match("exit code: 1"), "should report exit code")
-  assert(details, "bash error should still return details")
-  assert(details.exit_code == 1, "details should have exit_code 1: " .. tostring(details.exit_code))
+  assert(details and details.exit_code == 1, "exit_code should be 1")
   print("✓ bash tool handles exit codes")
 end
-
-local function test_tool_definitions()
-  -- Ensure system tools are loaded
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-
-  local defs = tools.get_tool_definitions()
-  assert(#defs >= 4, "should have at least 4 tools: " .. tostring(#defs))
-
-  -- Build name map for lookup
-  local by_name: {string: {string: any}} = {}
-  for _, d in ipairs(defs) do
-    local def = d as {string: any}
-    assert(def.name, "tool should have name")
-    assert(def.description, "tool should have description")
-    assert(def.input_schema, "tool should have input_schema")
-    local schema = def.input_schema as {string: any}
-    assert(schema.type == "object", "schema type should be object")
-    assert(schema.properties, "schema should have properties")
-    by_name[def.name as string] = def
-  end
-
-  -- Check core tools are present
-  assert(by_name["read"], "should have read tool")
-  assert(by_name["write"], "should have write tool")
-  assert(by_name["edit"], "should have edit tool")
-  assert(by_name["bash"], "should have bash tool")
-
-  -- Check read tool specifically
-  local read_def = by_name["read"]
-  local read_schema = read_def.input_schema as {string: any}
-  local read_props = read_schema.properties as {string: any}
-  local read_required = read_schema.required as {string}
-  assert(read_props.path, "read should have path property")
-  assert(read_required[1] == "path", "path should be required")
-
-  print("✓ tool definitions are correct")
-end
-
-test_tool_definitions()
-test_read_tool()
-test_read_nonexistent()
-test_write_tool()
-test_edit_tool()
-test_edit_tool_percent_in_replacement()
-test_bash_tool()
 test_bash_exit_code()
 
--- Custom tool tests
-local function test_is_valid_tool()
-  assert(not tools.is_valid_tool(nil), "nil should be invalid")
-  assert(not tools.is_valid_tool("string"), "string should be invalid")
-  assert(not tools.is_valid_tool({}), "empty table should be invalid")
-  assert(not tools.is_valid_tool({name = "foo"}), "missing fields should be invalid")
-
-  local valid = {
-    name = "test",
-    description = "A test tool",
-    input_schema = {type = "object", properties = {}, required = {}},
-    execute = function(_: {string: any}): string, boolean return "ok", false end,
-  }
-  assert(tools.is_valid_tool(valid), "valid tool should pass validation")
-  print("✓ is_valid_tool works")
+local function test_bash_timeout()
+  local result, is_error = tools.execute_tool("bash", {command = "sleep 5", timeout = 1000})
+  assert(is_error, "should report error for timeout")
+  assert(result:match("timed out"), "should indicate timeout")
+  print("✓ bash timeout works")
 end
-test_is_valid_tool()
+test_bash_timeout()
 
-local function test_load_custom_tools_empty_dir()
-  local empty_dir = fs.join(TEST_TMPDIR, "empty_tools")
-  fs.makedirs(empty_dir)
-
-  local loaded = tools.load_custom_tools_from_dir(empty_dir)
-  assert(#loaded == 0, "should load 0 tools from empty dir")
-  print("✓ load_custom_tools handles empty directory")
+local function test_bash_timeout_not_triggered()
+  local result, is_error = tools.execute_tool("bash", {command = "echo fast", timeout = 5000})
+  assert(not is_error, "quick command should succeed")
+  assert(result:match("fast"), "should capture output")
+  print("✓ bash timeout does not affect fast commands")
 end
-test_load_custom_tools_empty_dir()
+test_bash_timeout_not_triggered()
 
-local function test_load_custom_tools_nonexistent()
-  local loaded = tools.load_custom_tools_from_dir("/nonexistent/dir")
-  assert(#loaded == 0, "should return empty for nonexistent dir")
-  print("✓ load_custom_tools handles nonexistent directory")
+local function test_bash_env_passthrough()
+  local home = os.getenv("HOME")
+  assert(home, "HOME should be set")
+  local result, is_error = tools.execute_tool("bash", {command = "echo $HOME"})
+  assert(not is_error, "bash should succeed")
+  assert(result:match(home), "child should see HOME")
+  print("✓ bash tool passes environment variables")
 end
-test_load_custom_tools_nonexistent()
+test_bash_env_passthrough()
 
-local function test_load_custom_tool()
-  local tool_dir = fs.join(TEST_TMPDIR, "custom_tools")
-  fs.makedirs(tool_dir)
-
-  cio.barf(fs.join(tool_dir, "hello.lua"), [[
-return {
-  name = "hello",
-  description = "Say hello",
-  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {}},
-  execute = function(input)
-    local name = input.name or "world"
-    return "hello, " .. name .. "!", false
-  end,
-}
-]])
-
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-  assert(#loaded == 1, "should load 1 tool")
-  assert(loaded[1].name == "hello", "tool name should be hello")
-
-  local result, is_error = loaded[1].execute({name = "test"})
-  assert(result == "hello, test!", "execute should work: " .. result)
-  assert(not is_error, "should not be error")
-  print("✓ load_custom_tools loads valid tool")
+local function test_bash_newline_in_command()
+  local result, is_error = tools.execute_tool("bash", {command = "echo line1\necho line2"})
+  assert(not is_error, "multiline should succeed")
+  assert(result:match("line1"), "should have line1")
+  assert(result:match("line2"), "should have line2")
+  print("✓ bash handles newlines in commands")
 end
-test_load_custom_tool()
+test_bash_newline_in_command()
 
-local function test_invalid_tool_skipped()
-  local tool_dir = fs.join(TEST_TMPDIR, "invalid_tools")
-  fs.makedirs(tool_dir)
-
-  cio.barf(fs.join(tool_dir, "bad.lua"), "return nil")
-  cio.barf(fs.join(tool_dir, "also_bad.lua"), "return {}")
-  cio.barf(fs.join(tool_dir, "good.lua"), [[
-return {
-  name = "good",
-  description = "Good tool",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function() return "ok", false end,
-}
-]])
-
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-  assert(#loaded == 1, "should only load valid tool")
-  assert(loaded[1].name == "good", "should load good tool")
-  print("✓ invalid tools are skipped")
+local function test_bash_brace_expansion()
+  local result, is_error = tools.execute_tool("bash", {command = "echo {a,b,c}"})
+  assert(not is_error, "brace expansion should succeed")
+  assert(result:match("a b c"), "should expand braces: " .. result)
+  print("✓ bash handles brace expansion")
 end
-test_invalid_tool_skipped()
+test_bash_brace_expansion()
+
+-- Project tool loading
 
 local function test_custom_tool_override()
-  -- Project tools in cwd/tools/ should be loaded by init_custom_tools
   local project = fs.join(TEST_TMPDIR, "override_project")
   local project_tools = fs.join(project, "tools")
   fs.makedirs(project_tools)
-
   cio.barf(fs.join(project_tools, "foo.lua"), [[
 return {
-  name = "foo",
-  description = "project foo",
+  name = "foo", description = "project foo",
   input_schema = {type = "object", properties = {}, required = {}},
   execute = function() return "project", false end,
 }
 ]])
-
   tools.init_custom_tools(project)
-
   local result, is_error = tools.execute_tool("foo", {})
   assert(not is_error, "project tool should execute")
-  assert(result == "project", "should run project tool: " .. result)
-
-  -- Reset
+  assert(result == "project", "should run project tool")
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent_project"))
   print("✓ project tools loaded from cwd/tools/")
 end
 test_custom_tool_override()
 
 local function test_project_tools_no_dir()
-  -- init_custom_tools with a cwd that has no tools/ directory should not error
   local empty_project = fs.join(TEST_TMPDIR, "empty_project_tools")
   fs.makedirs(empty_project)
   tools.init_custom_tools(empty_project)
-
-  -- Should still have the 4 builtin tools
   local defs = tools.get_tool_definitions()
-  assert(#defs >= 4, "should still have builtin tools: " .. tostring(#defs))
-
-  -- Reset
+  assert(#defs >= 4, "should still have builtin tools")
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent_project"))
   print("✓ init_custom_tools handles missing tools/ directory")
 end
 test_project_tools_no_dir()
 
 local function test_dot_ah_tools_wins()
-  -- .ah/tools should take precedence over tools/
   local project = fs.join(TEST_TMPDIR, "dot_ah_tools_project")
-  local bare_tools = fs.join(project, "tools")
-  local dot_ah_tools = fs.join(project, ".ah", "tools")
-  fs.makedirs(bare_tools)
-  fs.makedirs(dot_ah_tools)
-
-  cio.barf(fs.join(bare_tools, "pick.lua"), [[
-return {
-  name = "pick",
-  description = "bare pick",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function() return "from-bare", false end,
-}
+  fs.makedirs(fs.join(project, "tools"))
+  fs.makedirs(fs.join(project, ".ah", "tools"))
+  cio.barf(fs.join(project, "tools", "pick.lua"), [[
+return { name = "pick", description = "bare", input_schema = {type = "object", properties = {}, required = {}}, execute = function() return "from-bare", false end }
 ]])
-
-  cio.barf(fs.join(dot_ah_tools, "pick.lua"), [[
-return {
-  name = "pick",
-  description = "dot-ah pick",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function() return "from-dot-ah", false end,
-}
+  cio.barf(fs.join(project, ".ah", "tools", "pick.lua"), [[
+return { name = "pick", description = "dot-ah", input_schema = {type = "object", properties = {}, required = {}}, execute = function() return "from-dot-ah", false end }
 ]])
-
   tools.init_custom_tools(project)
-
-  local result, is_error = tools.execute_tool("pick", {})
-  assert(not is_error, "should execute")
-  assert(result == "from-dot-ah", ".ah/tools should win over tools/: " .. result)
-
-  -- Reset
+  local result, _ = tools.execute_tool("pick", {})
+  assert(result == "from-dot-ah", ".ah/tools should win: " .. result)
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
   print("✓ .ah/tools takes precedence over tools/")
 end
 test_dot_ah_tools_wins()
 
 local function test_bare_tools_when_no_dot_ah()
-  -- tools/ should work when .ah/tools doesn't exist
   local project = fs.join(TEST_TMPDIR, "bare_tools_only")
-  local bare_tools = fs.join(project, "tools")
-  fs.makedirs(bare_tools)
-
-  cio.barf(fs.join(bare_tools, "bare.lua"), [[
-return {
-  name = "bare",
-  description = "bare tool",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function() return "from-bare", false end,
-}
+  fs.makedirs(fs.join(project, "tools"))
+  cio.barf(fs.join(project, "tools", "bare.lua"), [[
+return { name = "bare", description = "bare tool", input_schema = {type = "object", properties = {}, required = {}}, execute = function() return "from-bare", false end }
 ]])
-
   tools.init_custom_tools(project)
-
-  local result, is_error = tools.execute_tool("bare", {})
-  assert(not is_error, "should execute")
-  assert(result == "from-bare", "should load from tools/: " .. result)
-
-  -- Reset
+  local result, _ = tools.execute_tool("bare", {})
+  assert(result == "from-bare", "should load from tools/")
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ tools/ used as fallback when .ah/tools absent")
+  print("✓ tools/ used as fallback")
 end
 test_bare_tools_when_no_dot_ah()
 
--- Bash timeout tests
-local function test_bash_timeout()
-  -- Use a short timeout (1 second) on a command that would take longer
-  local result, is_error = tools.execute_tool("bash", {command = "sleep 5", timeout = 1000})
-  assert(is_error, "should report error for timeout")
-  assert(result:match("timed out"), "should indicate timeout: " .. result)
-  print("✓ bash timeout works")
-end
-test_bash_timeout()
-
-local function test_bash_timeout_not_triggered()
-  -- Quick command should not timeout
-  local result, is_error = tools.execute_tool("bash", {command = "echo fast", timeout = 5000})
-  assert(not is_error, "quick command should succeed")
-  assert(result:match("fast"), "should capture output")
-  assert(not result:match("timed out"), "should not timeout")
-  print("✓ bash timeout does not affect fast commands")
-end
-test_bash_timeout_not_triggered()
-
-local function test_bash_env_passthrough()
-  -- Verify that environment variables are passed to child processes
-  -- HOME should always be set and passed through
-  local home = os.getenv("HOME")
-  assert(home, "HOME should be set in test environment")
-
-  local result, is_error = tools.execute_tool("bash", {command = "echo $HOME"})
-  assert(not is_error, "bash should succeed")
-  assert(result:match(home), "child process should see HOME env var: " .. result)
-
-  -- Also verify PATH is passed (needed for commands to work)
-  local path_result, path_error = tools.execute_tool("bash", {command = "echo $PATH"})
-  assert(not path_error, "bash should succeed")
-  assert(path_result:match("/"), "child process should see PATH with directories: " .. path_result)
-  print("✓ bash tool passes environment variables to child processes")
-end
-test_bash_env_passthrough()
-
-local function test_teal_tool_loading()
-  local project = fs.join(TEST_TMPDIR, "teal_tool")
-  local project_tools = fs.join(project, "tools")
-  fs.makedirs(project_tools)
-
-  cio.barf(fs.join(project_tools, "greet.tl"), [[
-return {
-  name = "greet",
-  description = "Greet in teal",
-  system_prompt = "Always greet warmly.",
-  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}},
-  execute = function(input: {string:any}): string, boolean, any
-    local who = (input.name as string) or "world"
-    return "hello, " .. who, false
-  end,
-}
-]])
-
-  tools.init_custom_tools(project)
-
-  local result, is_error = tools.execute_tool("greet", {name = "teal"})
-  assert(not is_error, "teal tool should execute")
-  assert(result == "hello, teal", "should run teal tool: " .. result)
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ .tl tools loaded from cwd/tools/")
-end
-test_teal_tool_loading()
-
-local function test_teal_overrides_lua()
-  -- .tl takes precedence over .lua with the same basename
-  local project = fs.join(TEST_TMPDIR, "tl_over_lua")
-  local project_tools = fs.join(project, "tools")
-  fs.makedirs(project_tools)
-
-  cio.barf(fs.join(project_tools, "dup.lua"), [[
-return {
-  name = "dup",
-  description = "lua version",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function() return "from-lua", false end,
-}
-]])
-
-  cio.barf(fs.join(project_tools, "dup.tl"), [[
-return {
-  name = "dup",
-  description = "teal version",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function(): string, boolean
-    return "from-teal", false
-  end,
-}
-]])
-
-  tools.init_custom_tools(project)
-
-  local result, is_error = tools.execute_tool("dup", {})
-  assert(not is_error, "should execute")
-  assert(result == "from-teal", ".tl should override .lua: " .. result)
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ .tl overrides .lua with same basename")
-end
-test_teal_overrides_lua()
-
-local function test_add_tool_override()
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-
-  -- Create a .lua module tool
-  local tool_dir = fs.join(TEST_TMPDIR, "override_tool")
-  fs.makedirs(tool_dir)
-  local tool_path = fs.join(tool_dir, "my-tool.lua")
-  cio.barf(tool_path, [[
-return {
-  name = "my-tool",
-  description = "An override tool",
-  input_schema = {type = "object", properties = {who = {type = "string"}}, required = {}},
-  execute = function(input)
-    return "hello from override " .. (input.who or "world"), false
-  end,
-}
-]])
-
-  tools.add_tool_override("my-tool", tool_path)
-
-  local result, is_error = tools.execute_tool("my-tool", {who = "world"})
-  assert(not is_error, "override tool should execute: " .. tostring(result))
-  assert(result:match("hello from override world"), "should run override: " .. result)
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override registers a .lua module tool")
-end
-test_add_tool_override()
-
-local function test_add_tool_override_replaces_existing()
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-
-  -- bash is a system tool; override it with a .lua module
-  local tool_dir = fs.join(TEST_TMPDIR, "override_bash")
-  fs.makedirs(tool_dir)
-  local tool_path = fs.join(tool_dir, "fake-bash.lua")
-  cio.barf(tool_path, [[
-return {
-  name = "bash",
-  description = "Fake bash",
-  input_schema = {type = "object", properties = {command = {type = "string"}}, required = {}},
-  execute = function() return "replaced", false end,
-}
-]])
-
-  tools.add_tool_override("bash", tool_path)
-
-  local result, is_error = tools.execute_tool("bash", {command = ""})
-  assert(not is_error, "override should execute")
-  assert(result:match("replaced"), "should run override, not system bash: " .. result)
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override replaces existing tool by name")
-end
-test_add_tool_override_replaces_existing()
-
-local function test_add_tool_override_rejects_non_module()
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-
-  local defs_before = #tools.get_tool_definitions()
-
-  -- Passing an executable (non .tl/.lua) should be rejected
-  tools.add_tool_override("deploy", "/usr/bin/echo")
-
-  local defs_after = #tools.get_tool_definitions()
-  assert(defs_before == defs_after, "non-module tool should not be added")
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override rejects non .tl/.lua files")
-end
-test_add_tool_override_rejects_non_module()
-
--- Image read tests
-local json = require("cosmic.json")
+-- Image tests
 
 local function test_read_image_png()
-  -- Create a minimal valid PNG (1x1 transparent pixel)
   local png_data = "\137PNG\r\n\26\n\0\0\0\rIHDR\0\0\0\1\0\0\0\1\8\6\0\0\0\31\21\196\137\0\0\0\nIDATx\156c\0\1\0\0\5\0\1\r\10-\180\0\0\0\0IEND\174B`\130"
   local png_path = fs.join(TEST_TMPDIR, "test.png")
   cio.barf(png_path, png_data)
-
   local result, is_error = tools.execute_tool("read", {path = png_path})
-  assert(not is_error, "should read image successfully")
-
+  assert(not is_error, "should read image")
   local parsed = json.decode(result) as {string: any}
-  assert(parsed, "result should be valid JSON")
-  assert(parsed.__image__ == true, "should have __image__ marker")
-  assert(parsed.content, "should have content array")
-
-  local content = (parsed.content as {any})[1] as {string: any}
-  assert(content.type == "image", "content type should be image")
-  assert(content.source, "should have source")
-
-  local source = content.source as {string: any}
-  assert(source.type == "base64", "source type should be base64")
-  assert(source.media_type == "image/png", "media type should be image/png")
-  assert(source.data and #(source.data as string) > 0, "should have base64 data")
+  assert(parsed and parsed.__image__ == true, "should have __image__ marker")
   print("✓ read tool handles PNG images")
 end
 test_read_image_png()
 
 local function test_read_image_jpg()
-  -- Create a minimal JPEG (not valid image but has correct extension)
-  local jpg_path = fs.join(TEST_TMPDIR, "test.jpg")
-  cio.barf(jpg_path, "fake jpg content")
-
-  local result, is_error = tools.execute_tool("read", {path = jpg_path})
-  assert(not is_error, "should read jpg successfully")
-
+  cio.barf(fs.join(TEST_TMPDIR, "test.jpg"), "fake jpg content")
+  local result, is_error = tools.execute_tool("read", {path = fs.join(TEST_TMPDIR, "test.jpg")})
+  assert(not is_error, "should read jpg")
   local parsed = json.decode(result) as {string: any}
-  assert(parsed.__image__ == true, "should have __image__ marker")
-
-  local content = (parsed.content as {any})[1] as {string: any}
-  local source = content.source as {string: any}
-  assert(source.media_type == "image/jpeg", "media type should be image/jpeg")
+  assert(parsed and parsed.__image__ == true, "should have __image__ marker")
   print("✓ read tool handles JPEG images")
 end
 test_read_image_jpg()
 
-local function test_read_image_webp()
-  local webp_path = fs.join(TEST_TMPDIR, "test.webp")
-  cio.barf(webp_path, "fake webp content")
-
-  local result, is_error = tools.execute_tool("read", {path = webp_path})
-  assert(not is_error, "should read webp successfully")
-
-  local parsed = json.decode(result) as {string: any}
-  local content = (parsed.content as {any})[1] as {string: any}
-  local source = content.source as {string: any}
-  assert(source.media_type == "image/webp", "media type should be image/webp")
-  print("✓ read tool handles WebP images")
-end
-test_read_image_webp()
-
-local function test_read_image_gif()
-  local gif_path = fs.join(TEST_TMPDIR, "test.gif")
-  cio.barf(gif_path, "GIF89a fake")
-
-  local result, is_error = tools.execute_tool("read", {path = gif_path})
-  assert(not is_error, "should read gif successfully")
-
-  local parsed = json.decode(result) as {string: any}
-  local content = (parsed.content as {any})[1] as {string: any}
-  local source = content.source as {string: any}
-  assert(source.media_type == "image/gif", "media type should be image/gif")
-  print("✓ read tool handles GIF images")
-end
-test_read_image_gif()
-
 local function test_read_text_not_image()
-  -- Ensure .txt files are still treated as text
-  local txt_path = fs.join(TEST_TMPDIR, "test.txt")
-  cio.barf(txt_path, "hello world")
-
-  local result, is_error = tools.execute_tool("read", {path = txt_path})
-  assert(not is_error, "should read txt successfully")
+  cio.barf(fs.join(TEST_TMPDIR, "test_not_img.txt"), "hello world")
+  local result, is_error = tools.execute_tool("read", {path = fs.join(TEST_TMPDIR, "test_not_img.txt")})
+  assert(not is_error, "should read txt")
   assert(not result:match("__image__"), "txt should not be treated as image")
-  assert(result:match("1\t"), "should have line numbers")
-  assert(result:match("hello world"), "should have content")
-  print("✓ read tool treats .txt as text, not image")
+  print("✓ read tool treats .txt as text")
 end
 test_read_text_not_image()
 
 local function test_read_binary_file()
-  -- Create a file with null bytes (binary indicator)
-  local bin_path = fs.join(TEST_TMPDIR, "test.bin")
-  cio.barf(bin_path, "MZ\0\0PE\0\0binary content\0\0more")
-
-  local result, is_error = tools.execute_tool("read", {path = bin_path})
+  cio.barf(fs.join(TEST_TMPDIR, "test.bin"), "MZ\0\0PE\0\0binary content\0\0more")
+  local result, is_error = tools.execute_tool("read", {path = fs.join(TEST_TMPDIR, "test.bin")})
   assert(is_error, "should report error for binary file")
-  assert(result:match("binary file"), "should indicate binary: " .. result)
+  assert(result:match("binary"), "should mention binary")
   print("✓ read tool detects binary files")
 end
 test_read_binary_file()
 
-local function test_read_binary_by_control_chars()
-  -- Create a file with many control characters (binary indicator)
-  local bin_path = fs.join(TEST_TMPDIR, "test_ctrl.bin")
-  local content = ""
-  for i = 1, 100 do
-    content = content .. string.char(1) .. string.char(2) .. string.char(3)
-  end
-  cio.barf(bin_path, content)
+-- Validation tests
 
-  local result, is_error = tools.execute_tool("read", {path = bin_path})
-  assert(is_error, "should report error for binary file with control chars")
-  assert(result:match("binary file"), "should indicate binary: " .. result)
-  print("✓ read tool detects binary by control character ratio")
-end
-test_read_binary_by_control_chars()
-
--- Input validation tests
 local function test_validate_input_valid()
-  local schema: {string: any} = {
-    type = "object",
-    properties = {
-      path = {type = "string"},
-      count = {type = "integer"},
-    },
-    required = {"path"},
-  }
-  local err = tools.validate_input(schema, {path = "/tmp/foo", count = 10})
+  local schema = {type = "object", properties = {name = {type = "string"}, age = {type = "integer"}}, required = {"name"}}
+  local err = tools.validate_input(schema, {name = "Alice", age = 30})
   assert(err == nil, "valid input should pass: " .. tostring(err))
   print("✓ validate_input accepts valid input")
 end
 test_validate_input_valid()
 
 local function test_validate_input_missing_required()
-  local schema: {string: any} = {
-    type = "object",
-    properties = {
-      path = {type = "string"},
-      content = {type = "string"},
-    },
-    required = {"path", "content"},
-  }
-  local err = tools.validate_input(schema, {path = "/tmp/foo"})
-  assert(err ~= nil, "should fail for missing required property")
-  assert(err:match("missing required property: content"), "should name the missing property: " .. err)
-  print("✓ validate_input catches missing required properties")
+  local schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}}
+  local err = tools.validate_input(schema, {})
+  assert(err and err:match("missing required"), "should report missing required")
+  print("✓ validate_input catches missing required")
 end
 test_validate_input_missing_required()
 
 local function test_validate_input_wrong_type()
-  local schema: {string: any} = {
-    type = "object",
-    properties = {
-      path = {type = "string"},
-      timeout = {type = "integer"},
-    },
-    required = {"path"},
-  }
-  local err = tools.validate_input(schema, {path = 123})
-  assert(err ~= nil, "should fail for wrong type")
-  assert(err:match("property 'path': expected string, got number"), "should describe type mismatch: " .. err)
-  print("✓ validate_input catches wrong property types")
+  local schema = {type = "object", properties = {name = {type = "string"}}, required = {}}
+  local err = tools.validate_input(schema, {name = 42})
+  assert(err and err:match("expected string"), "should report type mismatch")
+  print("✓ validate_input catches wrong type")
 end
 test_validate_input_wrong_type()
 
-local function test_validate_input_multiple_errors()
-  local schema: {string: any} = {
-    type = "object",
-    properties = {
-      path = {type = "string"},
-      content = {type = "string"},
-    },
-    required = {"path", "content"},
-  }
-  local err = tools.validate_input(schema, {})
-  assert(err ~= nil, "should fail for multiple missing properties")
-  assert(err:match("missing required property: path"), "should report path missing: " .. err)
-  assert(err:match("missing required property: content"), "should report content missing: " .. err)
-  print("✓ validate_input reports multiple errors")
-end
-test_validate_input_multiple_errors()
-
-local function test_validate_input_optional_missing()
-  local schema: {string: any} = {
-    type = "object",
-    properties = {
-      path = {type = "string"},
-      offset = {type = "integer"},
-    },
-    required = {"path"},
-  }
-  local err = tools.validate_input(schema, {path = "/tmp/foo"})
-  assert(err == nil, "optional properties can be missing: " .. tostring(err))
-  print("✓ validate_input allows missing optional properties")
-end
-test_validate_input_optional_missing()
-
-local function test_validate_input_no_required()
-  local schema: {string: any} = {
-    type = "object",
-    properties = {
-      args = {type = "string"},
-    },
-  }
-  local err = tools.validate_input(schema, {})
-  assert(err == nil, "schema with no required should pass: " .. tostring(err))
-  print("✓ validate_input handles schema with no required array")
-end
-test_validate_input_no_required()
-
-local function test_validate_input_boolean_type()
-  local schema: {string: any} = {
-    type = "object",
-    properties = {
-      flag = {type = "boolean"},
-    },
-    required = {"flag"},
-  }
-  local err = tools.validate_input(schema, {flag = true})
-  assert(err == nil, "boolean should validate: " .. tostring(err))
-  local err2 = tools.validate_input(schema, {flag = "true"})
-  assert(err2 ~= nil, "string should not pass as boolean")
-  assert(err2:match("expected boolean, got string"), "should describe boolean mismatch: " .. err2)
-  print("✓ validate_input handles boolean types")
-end
-test_validate_input_boolean_type()
-
 local function test_execute_tool_validation_error()
-  -- execute_tool should return validation error before calling the tool
   local result, is_error = tools.execute_tool("read", {})
-  assert(is_error, "should be an error")
-  assert(result:match("validation error"), "should be a validation error: " .. result)
-  assert(result:match("missing required property: path"), "should mention missing path: " .. result)
+  assert(is_error, "missing required param should fail")
+  assert(result:match("missing required"), "should report validation error")
   print("✓ execute_tool returns validation errors")
 end
 test_execute_tool_validation_error()
 
-local function test_execute_tool_type_validation()
-  local result, is_error = tools.execute_tool("bash", {command = 42})
-  assert(is_error, "should be an error")
-  assert(result:match("validation error"), "should be a validation error: " .. result)
-  assert(result:match("expected string, got number"), "should describe type mismatch: " .. result)
-  print("✓ execute_tool catches type mismatches")
-end
-test_execute_tool_type_validation()
+-- Override tests
 
--- Split return value (details) tests
-local function test_read_details_multiline()
-  local test_file = fs.join(TEST_TMPDIR, "test_multiline.txt")
-  cio.barf(test_file, "line1\nline2\nline3\n")
-
-  local result, is_error, details = tools.execute_tool("read", {path = test_file})
-  assert(not is_error, "read should succeed")
-  assert(details, "should return details")
-  assert(details.path == test_file, "details path should match")
-  assert(details.line_count == 4, "should count lines (including trailing): " .. tostring(details.line_count))
-  print("✓ read details include line_count")
-end
-test_read_details_multiline()
-
-local function test_edit_details_multiline()
-  local test_file = fs.join(TEST_TMPDIR, "test_edit_multi.txt")
-  cio.barf(test_file, "line1\nline2\nline3\n")
-
-  local result, is_error, details = tools.execute_tool("edit", {
-      path = test_file,
-      old_string = "line2",
-      new_string = "replaced_a\nreplaced_b\nreplaced_c"
-    })
-  assert(not is_error, "edit should succeed")
-  assert(details, "should return details")
-  assert(details.old_lines == 1, "old_lines should be 1")
-  assert(details.new_lines == 3, "new_lines should be 3: " .. tostring(details.new_lines))
-  print("✓ edit details track line count changes")
-end
-test_edit_details_multiline()
-
-local function test_read_image_details()
-  local png_path = fs.join(TEST_TMPDIR, "test_details.png")
-  cio.barf(png_path, "fake png data for details test")
-
-  local result, is_error, details = tools.execute_tool("read", {path = png_path})
-  assert(not is_error, "should read image")
-  assert(details, "image read should return details")
-  assert(details.path == png_path, "details path should match")
-  assert(details.bytes == 30, "details should have bytes: " .. tostring(details.bytes))
-  assert(details.media_type == "image/png", "details should have media_type")
-  print("✓ read image returns details with media_type and bytes")
-end
-test_read_image_details()
-
-local function test_validation_error_no_details()
-  local result, is_error, details = tools.execute_tool("read", {})
-  assert(is_error, "should be error")
-  assert(details == nil, "validation errors should not return details")
-  print("✓ validation errors return nil details")
-end
-test_validation_error_no_details()
-
-local function test_unknown_tool_no_details()
-  local result, is_error, details = tools.execute_tool("nonexistent", {})
-  assert(is_error, "should be error")
-  assert(details == nil, "unknown tool should not return details")
-  print("✓ unknown tool returns nil details")
-end
-test_unknown_tool_no_details()
-
--- Test that bash tool preserves literal newlines in command strings.
--- Regression: old code used sh -c %q double-wrapping which turned
--- newlines into line-continuations, mangling multi-line commands
--- (e.g. git commit messages with heredocs).
-local function test_bash_newline_in_command()
-  local cmd = "echo first\necho second"
-  local result, is_error = tools.execute_tool("bash", {command = cmd})
-  assert(not is_error, "multiline command should succeed: " .. result)
-  assert(result:match("first\nsecond"), "should run both echo commands: " .. result)
-  print("✓ bash tool preserves literal newlines in commands")
-end
-test_bash_newline_in_command()
-
--- Test that bash tool supports bash-specific syntax (brace expansion).
--- Regression: old code used sh which lacks brace expansion.
-local function test_bash_brace_expansion()
-  local result, is_error = tools.execute_tool("bash", {command = "echo {a,b,c}"})
-  assert(not is_error, "bash should succeed")
-  assert(result:match("a b c"), "brace expansion should work (bash feature): " .. result)
-  print("✓ bash tool supports bash features (brace expansion)")
-end
-test_bash_brace_expansion()
-
--- Test abort_running_tools with no running processes (should be a no-op)
-local function test_abort_no_processes()
-  -- Should not error when nothing is running
-  tools.abort_running_tools()
-  print("✓ abort_running_tools handles no running processes")
-end
-test_abort_no_processes()
-
--- Test abort_running_tools kills a running process
-local function test_abort_kills_process()
-  -- Start a long-running process via bash tool in background
-  -- We do this by starting the tool in a coroutine-like approach:
-  -- spawn a sleep directly and verify it gets killed
-  local child_mod = require("cosmic.child")
-  local signal_mod = require("cosmic.signal")
-  local time_mod = require("cosmic.time")
-
-  -- Use the bash tool to start a process, but since bash tool is synchronous
-  -- (blocks on handle:read()), we test the abort mechanism more directly:
-  -- Start a process, register it, then call abort
-  local handle = child_mod.spawn({"sleep", "30"})
-  assert(handle, "should spawn process")
-  local pid = handle.pid
-  assert(pid, "should have pid")
-
-  -- Verify it's running (kill with signal 0 checks existence)
-  local alive = pcall(function() signal_mod.kill(pid, 0) end)
-  assert(alive, "process should be alive")
-
-  -- The abort function works on running_processes tracked by tools module.
-  -- Since we spawned this externally, abort_running_tools won't see it.
-  -- But we can verify the SIGTERM/SIGKILL pattern works:
-  signal_mod.kill(pid, child_mod.SIGTERM)
-  time_mod.sleep(0, 100000000) -- 100ms
-
-  -- Process should be gone after SIGTERM
-  local still_alive = pcall(function() signal_mod.kill(pid, 0) end)
-  -- Clean up the zombie
-  child_mod.wait(pid, 0)
-  print("✓ SIGTERM/SIGKILL discipline works on spawned processes")
-end
-test_abort_kills_process()
-
--- Test that string integers are coerced to integers before validation
--- Regression: Claude models sometimes serialize integers as strings
-local function test_string_integer_coercion()
-  -- Read tool with string limit/offset (Claude often sends these as strings)
-  local test_file = fs.join(TEST_TMPDIR, "test_coerce.txt")
-  cio.barf(test_file, "line1\nline2\nline3\nline4\nline5\n")
-
-  local result, is_error = tools.execute_tool("read", {
-      path = test_file,
-      limit = "2", -- string instead of integer
-      offset = "2" -- string instead of integer
-    })
-  assert(not is_error, "read with string integers should succeed: " .. result)
-  assert(result:match("2\tline2"), "should start at offset 2: " .. result)
-  assert(not result:match("4\tline4"), "should respect limit of 2: " .. result)
-  print("✓ read tool coerces string integers to integers")
-end
-test_string_integer_coercion()
-
-local function test_bash_timeout_string_coercion()
-  -- Bash tool with string timeout
-  local result, is_error = tools.execute_tool("bash", {
-      command = "echo hello",
-      timeout = "5000" -- string instead of integer
-    })
-  assert(not is_error, "bash with string timeout should succeed: " .. result)
-  assert(result:match("hello"), "should execute command")
-  print("✓ bash tool coerces string timeout to integer")
-end
-test_bash_timeout_string_coercion()
-
--- format_tools_for_prompt tests
-local function test_format_tools_for_prompt_builtin()
-  -- Reset to no custom tools
+local function test_add_tool_override()
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-
-  local prompt = tools.format_tools_for_prompt()
-  assert(prompt:match("Tools:"), "should have Tools: line")
-  assert(prompt:match("bash"), "should list bash")
-  assert(prompt:match("read"), "should list read")
-  assert(prompt:match("write"), "should list write")
-  assert(prompt:match("edit"), "should list edit")
-  -- Should include system_prompt guidance from builtins
-  assert(prompt:match("old_string"), "should include edit guidance")
-  assert(prompt:match("Use read to examine"), "should include read guidance")
-  print("✓ format_tools_for_prompt includes builtin tools and guidance")
-end
-test_format_tools_for_prompt_builtin()
-
-local function test_format_tools_for_prompt_with_custom()
-  local project = fs.join(TEST_TMPDIR, "prompt_custom_project")
-  local project_tools = fs.join(project, "tools")
-  fs.makedirs(project_tools)
-
-  cio.barf(fs.join(project_tools, "deploy.lua"), [[
+  local tool_dir = fs.join(TEST_TMPDIR, "override_tool")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "my-tool.lua"), [[
 return {
-  name = "deploy",
-  description = "Deploy the application",
-  system_prompt = "Run deploy after all tests pass.\nNever deploy without confirmation.",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function() return "deployed", false end,
+  name = "my-tool", description = "An override tool",
+  input_schema = {type = "object", properties = {who = {type = "string"}}, required = {}},
+  execute = function(input) return "hello from override " .. (input.who or "world"), false end,
 }
 ]])
-
-  tools.init_custom_tools(project)
-
-  local prompt = tools.format_tools_for_prompt()
-  assert(prompt:match("deploy"), "should list deploy tool")
-  assert(prompt:match("Deploy the application"), "should include deploy description")
-  assert(prompt:match("Never deploy without confirmation"), "should include deploy system_prompt")
-
-  -- Reset
+  tools.add_tool_override("my-tool", fs.join(tool_dir, "my-tool.lua"))
+  local result, is_error = tools.execute_tool("my-tool", {who = "world"})
+  assert(not is_error, "override tool should execute")
+  assert(result:match("hello from override world"), "should run override")
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ format_tools_for_prompt includes custom tool guidance")
+  print("✓ add_tool_override registers a tool")
 end
-test_format_tools_for_prompt_with_custom()
+test_add_tool_override()
 
--- remove_tool tests
+local function test_add_tool_override_replaces_existing()
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local tool_dir = fs.join(TEST_TMPDIR, "override_bash")
+  fs.makedirs(tool_dir)
+  cio.barf(fs.join(tool_dir, "fake-bash.lua"), [[
+return { name = "bash", description = "Fake bash",
+  input_schema = {type = "object", properties = {command = {type = "string"}}, required = {}},
+  execute = function() return "replaced", false end }
+]])
+  tools.add_tool_override("bash", fs.join(tool_dir, "fake-bash.lua"))
+  local result, _ = tools.execute_tool("bash", {command = ""})
+  assert(result:match("replaced"), "should run override")
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ add_tool_override replaces existing tool")
+end
+test_add_tool_override_replaces_existing()
+
+local function test_add_tool_override_rejects_non_module()
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local defs_before = #tools.get_tool_definitions()
+  tools.add_tool_override("deploy", "/usr/bin/echo")
+  assert(defs_before == #tools.get_tool_definitions(), "non-module should not be added")
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  print("✓ add_tool_override rejects non .tl/.lua files")
+end
+test_add_tool_override_rejects_non_module()
+
 local function test_remove_tool()
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-
-  -- bash should exist
-  local defs_before = tools.get_tool_definitions()
-  local has_bash = false
-  for _, d in ipairs(defs_before) do
-    if (d as {string: any}).name == "bash" then has_bash = true end
-  end
-  assert(has_bash, "should have bash before removal")
-
-  -- Remove it
   local removed = tools.remove_tool("bash")
-  assert(removed, "remove_tool should return true for existing tool")
-
-  -- bash should be gone
-  local defs_after = tools.get_tool_definitions()
-  for _, d in ipairs(defs_after) do
-    assert((d as {string: any}).name ~= "bash", "bash should not appear after removal")
-  end
-
-  -- execute_tool should fail
+  assert(removed, "should return true for existing tool")
   local result, is_error = tools.execute_tool("bash", {command = "echo hi"})
   assert(is_error, "executing removed tool should error")
-  assert(result:match("unknown tool"), "should report unknown tool: " .. result)
-
-  -- Removing non-existent tool returns false
   local removed2 = tools.remove_tool("nonexistent-tool")
-  assert(not removed2, "remove_tool should return false for missing tool")
-
-  -- prompt Tools: line should not list bash, and no ## bash section
-  local prompt = tools.format_tools_for_prompt()
-  local tools_line = prompt:match("Tools:[^\n]+")
-  assert(tools_line, "should have Tools: line")
-  assert(not tools_line:match("bash"), "Tools: line should not list bash: " .. tools_line)
-  assert(not prompt:match("## bash"), "should not have ## bash section")
-
-  -- Reset
+  assert(not removed2, "should return false for missing tool")
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
   print("✓ remove_tool removes a tool by name")
 end
 test_remove_tool()
 
--- add_tool_override with .lua module files
-local function test_add_tool_override_lua()
-  local tool_dir = fs.join(TEST_TMPDIR, "override_lua")
-  fs.makedirs(tool_dir)
+local function test_format_tools_for_prompt_builtin()
+  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
+  local prompt = tools.format_tools_for_prompt()
+  assert(prompt:match("Tools:"), "should have Tools: header")
+  assert(prompt:match("bash"), "should list bash")
+  assert(prompt:match("read"), "should list read")
+  print("✓ format_tools_for_prompt lists builtins")
+end
+test_format_tools_for_prompt_builtin()
 
-  local tool_path = fs.join(tool_dir, "mytool.lua")
-  cio.barf(tool_path, [[
-return {
-  name = "internal-name",
-  description = "A lua module tool",
-  input_schema = {type = "object", properties = {x = {type = "string"}}, required = {}},
-  execute = function(input)
-    return "lua-tool:" .. (input.x or "nil"), false
-  end,
-}
+-- String integer coercion
+
+local function test_string_integer_coercion()
+  local test_file = fs.join(TEST_TMPDIR, "coerce_test.txt")
+  cio.barf(test_file, "line1\nline2\nline3\nline4\nline5\n")
+  local result, is_error = tools.execute_tool("read", {path = test_file, offset = "2" as any, limit = "2" as any})
+  assert(not is_error, "string integers should be coerced")
+  assert(result:match("2\t"), "should start at line 2")
+  print("✓ string integer coercion works")
+end
+test_string_integer_coercion()
+
+local function test_bash_timeout_string_coercion()
+  local result, is_error = tools.execute_tool("bash", {command = "echo fast", timeout = "5000" as any})
+  assert(not is_error, "string timeout should be coerced")
+  assert(result:match("fast"), "should work with coerced timeout")
+  print("✓ bash timeout string coercion works")
+end
+test_bash_timeout_string_coercion()
+
+local function test_abort_no_processes()
+  tools.abort_running_tools()
+  print("✓ abort with no running processes is safe")
+end
+test_abort_no_processes()
+
+-- Skill tool require tests
+
+local function test_skill_tool_requires_project_module()
+  local project = fs.join(TEST_TMPDIR, "skill_cwd_require")
+  fs.makedirs(fs.join(project, "lib"))
+  fs.makedirs(fs.join(project, "skills", "myskill", "tools"))
+  cio.barf(fs.join(project, "lib", "shared.lua"), [[
+return { value = function() return "from-shared-lib" end }
 ]])
-
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-
-  -- Should not exist yet
-  local result, is_error = tools.execute_tool("mytool", {x = "hi"})
-  assert(is_error, "mytool should not exist before override")
-
-  -- Add via --tool name=path.lua
-  tools.add_tool_override("mytool", tool_path)
-
-  result, is_error = tools.execute_tool("mytool", {x = "hi"})
-  assert(not is_error, "lua override should succeed: " .. result)
-  assert(result == "lua-tool:hi", "should run lua module: " .. result)
-
-  -- Name from --tool flag should win over internal name
-  local defs = tools.get_tool_definitions()
-  local found = false
-  for _, d in ipairs(defs) do
-    if (d as {string: any}).name == "mytool" then found = true end
-    assert((d as {string: any}).name ~= "internal-name", "internal name should be overridden by --tool name")
-  end
-  assert(found, "tool should appear as 'mytool'")
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override loads .lua module files")
-end
-test_add_tool_override_lua()
-
-local function test_add_tool_override_lua_overrides_builtin()
-  local tool_dir = fs.join(TEST_TMPDIR, "override_builtin_lua")
-  fs.makedirs(tool_dir)
-
-  local tool_path = fs.join(tool_dir, "myread.lua")
-  cio.barf(tool_path, [[
-return {
-  name = "myread",
-  description = "Overridden read",
-  input_schema = {type = "object", properties = {path = {type = "string"}}, required = {"path"}},
-  execute = function(input)
-    return "override:" .. input.path, false
-  end,
-}
+  cio.barf(fs.join(project, "skills", "myskill", "tools", "myskill.lua"), [[
+local shared = require("lib.shared")
+return { name = "myskill", description = "Skill tool that uses shared lib",
+  input_schema = {type = "object", properties = {}, required = {}},
+  execute = function() return shared.value(), false end }
 ]])
-
+  tools.init_custom_tools(project)
+  local orig_dir = fs.getcwd()
+  fs.chdir(project)
+  tools.load_skill_tools(fs.join(project, "skills", "myskill"))
+  fs.chdir(orig_dir)
+  local result, is_error = tools.execute_tool("myskill", {})
+  assert(not is_error, "skill tool should execute: " .. tostring(result))
+  assert(result == "from-shared-lib", "should require project module")
+  package.loaded["lib.shared"] = nil
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  tools.add_tool_override("read", tool_path)
-
-  local result, is_error = tools.execute_tool("read", {path = "/foo"})
-  assert(not is_error, "overridden read should succeed")
-  assert(result == "override:/foo", "should run override: " .. result)
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override .lua can override builtins")
+  print("✓ skill tools can require() from project root")
 end
-test_add_tool_override_lua_overrides_builtin()
+test_skill_tool_requires_project_module()
 
-local function test_add_tool_override_lua_invalid()
-  local tool_dir = fs.join(TEST_TMPDIR, "override_invalid_lua")
-  fs.makedirs(tool_dir)
-
-  -- Invalid tool (missing required fields)
-  local tool_path = fs.join(tool_dir, "bad.lua")
-  cio.barf(tool_path, "return {}")
-
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  local defs_before = #tools.get_tool_definitions()
-
-  -- Should warn but not crash
-  tools.add_tool_override("bad", tool_path)
-
-  local defs_after = #tools.get_tool_definitions()
-  assert(defs_before == defs_after, "invalid lua tool should not be added")
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override skips invalid .lua files")
-end
-test_add_tool_override_lua_invalid()
-
-local function test_add_tool_override_lua_nonexistent()
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  local defs_before = #tools.get_tool_definitions()
-
-  -- Should warn but not crash
-  tools.add_tool_override("ghost", fs.join(TEST_TMPDIR, "no-such-file.lua"))
-
-  local defs_after = #tools.get_tool_definitions()
-  assert(defs_before == defs_after, "nonexistent .lua file should not add a tool")
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override handles nonexistent .lua file")
-end
-test_add_tool_override_lua_nonexistent()
-
--- Test that lua tools can require sibling lua modules
-local function test_lua_tool_require_lua()
-  local tool_dir = fs.join(TEST_TMPDIR, "lua_require_lua")
-  fs.makedirs(tool_dir)
-
-  -- Helper module
-  cio.barf(fs.join(tool_dir, "helper.lua"), [[
-return { greet = function(name) return "hello, " .. name end }
-]])
-
-  -- Tool that requires the helper
-  cio.barf(fs.join(tool_dir, "greeter.lua"), [[
-local helper = require("helper")
-return {
-  name = "greeter",
-  description = "Greet with helper",
-  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}},
-  execute = function(input)
-    return helper.greet(input.name), false
-  end,
-}
-]])
-
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-  assert(#loaded == 1, "should load 1 tool (helper is not a valid tool): " .. tostring(#loaded))
-  assert(loaded[1].name == "greeter", "should load greeter tool")
-
-  local result, is_error = loaded[1].execute({name = "world"})
-  assert(not is_error, "greeter should succeed: " .. tostring(result))
-  assert(result == "hello, world", "should use helper module: " .. result)
-
-  -- Clean up package.loaded to avoid interference
-  package.loaded["helper"] = nil
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ lua tool can require sibling lua module")
-end
-test_lua_tool_require_lua()
-
--- Test that teal tools can require sibling teal modules
-local function test_teal_tool_require_teal()
-  local tool_dir = fs.join(TEST_TMPDIR, "tl_require_tl")
-  fs.makedirs(tool_dir)
-
-  -- Helper teal module
-  cio.barf(fs.join(tool_dir, "tl_helper.tl"), [[
-local record M
-  greet: function(string): string
-end
-
-function M.greet(name: string): string
-  return "hi, " .. name
-end
-
-return M
-]])
-
-  -- Tool that requires the teal helper
-  cio.barf(fs.join(tool_dir, "tl_greeter.tl"), [[
-local helper = require("tl_helper")
-return {
-  name = "tl_greeter",
-  description = "Greet with teal helper",
-  input_schema = {type = "object", properties = {name = {type = "string"}}, required = {"name"}},
-  execute = function(input: {string:any}): string, boolean
-    local who = input.name as string
-    return helper.greet(who), false
-  end,
-}
-]])
-
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-
-  -- Find the greeter tool (helper is also a valid load target but not a tool)
-  local greeter: tools.Tool = nil
-  for _, t in ipairs(loaded) do
-    if t.name == "tl_greeter" then greeter = t end
-  end
-  assert(greeter, "should load tl_greeter tool")
-
-  local result, is_error = greeter.execute({name = "teal"})
-  assert(not is_error, "tl_greeter should succeed: " .. tostring(result))
-  assert(result == "hi, teal", "should use teal helper module: " .. result)
-
-  -- Clean up
-  package.loaded["tl_helper"] = nil
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ teal tool can require sibling teal module")
-end
-test_teal_tool_require_teal()
-
--- Test that add_tool_override enables sibling requires
 local function test_add_tool_override_require()
   local tool_dir = fs.join(TEST_TMPDIR, "override_require")
   fs.makedirs(tool_dir)
-
-  -- Helper module
-  cio.barf(fs.join(tool_dir, "ovr_helper.lua"), [[
-return { msg = function() return "from-helper" end }
-]])
-
-  -- Tool that requires the helper
-  local tool_path = fs.join(tool_dir, "ovr_tool.lua")
-  cio.barf(tool_path, [[
+  cio.barf(fs.join(tool_dir, "ovr_helper.lua"), [[return { msg = function() return "from-helper" end }]])
+  cio.barf(fs.join(tool_dir, "ovr_tool.lua"), [[
 local ovr_helper = require("ovr_helper")
-return {
-  name = "ovr_tool",
-  description = "Override tool with require",
+return { name = "ovr_tool", description = "Override tool with require",
   input_schema = {type = "object", properties = {}, required = {}},
-  execute = function()
-    return ovr_helper.msg(), false
-  end,
-}
+  execute = function() return ovr_helper.msg(), false end }
 ]])
-
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  tools.add_tool_override("ovr_tool", tool_path)
-
+  tools.add_tool_override("ovr_tool", fs.join(tool_dir, "ovr_tool.lua"))
   local result, is_error = tools.execute_tool("ovr_tool", {})
-  assert(not is_error, "override tool should succeed: " .. tostring(result))
-  assert(result == "from-helper", "should use helper via require: " .. result)
-
-  -- Clean up
+  assert(not is_error, "override tool should succeed")
+  assert(result == "from-helper", "should use helper via require")
   package.loaded["ovr_helper"] = nil
-
-  -- Reset
   tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
   print("✓ add_tool_override enables sibling requires")
 end
 test_add_tool_override_require()
-
--- Test that skill tools can require() modules from the project root (cwd)
--- Regression: load_skill_tools did not add cwd to package.path, so
--- skill tools that require("lib.foo") failed to resolve (issue #361)
-local function test_skill_tool_requires_project_module()
-  -- Set up a fake project with a shared lib and a skill tool that requires it
-  local project = fs.join(TEST_TMPDIR, "skill_cwd_require")
-  local lib_dir = fs.join(project, "lib")
-  local skill_dir = fs.join(project, "skills", "myskill")
-  local skill_tools = fs.join(skill_dir, "tools")
-  fs.makedirs(lib_dir)
-  fs.makedirs(skill_tools)
-
-  -- Shared library at lib/shared.lua
-  cio.barf(fs.join(lib_dir, "shared.lua"), [[
-return { value = function() return "from-shared-lib" end }
-]])
-
-  -- Skill tool that requires "lib.shared" (needs cwd in package.path)
-  cio.barf(fs.join(skill_tools, "myskill.lua"), [[
-local shared = require("lib.shared")
-return {
-  name = "myskill",
-  description = "Skill tool that uses shared lib",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function()
-    return shared.value(), false
-  end,
-}
-]])
-
-  -- init with this project as cwd, then load skill tools
-  tools.init_custom_tools(project)
-
-  -- Save and change to project dir so fs.getcwd() returns it
-  local orig_dir = fs.getcwd()
-  fs.chdir(project)
-
-  tools.load_skill_tools(skill_dir)
-
-  -- Restore cwd
-  fs.chdir(orig_dir)
-
-  -- The skill tool should be loaded and functional
-  local result, is_error = tools.execute_tool("myskill", {})
-  assert(not is_error, "skill tool should load and execute: " .. tostring(result))
-  assert(result == "from-shared-lib", "skill tool should require project module: " .. result)
-
-  -- Clean up
-  package.loaded["lib.shared"] = nil
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ skill tools can require() modules from project root (cwd)")
-end
-test_skill_tool_requires_project_module()
-
--- Test that .tl skill tools can require() .tl modules from project root (cwd)
--- Regression: tl.loader() was never called, so the teal package searcher
--- was not installed and require() only searched for .lua files (issue #364)
-local function test_tl_skill_tool_requires_tl_module()
-  local project = fs.join(TEST_TMPDIR, "tl_skill_cwd_require")
-  local lib_dir = fs.join(project, "lib")
-  local skill_dir = fs.join(project, "skills", "tskill")
-  local skill_tools = fs.join(skill_dir, "tools")
-  fs.makedirs(lib_dir)
-  fs.makedirs(skill_tools)
-
-  -- Shared teal library at lib/tl_shared.tl
-  cio.barf(fs.join(lib_dir, "tl_shared.tl"), [[
-local record M
-  value: function(): string
-end
-
-function M.value(): string
-  return "from-tl-shared-lib"
-end
-
-return M
-]])
-
-  -- Skill tool (.tl) that requires "lib.tl_shared"
-  cio.barf(fs.join(skill_tools, "tskill.tl"), [[
-local shared = require("lib.tl_shared")
-return {
-  name = "tskill",
-  description = "Teal skill tool that uses teal shared lib",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function(): string, boolean
-    return shared.value(), false
-  end,
-}
-]])
-
-  -- init with this project as cwd, then load skill tools
-  tools.init_custom_tools(project)
-
-  local orig_dir = fs.getcwd()
-  fs.chdir(project)
-
-  tools.load_skill_tools(skill_dir)
-
-  fs.chdir(orig_dir)
-
-  -- The .tl skill tool should be loaded and functional
-  local result, is_error = tools.execute_tool("tskill", {})
-  assert(not is_error, "tl skill tool should load and execute: " .. tostring(result))
-  assert(result == "from-tl-shared-lib", "tl skill tool should require tl project module: " .. result)
-
-  -- Clean up
-  package.loaded["lib.tl_shared"] = nil
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ .tl skill tools can require() .tl modules from project root (cwd)")
-end
-test_tl_skill_tool_requires_tl_module()
-
--- Tests for looks_like_tool AST guard (issue #408)
-
-local function test_looks_like_tool_valid_lua()
-  local source = [[
-return {
-  name = "foo",
-  description = "A test tool",
-  input_schema = {type = "object", properties = {}},
-  execute = function() return "ok", false end,
-}
-]]
-  assert(tools.looks_like_tool(source, true), "valid lua tool should pass")
-  print("✓ looks_like_tool accepts valid lua tool")
-end
-test_looks_like_tool_valid_lua()
-
-local function test_looks_like_tool_valid_teal()
-  local source = [[
-return {
-  name = "greet",
-  description = "test",
-  input_schema = {type = "object", properties = {}},
-  execute = function(input: {string:any}): string, boolean
-    return "ok", false
-  end,
-}
-]]
-  assert(tools.looks_like_tool(source, false), "valid teal tool should pass")
-  print("✓ looks_like_tool accepts valid teal tool")
-end
-test_looks_like_tool_valid_teal()
-
-local function test_looks_like_tool_os_exit()
-  local source = "os.exit(0)"
-  assert(not tools.looks_like_tool(source, true), "os.exit() script should be rejected")
-  print("✓ looks_like_tool rejects os.exit() script")
-end
-test_looks_like_tool_os_exit()
-
-local function test_looks_like_tool_no_return()
-  local source = "print('hello')"
-  assert(not tools.looks_like_tool(source, true), "script without return should be rejected")
-  print("✓ looks_like_tool rejects script without return")
-end
-test_looks_like_tool_no_return()
-
-local function test_looks_like_tool_empty()
-  assert(not tools.looks_like_tool("", true), "empty source should be rejected")
-  print("✓ looks_like_tool rejects empty source")
-end
-test_looks_like_tool_empty()
-
-local function test_looks_like_tool_syntax_error()
-  assert(not tools.looks_like_tool("invalid !!!", true), "syntax error should be rejected")
-  print("✓ looks_like_tool rejects syntax errors")
-end
-test_looks_like_tool_syntax_error()
-
-local function test_looks_like_tool_missing_name()
-  local source = [[
-return {
-  description = "no name",
-  execute = function() end,
-}
-]]
-  assert(not tools.looks_like_tool(source, true), "table missing name should be rejected")
-  print("✓ looks_like_tool rejects table missing name key")
-end
-test_looks_like_tool_missing_name()
-
-local function test_looks_like_tool_missing_execute()
-  local source = [[
-return {
-  name = "foo",
-  description = "no execute",
-}
-]]
-  assert(not tools.looks_like_tool(source, true), "table missing execute should be rejected")
-  print("✓ looks_like_tool rejects table missing execute key")
-end
-test_looks_like_tool_missing_execute()
-
-local function test_looks_like_tool_variable_return()
-  -- Returns a variable — can't statically verify, should pass optimistically
-  local source = "local t = {} ; t.name = 'foo' ; return t"
-  assert(tools.looks_like_tool(source, true), "variable return should pass optimistically")
-  print("✓ looks_like_tool accepts variable return optimistically")
-end
-test_looks_like_tool_variable_return()
-
-local function test_looks_like_tool_function_call_return()
-  -- Returns a function call — can't statically verify, should pass optimistically
-  local source = "return require('foo').make_tool()"
-  assert(tools.looks_like_tool(source, true), "function call return should pass optimistically")
-  print("✓ looks_like_tool accepts function call return optimistically")
-end
-test_looks_like_tool_function_call_return()
-
-local function test_looks_like_tool_return_nil()
-  local source = "return nil"
-  -- nil return is a variable-like expression, passes optimistically
-  -- is_valid_tool will catch it at runtime
-  assert(tools.looks_like_tool(source, true), "return nil should pass optimistically")
-  print("✓ looks_like_tool accepts return nil optimistically")
-end
-test_looks_like_tool_return_nil()
-
--- Integration test: os.exit() in tools dir is skipped without killing process
-local function test_os_exit_in_tools_dir_skipped()
-  local tool_dir = fs.join(TEST_TMPDIR, "os_exit_tools")
-  fs.makedirs(tool_dir)
-
-  -- This would kill the process if evaluated
-  cio.barf(fs.join(tool_dir, "killer.lua"), "os.exit(1)")
-
-  -- A valid tool alongside it
-  cio.barf(fs.join(tool_dir, "safe.lua"), [[
-return {
-  name = "safe",
-  description = "Safe tool",
-  input_schema = {type = "object", properties = {}, required = {}},
-  execute = function() return "safe", false end,
-}
-]])
-
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-  assert(#loaded == 1, "should load only the safe tool, got: " .. tostring(#loaded))
-  assert(loaded[1].name == "safe", "should load safe tool")
-  print("✓ os.exit() script in tools dir is skipped without killing process")
-end
-test_os_exit_in_tools_dir_skipped()
-
--- Integration test: os.exit() in teal file is skipped
-local function test_os_exit_teal_skipped()
-  local tool_dir = fs.join(TEST_TMPDIR, "os_exit_teal")
-  fs.makedirs(tool_dir)
-
-  cio.barf(fs.join(tool_dir, "killer.tl"), "os.exit(1)")
-
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-  assert(#loaded == 0, "os.exit teal file should be skipped")
-  print("✓ os.exit() in .tl file is skipped without killing process")
-end
-test_os_exit_teal_skipped()
-
--- Integration test: add_tool_override guards against os.exit()
-local function test_override_os_exit_guarded()
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  local defs_before = #tools.get_tool_definitions()
-
-  local tool_dir = fs.join(TEST_TMPDIR, "override_os_exit")
-  fs.makedirs(tool_dir)
-  local bad_path = fs.join(tool_dir, "bad.lua")
-  cio.barf(bad_path, "os.exit(1)")
-
-  tools.add_tool_override("bad", bad_path)
-
-  local defs_after = #tools.get_tool_definitions()
-  assert(defs_before == defs_after, "os.exit override should not be added")
-
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override guards against os.exit() script")
-end
-test_override_os_exit_guarded()
-
--- Tests for graceful handling of tools that fail to load (issue #321)
-
-local function test_teal_syntax_error_skipped()
-  -- A .tl file with invalid syntax should be skipped, not crash
-  local tool_dir = fs.join(TEST_TMPDIR, "teal_syntax_error")
-  fs.makedirs(tool_dir)
-
-  cio.barf(fs.join(tool_dir, "broken.tl"), "invalid syntax !!!")
-
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-  assert(#loaded == 0, "broken .tl should be skipped, loaded: " .. tostring(#loaded))
-  print("✓ .tl file with syntax error is skipped without crash")
-end
-test_teal_syntax_error_skipped()
-
-local function test_lua_load_error_skipped()
-  -- A .lua file with invalid syntax should be skipped, not crash
-  local tool_dir = fs.join(TEST_TMPDIR, "lua_load_error")
-  fs.makedirs(tool_dir)
-
-  cio.barf(fs.join(tool_dir, "broken.lua"), "this is not lua !!!")
-
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-  assert(#loaded == 0, "broken .lua should be skipped, loaded: " .. tostring(#loaded))
-  print("✓ .lua file with load error is skipped without crash")
-end
-test_lua_load_error_skipped()
-
-local function test_teal_runtime_error_at_load_skipped()
-  -- A .tl file that throws at module-level execution should be skipped
-  local tool_dir = fs.join(TEST_TMPDIR, "teal_runtime_error")
-  fs.makedirs(tool_dir)
-
-  cio.barf(fs.join(tool_dir, "throws.tl"), [[
--- valid teal that throws at module level
-error("boom at load time")
-]])
-
-  local loaded = tools.load_custom_tools_from_dir(tool_dir)
-  assert(#loaded == 0, ".tl that throws at load should be skipped, loaded: " .. tostring(#loaded))
-  print("✓ .tl file that throws at module level is skipped without crash")
-end
-test_teal_runtime_error_at_load_skipped()
-
-local function test_add_tool_override_teal_syntax_error()
-  -- add_tool_override with a broken .tl file should warn but not crash
-  local tool_dir = fs.join(TEST_TMPDIR, "override_teal_syntax_error")
-  fs.makedirs(tool_dir)
-
-  local broken_path = fs.join(tool_dir, "broken.tl")
-  cio.barf(broken_path, "invalid syntax !!!")
-
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  local defs_before = #tools.get_tool_definitions()
-
-  -- Should warn but not crash
-  tools.add_tool_override("broken", broken_path)
-
-  local defs_after = #tools.get_tool_definitions()
-  assert(defs_before == defs_after, "broken .tl override should not add a tool")
-
-  -- Reset
-  tools.init_custom_tools(fs.join(TEST_TMPDIR, "nonexistent"))
-  print("✓ add_tool_override skips .tl file with syntax error without crash")
-end
-test_add_tool_override_teal_syntax_error()
 
 print("\nAll tools tests passed!")

--- a/lib/ah/toolload.tl
+++ b/lib/ah/toolload.tl
@@ -1,0 +1,191 @@
+-- ah/toolload.tl: tool file loading, AST validation, and directory scanning
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+
+-- Validate that a loaded module is a valid tool
+local function is_valid_tool(t: any): boolean
+  if type(t) ~= "table" then return false end
+  local tool = t as {string: any}
+  if type(tool.name) ~= "string" then return false end
+  if type(tool.description) ~= "string" then return false end
+  if type(tool.input_schema) ~= "table" then return false end
+  if type(tool.execute) ~= "function" then return false end
+  return true
+end
+
+-- Add a directory to package.path if not already present.
+-- This enables require() for sibling .lua and .tl modules in the same directory.
+-- The teal package searcher automatically substitutes .lua with .tl in package.path,
+-- so adding dir/?.lua covers both lua and teal requires.
+local function add_to_package_path(dir: string)
+  local pattern = dir .. "/?.lua"
+  if not package.path:find(pattern, 1, true) then
+    package.path = pattern .. ";" .. dir .. "/?/init.lua;" .. package.path
+  end
+end
+
+-- Track whether the teal package searcher has been installed.
+-- tl.loader() registers a searcher in package.searchers so that
+-- require() inside .tl files can find other .tl modules.
+local tl_searcher_installed = false
+
+-- Ensure the tl package searcher is installed. Called before any tl.load()
+-- or tl.process_string() usage.
+local function ensure_tl_searcher(): {string: any}
+  local tl = require("tl") as {string: any}
+  if not tl_searcher_installed then
+    local tl_loader = tl.loader as function()
+    tl_loader()
+    tl_searcher_installed = true
+  end
+  return tl
+end
+
+-- Check whether source code looks like a tool module by parsing the AST
+-- without evaluating it. This guards against os.exit() and other dangerous
+-- top-level side effects in files that aren't tool modules.
+--
+-- Returns true if the file could be a tool module, false if it definitely
+-- is not (wrong shape). Conservative: returns true for variable/call returns
+-- that can't be statically verified — is_valid_tool catches those at runtime.
+local function looks_like_tool(source: string, is_lua: boolean): boolean
+  local tl = ensure_tl_searcher()
+  local process_string = tl.process_string as function(string, boolean): {string: any}
+  local result = process_string(source, is_lua)
+
+  if result.syntax_errors and #(result.syntax_errors as {any}) > 0 then
+    return false
+  end
+
+  local ast = result.ast as {any}
+  if not ast or #ast == 0 then
+    return false
+  end
+
+  local last = ast[#ast] as {string: any}
+  if not last or last.kind ~= "return" then
+    return false
+  end
+
+  -- Check if the return expression is a literal table with name + execute keys
+  local exps = last.exps as {any}
+  if exps and #exps > 0 then
+    local ret = exps[1] as {string: any}
+    if ret.kind == "literal_table" then
+      local keys: {string: boolean} = {}
+      for _, entry in ipairs(ret as {any}) do
+        local e = entry as {string: any}
+        if e.key then
+          local key = e.key as {string: any}
+          local k = (key.conststr or key.tk) as string
+          if k then keys[k] = true end
+        end
+      end
+      return (keys["name"] and keys["execute"]) as boolean
+    end
+  end
+
+  -- Returns a variable or function call — can't verify statically.
+  -- Let is_valid_tool catch bad shapes at runtime.
+  return true
+end
+
+-- Load a tool module from a .tl or .lua file.
+-- Returns the loaded chunk or nil + error string.
+local function load_tool_file(tool_path: string): any, string
+  if tool_path:match("%.tl$") then
+    local content = cio.slurp(tool_path)
+    if not content then
+      return nil, "failed to read file"
+    end
+    local tl = ensure_tl_searcher()
+    local loader = tl.load as function(string): any, string
+    return loader(content)
+  end
+  local loader = loadfile as function(string): any, string
+  return loader(tool_path)
+end
+
+-- Tool record (re-declared here to avoid circular dependency with tools.tl)
+local record Tool
+  name: string
+  description: string
+  input_schema: {string: any}
+  system_prompt: string
+  running_processes: {integer: any}
+  execute: function(input: {string: any}): string, boolean, any
+end
+
+-- Load lua/teal module tools from a directory.
+-- .tl files take precedence over .lua files with the same basename.
+local function load_custom_tools_from_dir(dir: string): {Tool}
+  local loaded: {Tool} = {}
+
+  local dh = fs.opendir(dir)
+  if not dh then return loaded end
+
+  -- Collect candidate files, .tl overrides .lua by basename
+  local candidates: {string: string} = {} -- basename -> path
+  while true do
+    local name = dh:read()
+    if not name then break end
+
+    if name:match("%.tl$") and not name:match("%.d%.tl$") then
+      local base = name:sub(1, -4)
+      candidates[base] = fs.join(dir, name)
+    elseif name:match("%.lua$") then
+      local base = name:sub(1, -5)
+      if not candidates[base] or not (candidates[base]):match("%.tl$") then
+        candidates[base] = fs.join(dir, name)
+      end
+    end
+  end
+  dh:close()
+
+  -- Add directory to package.path so tools can require sibling modules
+  local has_candidates = false
+  for _ in pairs(candidates) do has_candidates = true; break end
+  if has_candidates then
+    add_to_package_path(dir)
+  end
+
+  for _, tool_path in pairs(candidates) do
+    -- Read source and check AST before evaluating — guards against os.exit()
+    -- and other dangerous side effects in non-tool files.
+    local source = cio.slurp(tool_path)
+    if not source then
+      io.stderr:write(string.format("warning: failed to read %s\n", tool_path))
+    elseif not looks_like_tool(source, tool_path:match("%.lua$") ~= nil) then
+      io.stderr:write(string.format("warning: skipping %s: does not look like a tool module\n", tool_path))
+    else
+      local load_ok, chunk, load_err = pcall(load_tool_file, tool_path)
+      if not load_ok then
+        -- chunk holds the thrown error message when pcall catches a throw
+        io.stderr:write(string.format("warning: failed to load %s: %s\n", tool_path, tostring(chunk)))
+      elseif chunk then
+        local ok, result = pcall(chunk as function(): any)
+        if ok and is_valid_tool(result) then
+          table.insert(loaded, result as Tool)
+        elseif not ok then
+          io.stderr:write(string.format("warning: failed to execute %s: %s\n", tool_path, tostring(result)))
+        else
+          io.stderr:write(string.format("warning: invalid tool format in %s\n", tool_path))
+        end
+      else
+        io.stderr:write(string.format("warning: failed to load %s: %s\n", tool_path, tostring(load_err)))
+      end
+    end
+  end
+
+  return loaded
+end
+
+return {
+  is_valid_tool = is_valid_tool,
+  add_to_package_path = add_to_package_path,
+  ensure_tl_searcher = ensure_tl_searcher,
+  looks_like_tool = looks_like_tool,
+  load_tool_file = load_tool_file,
+  load_custom_tools_from_dir = load_custom_tools_from_dir,
+  Tool = Tool,
+}

--- a/lib/ah/tools.tl
+++ b/lib/ah/tools.tl
@@ -1,9 +1,10 @@
--- ah/tools.tl: tool loading, dispatch, and prompt generation
+-- ah/tools.tl: tool dispatch, initialization, and prompt generation
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local child = require("cosmic.child")
 local signal = require("cosmic.signal")
 local time = require("cosmic.time")
+local toolload = require("ah.toolload")
 
 local record ToolDetails
   path: string
@@ -30,178 +31,10 @@ end
 -- All tools loaded at runtime (system + embed + project)
 local tools: {Tool} = {}
 
--- Validate that a loaded module is a valid tool
-local function is_valid_tool(t: any): boolean
-  if type(t) ~= "table" then return false end
-  local tool = t as {string: any}
-  if type(tool.name) ~= "string" then return false end
-  if type(tool.description) ~= "string" then return false end
-  if type(tool.input_schema) ~= "table" then return false end
-  if type(tool.execute) ~= "function" then return false end
-  return true
-end
-
--- Add a directory to package.path if not already present.
--- This enables require() for sibling .lua and .tl modules in the same directory.
--- The teal package searcher automatically substitutes .lua with .tl in package.path,
--- so adding dir/?.lua covers both lua and teal requires.
-local function add_to_package_path(dir: string)
-  local pattern = dir .. "/?.lua"
-  if not package.path:find(pattern, 1, true) then
-    package.path = pattern .. ";" .. dir .. "/?/init.lua;" .. package.path
-  end
-end
-
--- Track whether the teal package searcher has been installed.
--- tl.loader() registers a searcher in package.searchers so that
--- require() inside .tl files can find other .tl modules.
-local tl_searcher_installed = false
-
--- Ensure the tl package searcher is installed. Called before any tl.load()
--- or tl.process_string() usage.
-local function ensure_tl_searcher(): {string: any}
-  local tl = require("tl") as {string: any}
-  if not tl_searcher_installed then
-    local tl_loader = tl.loader as function()
-    tl_loader()
-    tl_searcher_installed = true
-  end
-  return tl
-end
-
--- Check whether source code looks like a tool module by parsing the AST
--- without evaluating it. This guards against os.exit() and other dangerous
--- top-level side effects in files that aren't tool modules.
---
--- Returns true if the file could be a tool module, false if it definitely
--- is not (wrong shape). Conservative: returns true for variable/call returns
--- that can't be statically verified — is_valid_tool catches those at runtime.
-local function looks_like_tool(source: string, is_lua: boolean): boolean
-  local tl = ensure_tl_searcher()
-  local process_string = tl.process_string as function(string, boolean): {string: any}
-  local result = process_string(source, is_lua)
-
-  if result.syntax_errors and #(result.syntax_errors as {any}) > 0 then
-    return false
-  end
-
-  local ast = result.ast as {any}
-  if not ast or #ast == 0 then
-    return false
-  end
-
-  local last = ast[#ast] as {string: any}
-  if not last or last.kind ~= "return" then
-    return false
-  end
-
-  -- Check if the return expression is a literal table with name + execute keys
-  local exps = last.exps as {any}
-  if exps and #exps > 0 then
-    local ret = exps[1] as {string: any}
-    if ret.kind == "literal_table" then
-      local keys: {string: boolean} = {}
-      for _, entry in ipairs(ret as {any}) do
-        local e = entry as {string: any}
-        if e.key then
-          local key = e.key as {string: any}
-          local k = (key.conststr or key.tk) as string
-          if k then keys[k] = true end
-        end
-      end
-      return (keys["name"] and keys["execute"]) as boolean
-    end
-  end
-
-  -- Returns a variable or function call — can't verify statically.
-  -- Let is_valid_tool catch bad shapes at runtime.
-  return true
-end
-
--- Load a tool module from a .tl or .lua file.
--- Returns the loaded chunk or nil + error string.
-local function load_tool_file(tool_path: string): any, string
-  if tool_path:match("%.tl$") then
-    local content = cio.slurp(tool_path)
-    if not content then
-      return nil, "failed to read file"
-    end
-    local tl = ensure_tl_searcher()
-    local loader = tl.load as function(string): any, string
-    return loader(content)
-  end
-  local loader = loadfile as function(string): any, string
-  return loader(tool_path)
-end
-
--- Load lua/teal module tools from a directory.
--- .tl files take precedence over .lua files with the same basename.
-local function load_custom_tools_from_dir(dir: string): {Tool}
-  local loaded: {Tool} = {}
-
-  local dh = fs.opendir(dir)
-  if not dh then return loaded end
-
-  -- Collect candidate files, .tl overrides .lua by basename
-  local candidates: {string: string} = {} -- basename -> path
-  while true do
-    local name = dh:read()
-    if not name then break end
-
-    if name:match("%.tl$") and not name:match("%.d%.tl$") then
-      local base = name:sub(1, -4)
-      candidates[base] = fs.join(dir, name)
-    elseif name:match("%.lua$") then
-      local base = name:sub(1, -5)
-      if not candidates[base] or not (candidates[base]):match("%.tl$") then
-        candidates[base] = fs.join(dir, name)
-      end
-    end
-  end
-  dh:close()
-
-  -- Add directory to package.path so tools can require sibling modules
-  local has_candidates = false
-  for _ in pairs(candidates) do has_candidates = true; break end
-  if has_candidates then
-    add_to_package_path(dir)
-  end
-
-  for _, tool_path in pairs(candidates) do
-    -- Read source and check AST before evaluating — guards against os.exit()
-    -- and other dangerous side effects in non-tool files.
-    local source = cio.slurp(tool_path)
-    if not source then
-      io.stderr:write(string.format("warning: failed to read %s\n", tool_path))
-    elseif not looks_like_tool(source, tool_path:match("%.lua$") ~= nil) then
-      io.stderr:write(string.format("warning: skipping %s: does not look like a tool module\n", tool_path))
-    else
-      local load_ok, chunk, load_err = pcall(load_tool_file, tool_path)
-      if not load_ok then
-        -- chunk holds the thrown error message when pcall catches a throw
-        io.stderr:write(string.format("warning: failed to load %s: %s\n", tool_path, tostring(chunk)))
-      elseif chunk then
-        local ok, result = pcall(chunk as function(): any)
-        if ok and is_valid_tool(result) then
-          table.insert(loaded, result as Tool)
-        elseif not ok then
-          io.stderr:write(string.format("warning: failed to execute %s: %s\n", tool_path, tostring(result)))
-        else
-          io.stderr:write(string.format("warning: invalid tool format in %s\n", tool_path))
-        end
-      else
-        io.stderr:write(string.format("warning: failed to load %s: %s\n", tool_path, tostring(load_err)))
-      end
-    end
-  end
-
-  return loaded
-end
-
 -- Merge tools into a name-indexed map (later calls override earlier)
-local function merge_tools(by_name: {string: Tool}, new_tools: {Tool})
+local function merge_tools(by_name: {string: Tool}, new_tools: {toolload.Tool})
   for _, tool in ipairs(new_tools) do
-    by_name[tool.name] = tool
+    by_name[tool.name] = tool as Tool
   end
 end
 
@@ -216,14 +49,14 @@ local function init_custom_tools(cwd?: string)
   local by_name: {string: Tool} = {}
 
   -- System tier: try embedded path first, fall back to compiled source for dev/test
-  local sys_tools = load_custom_tools_from_dir("/zip/embed/sys/tools")
+  local sys_tools = toolload.load_custom_tools_from_dir("/zip/embed/sys/tools")
   if #sys_tools == 0 then
-    sys_tools = load_custom_tools_from_dir("o/sys/tools")
+    sys_tools = toolload.load_custom_tools_from_dir("o/sys/tools")
   end
   merge_tools(by_name, sys_tools)
 
   -- Embed tier: lua modules
-  merge_tools(by_name, load_custom_tools_from_dir("/zip/embed/tools"))
+  merge_tools(by_name, toolload.load_custom_tools_from_dir("/zip/embed/tools"))
 
   -- Project tier: .ah/tools wins over tools/ if present
   local dot_ah_tools = fs.join(cwd, ".ah", "tools")
@@ -236,7 +69,7 @@ local function init_custom_tools(cwd?: string)
   else
     project_tools_dir = bare_tools
   end
-  merge_tools(by_name, load_custom_tools_from_dir(project_tools_dir))
+  merge_tools(by_name, toolload.load_custom_tools_from_dir(project_tools_dir))
 
   tools = {}
   for _, tool in pairs(by_name) do
@@ -256,7 +89,7 @@ local function load_skill_tools(base_dir: string)
 
   -- Ensure project root is in package.path so skill tools
   -- can require() shared modules (e.g. "lib.mcp")
-  add_to_package_path((fs.getcwd()))
+  toolload.add_to_package_path((fs.getcwd()))
 
   -- Build name index of current tools
   local by_name: {string: Tool} = {}
@@ -265,7 +98,7 @@ local function load_skill_tools(base_dir: string)
   end
 
   -- Load module tools (.tl/.lua)
-  merge_tools(by_name, load_custom_tools_from_dir(tools_dir))
+  merge_tools(by_name, toolload.load_custom_tools_from_dir(tools_dir))
 
   tools = {}
   for _, tool in pairs(by_name) do
@@ -284,7 +117,7 @@ local function add_tool_override(name: string, cmd: string)
 
   -- Add tool's directory to package.path for sibling requires
   local dir = cmd:match("^(.+)/[^/]+$") or "."
-  add_to_package_path(dir)
+  toolload.add_to_package_path(dir)
 
   -- Read source and check AST before evaluating — guards against os.exit()
   local source = cio.slurp(cmd)
@@ -292,14 +125,13 @@ local function add_tool_override(name: string, cmd: string)
     io.stderr:write(string.format("warning: failed to read tool %s from %s\n", name, cmd))
     return
   end
-  if not looks_like_tool(source, cmd:match("%.lua$") ~= nil) then
+  if not toolload.looks_like_tool(source, cmd:match("%.lua$") ~= nil) then
     io.stderr:write(string.format("warning: skipping tool %s from %s: does not look like a tool module\n", name, cmd))
     return
   end
 
-  local load_ok, chunk, load_err = pcall(load_tool_file, cmd)
+  local load_ok, chunk, load_err = pcall(toolload.load_tool_file, cmd)
   if not load_ok then
-    -- chunk holds the thrown error message when pcall catches a throw
     io.stderr:write(string.format("warning: failed to load tool %s from %s: %s\n", name, cmd, tostring(chunk)))
     return
   end
@@ -312,7 +144,7 @@ local function add_tool_override(name: string, cmd: string)
     io.stderr:write(string.format("warning: failed to execute tool %s from %s: %s\n", name, cmd, tostring(result)))
     return
   end
-  if not is_valid_tool(result) then
+  if not toolload.is_valid_tool(result) then
     io.stderr:write(string.format("warning: invalid tool format in %s\n", cmd))
     return
   end
@@ -574,9 +406,9 @@ return {
   load_skill_tools = load_skill_tools,
   add_tool_override = add_tool_override,
   remove_tool = remove_tool,
-  load_custom_tools_from_dir = load_custom_tools_from_dir,
-  is_valid_tool = is_valid_tool,
-  looks_like_tool = looks_like_tool,
+  load_custom_tools_from_dir = toolload.load_custom_tools_from_dir,
+  is_valid_tool = toolload.is_valid_tool,
+  looks_like_tool = toolload.looks_like_tool,
   Tool = Tool,
   ToolDetails = ToolDetails,
 }


### PR DESCRIPTION
Extract focused modules from init.tl, loop.tl, tools.tl, and db.tl to reduce file size and improve maintainability.

## New modules

| module | extracted from | responsibility |
|--------|---------------|----------------|
| args.tl | init.tl | CLI argument parsing |
| cli.tl | init.tl | CLI display handler, output formatting |
| prompt.tl | init.tl | system prompt loading, git context |
| sessions.tl | init.tl | session listing, resolution |
| looptool.tl | loop.tl | tool dispatch within agent loop |
| looputil.tl | loop.tl | loop utilities and helpers |
| toolload.tl | tools.tl | tool file loading, directory scanning |

## Test files split correspondingly

- test_args.tl (from test_init.tl)
- test_cli.tl (from test_init.tl)
- test_toolload.tl (from test_tools.tl)

## Additional fixes

- Move TokenTotals record earlier in db.tl, inline get_db_path
- Fix json.encode multi-return leaking extra arg to db.log_event
- Fix type annotations in test_cli.tl and test_toolload.tl

## Stats

```
16 files changed, 2848 insertions(+), 4078 deletions(-)
```

Net reduction of ~1,230 lines. Large monolithic files (init.tl was 1100+ lines, loop.tl 690+, tools.tl 200+) are now split into focused, independently testable modules.