### PR TITLE
native --timeout via SIGALRM + time budget in system prompt

### DIFF
--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -53,12 +53,10 @@ end
 local record ChildMod
   spawn: function({string}, {string: any}): ChildHandle, string
 end
-
 local record ChildHandle
   stderr: StderrHandle
   read: function(ChildHandle): boolean, string, string
 end
-
 local record StderrHandle
   read: function(StderrHandle): string
 end
@@ -102,7 +100,6 @@ local function main(args: {string}): integer, string
 
   -- Enable core dumps for crash debugging
   proc.setrlimit(4, -1, -1)
-
   -- Sandbox mode: when AH_SANDBOX=1, apply network sandbox restrictions.
   -- When AH_UNVEIL is set (with or without AH_SANDBOX), apply unveil.
   -- When AH_PLEDGE is set (with or without AH_SANDBOX), apply pledge.
@@ -210,10 +207,6 @@ local function main(args: {string}): integer, string
 
     local child_args: {string} = {}
     local exe = sbox.ah_exe()
-    if parsed.timeout and parsed.timeout > 0 then
-      table.insert(child_args, "timeout")
-      table.insert(child_args, tostring(parsed.timeout))
-    end
     table.insert(child_args, exe)
 
     local i = 1
@@ -221,7 +214,6 @@ local function main(args: {string}): integer, string
       local a = args[i]
       if a == "--sandbox" then
         -- skip
-      elseif a == "--timeout" then i = i + 1
       elseif a == "--allow-host" then i = i + 1
       elseif a == "--unveil" then i = i + 1
       elseif a == "--pledge" then i = i + 1
@@ -449,6 +441,9 @@ local function main(args: {string}): integer, string
   if parsed.must_produce then
     effective_system = effective_system .. "\n\nIMPORTANT: You must write the file `" .. parsed.must_produce .. "` before finishing."
   end
+  if parsed.timeout and parsed.timeout > 0 then
+    effective_system = effective_system .. "\n\nYou have " .. tostring(parsed.timeout) .. " seconds of wall-clock time. Budget your turns accordingly."
+  end
 
   local lock_acquired, lock_err = queue.try_acquire_lock(qdb)
   if not lock_acquired then
@@ -458,11 +453,16 @@ local function main(args: {string}): integer, string
     return 0
   end
 
-  signal.sigaction(signal.SIGINT, function()
-      interrupted = true
-      tools.abort_running_tools()
-      queue.release_lock(qdb)
-    end)
+  local function on_interrupt()
+    interrupted = true
+    tools.abort_running_tools()
+    queue.release_lock(qdb)
+  end
+  signal.sigaction(signal.SIGINT, on_interrupt)
+  if parsed.timeout and parsed.timeout > 0 then
+    signal.sigaction(signal.SIGALRM, on_interrupt)
+    signal.setitimer({which = signal.ITIMER_REAL, valuesec = parsed.timeout, valuens = 0, intervalsec = 0, intervalns = 0})
+  end
 
   local effective_model = api.resolve_model(model or os.getenv("AH_MODEL"))
   local on_event = cli_mod.make_cli_handler(parsed.skill, session_ulid)

