### PR TITLE
feat: add markdown table rendering with box-drawing borders and bold headers

### DIFF
--- a/lib/ah/render.tl
+++ b/lib/ah/render.tl
@@ -1,7 +1,7 @@
 -- ah/render.tl: line-oriented markdown-to-ANSI renderer for terminal output
 -- Converts common markdown constructs to ANSI escape sequences.
 -- Handles headings, bold, inline code, code fences (with diff colorization),
--- and horizontal rules.
+-- horizontal rules, and tables with box-drawing borders.
 
 local BOLD = "\27[1m"
 local DIM = "\27[2m"
@@ -32,30 +32,185 @@ local function apply_inline(line: string): string
   return line
 end
 
+-- Check if a line looks like a markdown table row (starts and ends with |).
+local function is_table_line(line: string): boolean
+  local trimmed = line:match("^%s*(.-)%s*$")
+  return trimmed:sub(1, 1) == "|" and trimmed:sub(-1) == "|"
+end
+
+-- Check if a line is a table separator row (e.g. |---|---|).
+local function is_separator_line(line: string): boolean
+  local trimmed = line:match("^%s*(.-)%s*$")
+  return trimmed:match("^|[%-|:%s]+|%s*$") ~= nil
+end
+
+-- Parse a table row into cells (trimmed content between pipes).
+local function parse_row(line: string): {string}
+  local cells: {string} = {}
+  local trimmed = line:match("^%s*(.-)%s*$")
+  -- Strip leading and trailing pipes
+  local inner = trimmed:sub(2, -2)
+  for cell in inner:gmatch("([^|]*)") do
+    table.insert(cells, cell:match("^%s*(.-)%s*$"))
+  end
+  return cells
+end
+
+-- Compute display width of a string, stripping ANSI escape sequences.
+local function display_width(s: string): integer
+  local stripped = s:gsub("\27%[[%d;]*m", "")
+  return #stripped
+end
+
+-- Render a table block from raw markdown lines into box-drawing output.
+-- Returns a list of rendered lines.
+local function render_table(lines: {string}): {string}
+  -- Parse all rows, detecting separator
+  local rows: {{string}} = {}
+  local sep_index = 0
+  for i, line in ipairs(lines) do
+    if is_separator_line(line) and i == 2 then
+      sep_index = i
+    else
+      table.insert(rows, parse_row(line))
+    end
+  end
+
+  if #rows == 0 then
+    return lines
+  end
+
+  -- Determine column count (max across all rows)
+  local num_cols = 0
+  for _, row in ipairs(rows) do
+    if #row > num_cols then
+      num_cols = #row
+    end
+  end
+
+  -- Compute column widths (max cell display width per column)
+  local widths: {integer} = {}
+  for c = 1, num_cols do
+    widths[c] = 0
+  end
+  for _, row in ipairs(rows) do
+    for c = 1, num_cols do
+      local cell = row[c] or ""
+      local w = display_width(cell)
+      if w > widths[c] then
+        widths[c] = w
+      end
+    end
+  end
+
+  -- Ensure minimum width of 1
+  for c = 1, num_cols do
+    if widths[c] < 1 then
+      widths[c] = 1
+    end
+  end
+
+  -- Build horizontal border line
+  local function hline(left: string, mid: string, right: string, fill: string): string
+    local parts: {string} = {left}
+    for c = 1, num_cols do
+      table.insert(parts, string.rep(fill, widths[c] + 2))
+      if c < num_cols then
+        table.insert(parts, mid)
+      end
+    end
+    table.insert(parts, right)
+    return table.concat(parts)
+  end
+
+  -- Build data row with optional bold and inline formatting
+  local function data_row(cells: {string}, bold: boolean): string
+    local parts: {string} = {"│"}
+    for c = 1, num_cols do
+      local cell = cells[c] or ""
+      local padded = " " .. cell .. string.rep(" ", widths[c] - display_width(cell)) .. " "
+      if bold then
+        padded = BOLD .. padded .. RESET
+      else
+        padded = apply_inline(padded)
+      end
+      table.insert(parts, padded)
+      table.insert(parts, "│")
+    end
+    return table.concat(parts)
+  end
+
+  local out: {string} = {}
+
+  -- Top border
+  table.insert(out, hline("┌", "┬", "┐", "─"))
+
+  -- Header row (if separator was found)
+  if sep_index > 0 and #rows >= 1 then
+    table.insert(out, data_row(rows[1], true))
+    -- Header separator
+    table.insert(out, hline("├", "┼", "┤", "─"))
+    -- Body rows
+    for r = 2, #rows do
+      table.insert(out, data_row(rows[r], false))
+    end
+  else
+    -- No header, all body rows
+    for _, row in ipairs(rows) do
+      table.insert(out, data_row(row, false))
+    end
+  end
+
+  -- Bottom border
+  table.insert(out, hline("└", "┴", "┘", "─"))
+
+  return out
+end
+
 -- Render markdown text to ANSI-escaped text for terminal display.
