### PR TITLE
Bump cosmic to 2026-03-02-c363a79

### DIFF
--- a/deps/cosmic.mk
+++ b/deps/cosmic.mk
@@ -1,4 +1,4 @@
-cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-02-28-4cc5b3b/cosmic-lua
-cosmic_sha := cb7db25b5199bfbd680425a522687bc61dcbedbb5b22d1b31c1f6a9def6e060a
-cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/2026-02-28-4cc5b3b/cosmic-lua-debug
-cosmic_debug_sha := 6502d390cbd55b6eefeea98d96e0a55cd87d831dd8bdb546571da80b443e9199
+cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-03-02-c363a79/cosmic-lua
+cosmic_sha := 9dc7fc906431ea5f40d18a0710010aa231a762edcd13e20c718cda91c6be91f9
+cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/2026-03-02-c363a79/cosmic-lua-debug
+cosmic_debug_sha := 74f4722155852f7e8a560d5759bbd1879226dcba52ef1a9015219204743b29ad


### PR DESCRIPTION
## Summary
- Bump cosmic dependency from `2026-02-28-4cc5b3b` to `2026-03-02-c363a79`
- Update SHA256 checksums for `cosmic-lua` and `cosmic-lua-debug` binaries

## Test plan
- [ ] `make -j ci` passes with new cosmic version

https://claude.ai/code/session_01Fuw85jDW4aEhS3sgTjX7x6