### PR TITLE
render: fix table column misalignment with multi-byte UTF-8 characters

### DIFF
--- a/lib/ah/cli.tl
+++ b/lib/ah/cli.tl
@@ -397,8 +397,8 @@ local function make_cli_handler(skill_name: string, session_ulid?: string): even
           local max_lines = 3
           for j = 1, math.min(max_lines, #lines) do
             local line = lines[j]
-            if #line > 80 then
-              line = line:sub(1, 77) .. "..."
+            if render.display_width(line) > 80 then
+              line = render.utf8_truncate(line, 77, "...")
             end
             if is_diff_cmd then
               local colored = render.colorize_diff_line(line)

--- a/lib/ah/render.tl
+++ b/lib/ah/render.tl
@@ -56,10 +56,26 @@ local function parse_row(line: string): {string}
   return cells
 end
 
--- Compute display width of a string, stripping ANSI escape sequences.
+-- Compute display width of a string, stripping ANSI escape sequences
+-- and counting UTF-8 characters (not bytes).
 local function display_width(s: string): integer
   local stripped = s:gsub("\27%[[%d;]*m", "")
-  return #stripped
+  local len = 0
+  local i = 1
+  while i <= #stripped do
+    local b = stripped:byte(i)
+    if b < 0x80 then
+      i = i + 1
+    elseif b < 0xE0 then
+      i = i + 2
+    elseif b < 0xF0 then
+      i = i + 3
+    else
+      i = i + 4
+    end
+    len = len + 1
+  end
+  return len
 end
 
 -- Render a table block from raw markdown lines into box-drawing output.
@@ -233,9 +249,36 @@ local function render_markdown(text: string): string
   return table.concat(result, "\n")
 end
 
+-- Truncate a string to at most max_chars UTF-8 characters, appending suffix
+-- if truncated. Safe: never splits a multi-byte sequence.
+local function utf8_truncate(s: string, max_chars: integer, suffix: string): string
+  suffix = suffix or "..."
+  local char_count = 0
+  local i = 1
+  while i <= #s do
+    local b = s:byte(i)
+    local seq_len = 1
+    if b >= 0xF0 then
+      seq_len = 4
+    elseif b >= 0xE0 then
+      seq_len = 3
+    elseif b >= 0xC0 then
+      seq_len = 2
+    end
+    char_count = char_count + 1
+    if char_count > max_chars then
+      return s:sub(1, i - 1) .. suffix
+    end
+    i = i + seq_len
+  end
+  return s
+end
+
 return {
   render_markdown = render_markdown,
   apply_inline = apply_inline,
   colorize_diff_line = colorize_diff_line,
   render_table = render_table,
+  display_width = display_width,
+  utf8_truncate = utf8_truncate,
 }

--- a/lib/ah/sessions.tl
+++ b/lib/ah/sessions.tl
@@ -3,6 +3,7 @@ local fs = require("cosmic.fs")
 local db = require("ah.db")
 local ulid = require("ulid")
 local cli = require("ah.cli")
+local render = require("ah.render")
 
 -- Session record for listing
 local record Session
@@ -113,10 +114,8 @@ local function cmd_sessions(cwd: string, current_ulid: string)
     local time_str = decoded and decoded.time or "unknown"
     local short_ulid = s.ulid:sub(1, 11)
     local name_str = s.name and string.format("  [%s]", s.name) or ""
-    local preview = s.first_prompt:gsub("\n", " "):sub(1, 40)
-    if #s.first_prompt > 40 then
-      preview = preview .. "..."
-    end
+    local flat_prompt = s.first_prompt:gsub("\n", " ")
+    local preview = render.utf8_truncate(flat_prompt, 40, "...")
     io.write(string.format("%s %s  %s  %2d msgs%s  %s\n",
         marker, short_ulid, time_str, s.msg_count, name_str, preview))
   end

--- a/lib/ah/test_render.tl
+++ b/lib/ah/test_render.tl
@@ -295,6 +295,72 @@ local function test_ragged_table()
   print("PASS: ragged table")
 end
 
+-- test: table with multi-byte UTF-8 characters aligns correctly
+local function test_utf8_table()
+  local input = "| Name | City |\n|------|------|\n| Alice | Zürich |\n| Bob | Paris |\n"
+  local result = render.render_markdown(input)
+  -- All rows should have same visual width between │ delimiters.
+  -- Extract lines with │ (data rows) and check they have consistent segments.
+  local data_lines: {string} = {}
+  for line in result:gmatch("([^\n]+)") do
+    if line:sub(1, 3) == "│" then
+      table.insert(data_lines, line)
+    end
+  end
+  assert(#data_lines >= 2, "should have at least 2 data rows, got: " .. #data_lines)
+  -- Strip ANSI codes and check visual widths match
+  local function strip_ansi(s: string): string
+    return (s:gsub("\27%[[%d;]*m", ""))
+  end
+  local function utf8len(s: string): integer
+    local len = 0
+    local i = 1
+    while i <= #s do
+      local b = s:byte(i)
+      if b < 0x80 then i = i + 1
+      elseif b < 0xE0 then i = i + 2
+      elseif b < 0xF0 then i = i + 3
+      else i = i + 4 end
+      len = len + 1
+    end
+    return len
+  end
+  local widths: {integer} = {}
+  for _, line in ipairs(data_lines) do
+    table.insert(widths, utf8len(strip_ansi(line)))
+  end
+  for i = 2, #widths do
+    assert(widths[i] == widths[1],
+      "data row " .. i .. " width " .. widths[i] .. " != header width " .. widths[1] .. "\n" .. result)
+  end
+  print("PASS: table with multi-byte UTF-8 characters aligns correctly")
+end
+
+-- test: display_width counts UTF-8 characters not bytes
+local function test_display_width()
+  -- re-export display_width
+  local dw = (render as {string: function(string): integer}).display_width
+  assert(dw("hello") == 5, "ASCII should be 5")
+  assert(dw("café") == 4, "café should be 4 chars, not 5 bytes")
+  assert(dw("日本語") == 3, "3 CJK chars")
+  assert(dw("a\27[1mb\27[0mc") == 3, "ANSI codes should be stripped")
+  assert(dw("") == 0, "empty string")
+  print("PASS: display_width counts UTF-8 characters not bytes")
+end
+
+-- test: utf8_truncate never splits multi-byte sequences
+local function test_utf8_truncate()
+  local trunc = (render as {string: function(string, integer, string): string}).utf8_truncate
+  assert(trunc("hello", 3, "...") == "hel...", "ASCII truncate")
+  assert(trunc("hi", 10, "...") == "hi", "no truncate when short")
+  assert(trunc("café", 3, "...") == "caf...", "truncate before é")
+  assert(trunc("café", 4, "...") == "café", "exact length no truncate")
+  -- Verify no broken UTF-8
+  local result = trunc("aübcd", 3, "…")
+  assert(result == "aüb…", "should not split ü, got: " .. result)
+  print("PASS: utf8_truncate never splits multi-byte sequences")
+end
+
 test_h1_heading()
 test_h2_heading()
 test_h3_heading()
@@ -322,3 +388,6 @@ test_inline_formatting_in_cells()
 test_empty_cells()
 test_render_table_direct()
 test_ragged_table()
+test_utf8_table()
+test_display_width()
+test_utf8_truncate()


### PR DESCRIPTION
display_width() used lua's `#` operator which counts bytes, not UTF-8
characters. multi-byte chars (ü, é, emoji) caused data rows to be narrower
than header/border rows in rendered tables.

**fixes:**
- `display_width()` now counts UTF-8 characters via byte-sequence walking
- new `utf8_truncate()` helper that never splits multi-byte sequences
- both exported from render module

**callers fixed:**
- `cli.tl`: tool output preview line truncation at 80 chars
- `sessions.tl`: session list prompt preview at 40 chars

**tests added:** `test_utf8_table`, `test_display_width`, `test_utf8_truncate`