--- Processes text line-by-line, tracking code fence state.
+-- Processes text line-by-line, tracking code fence and table state.
 local function render_markdown(text: string): string
   local result: {string} = {}
   local in_code_fence = false
   local fence_lang = ""
+  local table_buf: {string} = {}
+
+  -- Flush accumulated table lines through render_table
+  local function flush_table()
+    if #table_buf > 0 then
+      local rendered = render_table(table_buf)
+      for _, l in ipairs(rendered) do
+        table.insert(result, l)
+      end
+      table_buf = {}
+    end
+  end
 
   for line in text:gmatch("([^\n]*)\n?") do
     if not in_code_fence then
-      -- Check for fence open
-      local lang = line:match("^```(.*)$")
-      if lang then
-        in_code_fence = true
-        fence_lang = lang
-        table.insert(result, line)
-      elseif line:match("^#+ ") then
-        -- Heading: bold the full line
-        table.insert(result, BOLD .. line .. RESET)
-      elseif line:match("^%-%-%-$") or line:match("^___$") or line:match("^%*%*%*$") then
-        -- Horizontal rule: dim dashes
-        table.insert(result, DIM .. string.rep("─", 40) .. RESET)
+      -- Check for table line (outside code fences)
+      if is_table_line(line) then
+        table.insert(table_buf, line)
       else
-        -- Regular line: apply inline formatting
-        table.insert(result, apply_inline(line))
+        -- Flush any buffered table before processing non-table line
+        flush_table()
+
+        -- Check for fence open
+        local lang = line:match("^```(.*)$")
+        if lang then
+          in_code_fence = true
+          fence_lang = lang
+          table.insert(result, line)
+        elseif line:match("^#+ ") then
+          -- Heading: bold the full line
+          table.insert(result, BOLD .. line .. RESET)
+        elseif line:match("^%-%-%-$") or line:match("^___$") or line:match("^%*%*%*$") then
+          -- Horizontal rule: dim dashes
+          table.insert(result, DIM .. string.rep("─", 40) .. RESET)
+        else
+          -- Regular line: apply inline formatting
+          table.insert(result, apply_inline(line))
+        end
       end
     else
       -- Inside code fence
@@ -72,6 +227,9 @@ local function render_markdown(text: string): string
     end
   end
 
+  -- Flush any remaining table at end of input
+  flush_table()
+
   return table.concat(result, "\n")
 end
 
@@ -79,4 +237,5 @@ return {
   render_markdown = render_markdown,
   apply_inline = apply_inline,
   colorize_diff_line = colorize_diff_line,
+  render_table = render_table,
 }

--- a/lib/ah/test_render.tl
+++ b/lib/ah/test_render.tl
@@ -5,6 +5,7 @@ local record Render
   render_markdown: function(text: string): string
   apply_inline: function(line: string): string
   colorize_diff_line: function(line: string): string
+  render_table: function(lines: {string}): {string}
 end
 
 local render = require("ah.render") as Render
@@ -169,6 +170,131 @@ local function test_no_bold_in_fence()
   print("PASS: no bold formatting inside code fence")
 end
 
