### PR TITLE
unified braille bracket rendering for all tools

### DIFF
--- a/lib/ah/cli.tl
+++ b/lib/ah/cli.tl
@@ -332,10 +332,9 @@ local function make_cli_handler(skill_name: string, session_ulid?: string): even
       end
 
       local key = event.tool_key or ""
+      local prefix = is_dumb and "> " or "⠋ "
 
       if event.tool_name == "bash" then
-        -- Bash: single line with braille bracket, "⠋ $ command"
-        local prefix = is_dumb and "> " or "⠋ "
         local term_width = 80
         local ws = tty.winsize(2)
         if ws then term_width = ws.cols as integer end
@@ -343,14 +342,10 @@ local function make_cli_handler(skill_name: string, session_ulid?: string): even
         local available = term_width - #prefix - 2 -- 2 for "$ "
         local wrapped = loop.wrap_command(key, available, wrap_indent)
         io.stderr:write(string.format("%s%s$ %s%s\n", DIM, prefix, wrapped, RESET))
+      elseif key ~= "" then
+        io.stderr:write(string.format("%s%s%s %s%s\n", DIM, prefix, event.tool_name, key, RESET))
       else
-        -- Non-bash: tool name with optional key
-        local prefix = is_tty and (is_dumb and "> " or "⠋ ") or ""
-        if key ~= "" then
-          io.stderr:write(string.format("%s%s%s %s%s\n", DIM, prefix, event.tool_name, key, RESET))
-        else
-          io.stderr:write(string.format("%s%s%s%s\n", DIM, prefix, event.tool_name, RESET))
-        end
+        io.stderr:write(string.format("%s%s%s%s\n", DIM, prefix, event.tool_name, RESET))
       end
 
     elseif t == "tool_call_end" then
@@ -437,36 +432,29 @@ local function make_cli_handler(skill_name: string, session_ulid?: string): even
         end
       end
 
-      if event.tool_name == "bash" then
-        -- Bash: mirror braille bracket with duration, line count, exit status
-        local line_count = 0
-        if result ~= "" and result ~= "(no output)" then
-          for _ in result:gmatch("\n") do line_count = line_count + 1 end
-          if result:sub(-1) ~= "\n" then line_count = line_count + 1 end
-        end
-        local suffix = is_dumb and "< " or "⠜ "
-        local parts: {string} = {}
-        table.insert(parts, string.format("%.1fs", elapsed))
-        if line_count > 0 then
-          table.insert(parts, string.format("%d line%s", line_count, line_count == 1 and "" or "s"))
-        end
-        if event.is_error then
+      -- Summary line with braille bracket: duration, line count, error status
+      local line_count = 0
+      if result ~= "" and result ~= "(no output)" then
+        for _ in result:gmatch("\n") do line_count = line_count + 1 end
+        if result:sub(-1) ~= "\n" then line_count = line_count + 1 end
+      end
+      local suffix = is_dumb and "< " or "⠜ "
+      local parts: {string} = {}
+      table.insert(parts, string.format("%.1fs", elapsed))
+      if line_count > 0 then
+        table.insert(parts, string.format("%d line%s", line_count, line_count == 1 and "" or "s"))
+      end
+      if event.is_error then
+        if event.tool_name == "bash" then
           local code = result:match("exit code: (%d+)")
-          if code then
-            table.insert(parts, "exit " .. code)
-          else
-            table.insert(parts, "error")
-          end
-        end
-        local summary = table.concat(parts, ", ")
-        io.stderr:write(string.format("%s%s%s%s\n", DIM, suffix, summary, RESET))
-      else
-        if is_tty and event.is_error then
-          io.stderr:write(string.format("%s\27[1;33m✗ %.1fs\27[0m\n", indent, elapsed))
+          if code then table.insert(parts, "exit " .. code)
+          else table.insert(parts, "error") end
         else
-          io.stderr:write(string.format("%s%s%.1fs%s\n", indent, DIM, elapsed, RESET))
+          table.insert(parts, "error")
         end
       end
+      local summary = table.concat(parts, ", ")
+      io.stderr:write(string.format("%s%s%s%s\n", DIM, suffix, summary, RESET))
 
       -- Blank line after tool block
       io.stderr:write("\n")

