### PR TITLE
move protect module from sys/tools/ to lib/ah/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ ah_version := $(shell \
   echo "$$v")
 ah_version_lua := $(o)/embed/.lua/ah/version.lua
 
-TL_PATH := sys/tools/?.tl;lib/?.tl;lib/?/init.tl;/zip/.tl/?.tl;/zip/.tl/?/init.tl;/zip/.lua/types/?.d.tl;/zip/.lua/types/?/init.d.tl
+TL_PATH := lib/?.tl;lib/?/init.tl;/zip/.tl/?.tl;/zip/.tl/?/init.tl;/zip/.lua/types/?.d.tl;/zip/.lua/types/?/init.d.tl
 
 # compile .tl to .lua
 $(o)/%.lua: %.tl $(cosmic)

--- a/lib/ah/protect.tl
+++ b/lib/ah/protect.tl
@@ -1,4 +1,4 @@
--- sys/tools/protect.tl: shared path protection check for AH_PROTECT_DIRS
+-- ah/protect.tl: shared path protection check for AH_PROTECT_DIRS
 local fs = require("cosmic.fs")
 
 local function is_protected(path: string): boolean

--- a/sys/tools/edit.tl
+++ b/sys/tools/edit.tl
@@ -1,6 +1,6 @@
 -- sys/tools/edit.tl: edit file tool
 local cio = require("cosmic.io")
-local protect = require("protect")
+local protect = require("ah.protect")
 local pathutil = require("ah.pathutil")
 
 return {

--- a/sys/tools/write.tl
+++ b/sys/tools/write.tl
@@ -1,7 +1,7 @@
 -- sys/tools/write.tl: write file tool
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
-local protect = require("protect")
+local protect = require("ah.protect")
 local pathutil = require("ah.pathutil")
 
 return {


### PR DESCRIPTION
protect.tl is a shared utility module, not a tool. living in sys/tools/ meant it was picked up by the tool loader scan (filtered out by looks_like_tool, but still in the wrong place).

moves to lib/ah/protect.tl so it loads as a normal library module. updates write.tl and edit.tl to require('ah.protect'). removes sys/tools/?.tl from TL_PATH since it's no longer needed.

all 26 tests pass, all 58 type checks pass.