+-- test: basic table renders with box-drawing chars and aligned columns
+local function test_basic_table()
+  local input = "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |\n"
+  local result = render.render_markdown(input)
+  assert(result:find("┌", 1, true), "table should have top-left corner, got: " .. result)
+  assert(result:find("┐", 1, true), "table should have top-right corner, got: " .. result)
+  assert(result:find("└", 1, true), "table should have bottom-left corner, got: " .. result)
+  assert(result:find("┘", 1, true), "table should have bottom-right corner, got: " .. result)
+  assert(result:find("│", 1, true), "table should have vertical borders, got: " .. result)
+  assert(result:find("─", 1, true), "table should have horizontal borders, got: " .. result)
+  -- Header should be bold
+  assert(result:find(BOLD .. " Name", 1, true), "header Name should be bold, got: " .. result)
+  assert(result:find(BOLD .. " Age", 1, true), "header Age should be bold, got: " .. result)
+  -- Body cells present
+  assert(result:find("Alice", 1, true), "body should contain Alice, got: " .. result)
+  assert(result:find("Bob", 1, true), "body should contain Bob, got: " .. result)
+  print("PASS: basic table renders with box-drawing chars and aligned columns")
+end
+
+-- test: separator row is consumed (not shown as-is)
+local function test_separator_consumed()
+  local input = "| H1 | H2 |\n|----|----|  \n| a | b |\n"
+  local result = render.render_markdown(input)
+  assert(not result:find("|----", 1, true), "separator row should be consumed, got: " .. result)
+  assert(result:find("├", 1, true), "should have header separator border, got: " .. result)
+  assert(result:find("┼", 1, true), "should have header separator cross, got: " .. result)
+  assert(result:find("┤", 1, true), "should have header separator right, got: " .. result)
+  print("PASS: separator row is consumed")
+end
+
+-- test: header cells are bold
+local function test_header_bold()
+  local input = "| X | Y |\n|---|---|\n| 1 | 2 |\n"
+  local result = render.render_markdown(input)
+  assert(result:find(BOLD, 1, true), "header cells should be bold, got: " .. result)
+  print("PASS: header cells are bold")
+end
+
+-- test: table with no separator row treats all rows as body
+local function test_no_separator()
+  local input = "| a | b |\n| c | d |\n"
+  local result = render.render_markdown(input)
+  assert(result:find("┌", 1, true), "no-sep table should have borders, got: " .. result)
+  assert(not result:find("├", 1, true), "no-sep table should not have header sep, got: " .. result)
+  assert(not result:find(BOLD, 1, true), "no-sep table should not have bold, got: " .. result)
+  print("PASS: table with no separator row treats all as body")
+end
+
+-- test: table with varying cell widths aligns correctly
+local function test_varying_widths()
+  local input = "| Short | Very Long Header |\n|-------|------------------|\n| x | y |\n"
+  local result = render.render_markdown(input)
+  assert(result:find("┌", 1, true), "varying widths should render, got: " .. result)
+  assert(result:find("Short", 1, true), "should contain Short, got: " .. result)
+  assert(result:find("Very Long Header", 1, true), "should contain long header, got: " .. result)
+  print("PASS: table with varying cell widths aligns correctly")
+end
+
+-- test: table surrounded by other markdown renders correctly
+local function test_table_with_context()
+  local input = "# Title\n\nSome text.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nMore text.\n"
+  local result = render.render_markdown(input)
+  assert(result:find(BOLD .. "# Title" .. RESET, 1, true), "heading should render")
+  assert(result:find("┌", 1, true), "table should render in context, got: " .. result)
+  assert(result:find("Some text.", 1, true), "text before table should be present")
+  assert(result:find("More text.", 1, true), "text after table should be present")
+  print("PASS: table surrounded by other markdown renders correctly")
+end
+
+-- test: table inside code fence is NOT formatted
+local function test_table_in_code_fence()
+  local input = "```\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n"
+  local result = render.render_markdown(input)
+  assert(not result:find("┌", 1, true), "table in fence should not have box chars, got: " .. result)
+  assert(result:find("| A | B |", 1, true), "table in fence should pass through raw, got: " .. result)
+  print("PASS: table inside code fence is NOT formatted")
+end
+
+-- test: single-row table
+local function test_single_row_table()
+  local input = "| only | row |\n"
+  local result = render.render_markdown(input)
+  assert(result:find("┌", 1, true), "single-row table should have borders, got: " .. result)
+  assert(result:find("└", 1, true), "single-row table should have bottom border, got: " .. result)
+  assert(result:find("only", 1, true), "single-row should contain 'only', got: " .. result)
+  print("PASS: single-row table")
+end
+
+-- test: cells with inline formatting (bold, code)
+local function test_inline_formatting_in_cells()
+  local input = "| **bold** | `code` |\n|----------|--------|\n| normal | text |\n"
+  local result = render.render_markdown(input)
+  assert(result:find("normal", 1, true), "body should contain normal, got: " .. result)
+  print("PASS: cells with inline formatting")
+end
+
+-- test: empty cells
+local function test_empty_cells()
+  local input = "| A | B |\n|---|---|\n|  |  |\n"
+  local result = render.render_markdown(input)
+  assert(result:find("┌", 1, true), "empty cell table should render, got: " .. result)
+  assert(result:find("└", 1, true), "empty cell table should have bottom, got: " .. result)
+  print("PASS: empty cells")
+end
+
+-- test: render_table directly
+local function test_render_table_direct()
+  local lines = {"| H1 | H2 |", "|----|----|", "| a  | b  |"}
+  local out = render.render_table(lines)
+  assert(#out > 0, "render_table should return lines")
+  local joined = table.concat(out, "\n")
+  assert(joined:find("┌", 1, true), "render_table should produce box chars, got: " .. joined)
+  assert(joined:find("H1", 1, true), "render_table should contain H1, got: " .. joined)
+  print("PASS: render_table direct")
+end
+
+-- test: ragged table (rows with different column counts)
+local function test_ragged_table()
+  local input = "| A | B | C |\n|---|---|---|\n| 1 | 2 |\n"
+  local result = render.render_markdown(input)
+  assert(result:find("┌", 1, true), "ragged table should render, got: " .. result)
+  assert(result:find("A", 1, true), "ragged table should contain A, got: " .. result)
+  print("PASS: ragged table")
+end
+
 test_h1_heading()
 test_h2_heading()
 test_h3_heading()
@@ -184,3 +310,15 @@ test_colorize_diff_line()
 test_apply_inline()
 test_hr_variants()
 test_no_bold_in_fence()
+test_basic_table()
+test_separator_consumed()
+test_header_bold()
+test_no_separator()
+test_varying_widths()
+test_table_with_context()
+test_table_in_code_fence()
+test_single_row_table()
+test_inline_formatting_in_cells()
+test_empty_cells()
+test_render_table_direct()
+test_ragged_table()


### PR DESCRIPTION
## Summary

Add table rendering support to the markdown-to-ANSI renderer (`lib/ah/render.tl`). Pipe-delimited markdown tables are now rendered with box-drawing borders, bold headers, and aligned columns.

## Changes

- **`lib/ah/render.tl`**: added `is_table_line()`, `is_separator_line()`, `parse_row()`, `display_width()`, and `render_table()` helpers. Updated `render_markdown()` to buffer consecutive pipe-delimited lines and flush them through `render_table()` when the table ends.
- **`lib/ah/test_render.tl`**: added 12 tests covering basic tables, separator consumption, bold headers, no-separator tables, varying column widths, tables with surrounding markdown, tables inside code fences, single-row tables, inline formatting in cells, empty cells, direct `render_table()` calls, and ragged tables.

## Rendering

```
┌───────┬─────┐
│ Name  │ Age │
├───────┼─────┤
│ Alice │ 30  │
│ Bob   │ 25  │
└───────┴─────┘
```

## Edge cases handled

- No separator row → all rows treated as body (no bold, no header separator border)
- Ragged tables (different column counts) → missing cells padded with empty strings
- Tables inside code fences → passed through raw, not formatted
- Empty cells → padded to column width
- Inline formatting (`**bold**`, `\`code\``) → applied inside cells
- ANSI-aware column alignment via `display_width()` helper