--- a/lib/ah/test_tool_render.tl
+++ b/lib/ah/test_tool_render.tl
@@ -1,0 +1,119 @@
+#!/usr/bin/env cosmic
+-- test_tool_render.tl: tests for unified braille bracket rendering of non-bash tools
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local cli = require("ah.cli")
+local events = require("ah.events")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local function capture_stderr(fn: function()): string
+  local tmpfile = fs.join(TEST_TMPDIR, "test_stderr_tr_" .. tostring(os.time()) .. ".txt")
+  local old_stderr = io.stderr
+  local new_stderr = io.open(tmpfile, "w")
+  io.stderr = new_stderr
+  fn()
+  io.stderr:close()
+  io.stderr = old_stderr
+  local output = cio.slurp(tmpfile) or ""
+  os.remove(tmpfile)
+  return output
+end
+
+local function test_tool_call_start_non_bash_braille()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({
+          event_type = "tool_call_start",
+          tool_name = "read",
+          tool_key = "lib/ah/cli.tl",
+          tool_input = '{"path":"lib/ah/cli.tl"}',
+          tool_index = 1,
+          tool_count = 1,
+        } as events.EventData)
+    end)
+  assert(output:match("read lib/ah/cli.tl"), "should show tool name and key, got: " .. output)
+  print("✓ non-bash tool_call_start shows braille prefix with tool name and key")
+end
+test_tool_call_start_non_bash_braille()
+
+local function test_tool_call_end_non_bash_summary()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({
+          event_type = "tool_call_end",
+          tool_name = "read",
+          tool_key = "lib/ah/cli.tl",
+          tool_output = "line1\nline2\nline3\n",
+          is_error = false,
+          duration_ms = 250,
+          tool_index = 1,
+          tool_count = 1,
+        } as events.EventData)
+    end)
+  assert(output:match("0%.2s"), "should show elapsed time, got: " .. output)
+  assert(output:match("3 lines"), "should show line count, got: " .. output)
+  assert(not output:match("error"), "should not show error, got: " .. output)
+  print("✓ non-bash tool_call_end shows braille summary with duration and line count")
+end
+test_tool_call_end_non_bash_summary()
+
+local function test_tool_call_end_non_bash_error()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({
+          event_type = "tool_call_end",
+          tool_name = "write",
+          tool_key = "foo.txt",
+          tool_output = "permission denied",
+          is_error = true,
+          duration_ms = 100,
+          tool_index = 1,
+          tool_count = 1,
+        } as events.EventData)
+    end)
+  assert(output:match("0%.1s"), "should show elapsed time, got: " .. output)
+  assert(output:match("error"), "should show error in summary, got: " .. output)
+  assert(not output:match("exit"), "non-bash error should not show exit code, got: " .. output)
+  print("✓ non-bash tool_call_end shows error in summary without exit code")
+end
+test_tool_call_end_non_bash_error()
+
+local function test_tool_call_end_no_output()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({
+          event_type = "tool_call_end",
+          tool_name = "edit",
+          tool_key = "foo.tl",
+          tool_output = "(no output)",
+          is_error = false,
+          duration_ms = 40,
+          tool_index = 1,
+          tool_count = 1,
+        } as events.EventData)
+    end)
+  assert(output:match("0%.0s"), "should show elapsed time, got: " .. output)
+  assert(not output:match("line"), "no-output should not show line count, got: " .. output)
+  print("✓ non-bash tool_call_end with no output omits line count")
+end
+test_tool_call_end_no_output()
+
+local function test_tool_call_start_no_key()
+  local handler = cli.make_cli_handler(nil)
+  local output = capture_stderr(function()
+      handler({
+          event_type = "tool_call_start",
+          tool_name = "skill",
+          tool_key = "",
+          tool_input = "{}",
+          tool_index = 1,
+          tool_count = 1,
+        } as events.EventData)
+    end)
+  assert(output:match("skill"), "should show tool name, got: " .. output)
+  print("✓ tool_call_start with no key shows only tool name")
+end
+test_tool_call_start_no_key()
+
+print("PASS")


### PR DESCRIPTION
all tools now render with the same ⠋/⠜ bracket pattern that bash uses.

## before

```
⠋ $ echo hello
  hello world
⠜ 0.1s, 1 line

⠋ read lib/ah/cli.tl
  line1
  line2
  0.1s
```

## after

```
⠋ $ echo hello
  hello world
⠜ 0.1s, 1 line

⠋ read lib/ah/cli.tl
  line1
  line2
⠜ 0.1s, 3 lines
```

### changes

- `⠋` prefix on `tool_call_start` for all tools (was tty-conditional for non-bash)
- `⠜` summary line with duration, line count, and error status for all tools (replaces indented duration-only line and `✗` error indicator)
- non-bash errors show `error` in summary; bash errors continue showing `exit N`
- tests in `test_tool_render.tl` covering non-bash start/end rendering