--- a/lib/ah/test_timeout.tl
+++ b/lib/ah/test_timeout.tl
@@ -1,0 +1,102 @@
+-- test_timeout.tl: tests for native --timeout via SIGALRM
+local signal = require("cosmic.signal")
+local args_mod = require("ah.args")
+
+-- Test 1: system prompt injection when --timeout is set
+local function test_timeout_system_prompt_injection()
+  local parsed = args_mod.parse_args({"--timeout", "600", "hello"})
+  assert(parsed, "should parse")
+  assert(parsed.timeout == 600, "timeout should be 600")
+
+  -- Simulate the system prompt injection logic from init.tl
+  local effective_system = "base prompt"
+  if parsed.timeout and parsed.timeout > 0 then
+    effective_system = effective_system .. "\n\nYou have " .. tostring(parsed.timeout) .. " seconds of wall-clock time. Budget your turns accordingly."
+  end
+  assert(effective_system:match("You have 600 seconds"), "should contain time budget")
+  assert(effective_system:match("Budget your turns"), "should contain budget advice")
+  print("✓ timeout system prompt injection")
+end
+test_timeout_system_prompt_injection()
+
+-- Test 2: no injection when timeout is not set
+local function test_no_timeout_no_injection()
+  local parsed = args_mod.parse_args({"hello"})
+  assert(parsed, "should parse")
+  assert(not parsed.timeout, "timeout should be nil")
+
+  local effective_system = "base prompt"
+  if parsed.timeout and parsed.timeout > 0 then
+    effective_system = effective_system .. "\n\nYou have " .. tostring(parsed.timeout) .. " seconds of wall-clock time. Budget your turns accordingly."
+  end
+  assert(not effective_system:match("wall%-clock"), "should not contain time budget")
+  print("✓ no timeout means no injection")
+end
+test_no_timeout_no_injection()
+
+-- Test 3: SIGALRM fires and sets interrupted
+local function test_sigalrm_fires()
+  -- Declare global
+  global interrupted: boolean = false
+
+  signal.sigaction(signal.SIGALRM, function()
+      interrupted = true
+    end)
+
+  -- Set a 1-second timer
+  signal.setitimer({which = signal.ITIMER_REAL, valuesec = 1, valuens = 0, intervalsec = 0, intervalns = 0})
+
+  -- Busy-wait for the signal (up to 3 seconds)
+  local start = os.time()
+  while not interrupted do
+    if os.difftime(os.time(), start) > 3 then
+      break
+    end
+  end
+
+  assert(interrupted, "SIGALRM should have set interrupted=true")
+  print("✓ SIGALRM fires and sets interrupted")
+
+  -- Disarm any leftover timer
+  signal.setitimer({which = signal.ITIMER_REAL, valuesec = 0, valuens = 0, intervalsec = 0, intervalns = 0})
+end
+test_sigalrm_fires()
+
+-- Test 4: sandbox child_args no longer include external timeout
+local function test_sandbox_no_external_timeout()
+  local parsed = args_mod.parse_args({"--sandbox", "--timeout", "300", "hello"})
+  assert(parsed, "should parse")
+  assert(parsed.timeout == 300, "timeout should be 300")
+  assert(parsed.sandbox == true, "sandbox should be true")
+
+  -- Simulate the child_args construction from init.tl (post-change)
+  local args = {"--sandbox", "--timeout", "300", "hello"}
+  local child_args: {string} = {}
+  table.insert(child_args, "/path/to/ah") -- exe placeholder
+
+  local i = 1
+  while i <= #args do
+    local a = args[i]
+    if a == "--sandbox" then
+      -- skip
+    elseif a == "--allow-host" then i = i + 1
+    elseif a == "--unveil" then i = i + 1
+    elseif a == "--pledge" then i = i + 1
+    else table.insert(child_args, a) end
+    i = i + 1
+  end
+
+  -- --timeout and its value should be passed through to the child
+  local has_timeout_flag = false
+  local has_timeout_binary = false
+  for _, v in ipairs(child_args) do
+    if v == "--timeout" then has_timeout_flag = true end
+    if v == "timeout" then has_timeout_binary = true end
+  end
+  assert(has_timeout_flag, "--timeout should be passed through to child")
+  assert(not has_timeout_binary, "external 'timeout' binary should not be in child_args")
+  print("✓ sandbox passes --timeout to child instead of external timeout binary")
+end
+test_sandbox_no_external_timeout()
+
+print("PASS")


### PR DESCRIPTION
native wall-clock timeout using `setitimer(ITIMER_REAL)` + `SIGALRM`, replacing the external `timeout` binary wrapper.

## changes

- **native timer** — when `--timeout N` is set, arms a one-shot `ITIMER_REAL` timer and registers a `SIGALRM` handler that sets `interrupted = true` and aborts running tools. shares a single `on_interrupt` handler with `SIGINT`.
- **system prompt** — appends "You have N seconds of wall-clock time. Budget your turns accordingly." so the agent can prioritize.
- **sandbox simplified** — removes the external `timeout` binary from sandbox child args. `--timeout` passes through to the child, which handles it natively.
- **tests** — `test_timeout.tl` covers prompt injection, no-injection when unset, SIGALRM delivery, and sandbox child_args construction.

closes #228