### PR TITLE
bash: detect binary output, sanitize non-UTF-8 in truncation

### DIFF
--- a/lib/ah/test_truncate.tl
+++ b/lib/ah/test_truncate.tl
@@ -210,4 +210,90 @@ local function test_truncate_chars_notice_content()
 end
 test_truncate_chars_notice_content()
 
+-- sanitize_utf8 tests
+local function test_sanitize_utf8_ascii()
+  local result, changed = truncate.sanitize_utf8("hello world")
+  assert(result == "hello world", "ascii unchanged")
+  assert(not changed, "no change for ascii")
+  print("✓ sanitize_utf8 ascii passthrough")
+end
+test_sanitize_utf8_ascii()
+
+local function test_sanitize_utf8_valid_multibyte()
+  local s = "café résumé"
+  local result, changed = truncate.sanitize_utf8(s)
+  assert(result == s, "valid utf8 unchanged")
+  assert(not changed, "no change for valid utf8")
+  print("✓ sanitize_utf8 valid multibyte passthrough")
+end
+test_sanitize_utf8_valid_multibyte()
+
+local function test_sanitize_utf8_invalid_bytes()
+  -- 0x80 is an invalid leading byte (continuation byte without leader)
+  local s = "hello\x80world"
+  local result, changed = truncate.sanitize_utf8(s)
+  assert(changed, "should detect invalid bytes")
+  assert(result == "hello\xEF\xBF\xBDworld", "should replace with U+FFFD: got " .. result)
+  print("✓ sanitize_utf8 replaces invalid bytes")
+end
+test_sanitize_utf8_invalid_bytes()
+
+local function test_sanitize_utf8_null_byte()
+  -- Null bytes are valid ASCII but let's verify they pass through
+  local s = "hello\0world"
+  local result, changed = truncate.sanitize_utf8(s)
+  assert(result == s, "null byte is valid ascii")
+  assert(not changed, "no change for null byte")
+  print("✓ sanitize_utf8 null byte passthrough")
+end
+test_sanitize_utf8_null_byte()
+
+local function test_sanitize_utf8_gzip_header()
+  -- Simulate gzip magic bytes: 1f 8b 08 00
+  local s = "\x1f\x8b\x08\x00binary data"
+  local result, changed = truncate.sanitize_utf8(s)
+  assert(changed, "gzip bytes should be replaced")
+  assert(not result:find("\x8b"), "invalid bytes should be gone")
+  print("✓ sanitize_utf8 handles gzip-like binary")
+end
+test_sanitize_utf8_gzip_header()
+
+local function test_sanitize_utf8_truncated_sequence()
+  -- 2-byte sequence leader at end of string (truncated)
+  local s = "hello\xC3"
+  local result, changed = truncate.sanitize_utf8(s)
+  assert(changed, "truncated sequence should be replaced")
+  assert(result == "hello\xEF\xBF\xBD", "should replace truncated sequence")
+  print("✓ sanitize_utf8 handles truncated sequences")
+end
+test_sanitize_utf8_truncated_sequence()
+
+local function test_sanitize_utf8_empty()
+  local result, changed = truncate.sanitize_utf8("")
+  assert(result == "", "empty string unchanged")
+  assert(not changed, "no change for empty")
+  print("✓ sanitize_utf8 empty string")
+end
+test_sanitize_utf8_empty()
+
+local function test_sanitize_utf8_overlong()
+  -- 0xC0 0x80 is an overlong encoding of NUL — should be rejected
+  local s = "a\xC0\x80b"
+  local result, changed = truncate.sanitize_utf8(s)
+  assert(changed, "overlong should be replaced")
+  -- 0xC0 is invalid leader (< 0xC2), 0x80 is continuation without leader
+  assert(result:find("\xEF\xBF\xBD"), "should contain replacement char")
+  print("✓ sanitize_utf8 rejects overlong encodings")
+end
+test_sanitize_utf8_overlong()
+
+local function test_truncate_output_sanitizes()
+  -- Verify truncate_output applies sanitization
+  local s = "hello\x80world"
+  local r = truncate.truncate_output(s, "bash")
+  assert(r.content == "hello\xEF\xBF\xBDworld", "truncate_output should sanitize: got " .. r.content)
+  print("✓ truncate_output sanitizes non-utf8")
+end
+test_truncate_output_sanitizes()
+
 print("\nAll truncate tests passed!")

--- a/lib/ah/truncate.tl
+++ b/lib/ah/truncate.tl
@@ -88,6 +88,90 @@ local function truncate_lines(output: string, max_lines: integer): string, boole
   .. table.concat(tail_lines, "\n"), true
 end
 
+-- Sanitize non-UTF-8 bytes by replacing them with the Unicode replacement
+-- character (U+FFFD). Acts as a safety net to prevent invalid JSON when
+-- binary content slips past tool-level checks.
+local function sanitize_utf8(s: string): string, boolean
+  local out: {string} = {}
+  local changed = false
+  local i = 1
+  local len = #s
+  while i <= len do
+    local b = s:byte(i)
+    if b < 0x80 then
+      -- ASCII
+      table.insert(out, s:sub(i, i))
+      i = i + 1
+    elseif b >= 0xC2 and b <= 0xDF then
+      -- 2-byte sequence
+      if i + 1 <= len then
+        local b2 = s:byte(i + 1)
+        if b2 >= 0x80 and b2 <= 0xBF then
+          table.insert(out, s:sub(i, i + 1))
+          i = i + 2
+        else
+          table.insert(out, "\xEF\xBF\xBD")
+          changed = true
+          i = i + 1
+        end
+      else
+        table.insert(out, "\xEF\xBF\xBD")
+        changed = true
+        i = i + 1
+      end
+    elseif b >= 0xE0 and b <= 0xEF then
+      -- 3-byte sequence
+      if i + 2 <= len then
+        local b2 = s:byte(i + 1)
+        local b3 = s:byte(i + 2)
+        local valid = b2 >= 0x80 and b2 <= 0xBF and b3 >= 0x80 and b3 <= 0xBF
+        if b == 0xE0 then valid = valid and b2 >= 0xA0 end
+        if b == 0xED then valid = valid and b2 <= 0x9F end
+        if valid then
+          table.insert(out, s:sub(i, i + 2))
+          i = i + 3
+        else
+          table.insert(out, "\xEF\xBF\xBD")
+          changed = true
+          i = i + 1
+        end
+      else
+        table.insert(out, "\xEF\xBF\xBD")
+        changed = true
+        i = i + 1
+      end
+    elseif b >= 0xF0 and b <= 0xF4 then
+      -- 4-byte sequence
+      if i + 3 <= len then
+        local b2 = s:byte(i + 1)
+        local b3 = s:byte(i + 2)
+        local b4 = s:byte(i + 3)
+        local valid = b2 >= 0x80 and b2 <= 0xBF and b3 >= 0x80 and b3 <= 0xBF and b4 >= 0x80 and b4 <= 0xBF
+        if b == 0xF0 then valid = valid and b2 >= 0x90 end
+        if b == 0xF4 then valid = valid and b2 <= 0x8F end
+        if valid then
+          table.insert(out, s:sub(i, i + 3))
+          i = i + 4
+        else
+          table.insert(out, "\xEF\xBF\xBD")
+          changed = true
+          i = i + 1
+        end
+      else
+        table.insert(out, "\xEF\xBF\xBD")
+        changed = true
+        i = i + 1
+      end
+    else
+      -- Invalid leading byte (0x80-0xBF, 0xC0-0xC1, 0xF5-0xFF)
+      table.insert(out, "\xEF\xBF\xBD")
+      changed = true
+      i = i + 1
+    end
+  end
+  return table.concat(out), changed
+end
+
 -- Truncate tool output: character-based first, then line-based.
 -- Returns a TruncateResult with the (possibly truncated) content and metadata.
 local function truncate_output(output: string, tool_name: string): TruncateResult
@@ -103,6 +187,10 @@ local function truncate_output(output: string, tool_name: string): TruncateResul
     result, line_truncated = truncate_lines(result, max_lines)
   end
 
+  -- Safety net: replace any non-UTF-8 bytes that survived tool-level checks.
+  -- This prevents invalid JSON when binary content reaches the API.
+  result = sanitize_utf8(result)
+
   return {
     content = result,
     truncated = char_truncated or line_truncated,
@@ -115,6 +203,7 @@ return {
   truncate_output = truncate_output,
   truncate_chars = truncate_chars,
   truncate_lines = truncate_lines,
+  sanitize_utf8 = sanitize_utf8,
   count_lines = count_lines,
   TruncateResult = TruncateResult,
   DEFAULT_CHAR_LIMITS = DEFAULT_CHAR_LIMITS,

--- a/sys/tools/bash.tl
+++ b/sys/tools/bash.tl
@@ -5,6 +5,29 @@ local child = require("cosmic.child")
 -- Exported as .running_processes so tools.tl can abort them.
 local running_processes: {integer: any} = {}
 
+-- Check if output contains binary (non-text) content.
+-- Mirrors the is_binary check in sys/tools/read.tl.
+local function is_binary(content: string): boolean
+  local sample_size = math.min(#content, 8192)
+  local sample = content:sub(1, sample_size)
+
+  if sample:find("\0") then
+    return true
+  end
+
+  local non_printable = 0
+  for i = 1, #sample do
+    local b = sample:byte(i)
+    if not ((b >= 32 and b <= 126) or b == 9 or b == 10 or b == 13) then
+      if b < 128 then
+        non_printable = non_printable + 1
+      end
+    end
+  end
+
+  return non_printable > sample_size * 0.1
+end
+
 -- Find executable in PATH or common locations
 local function find_executable(name: string): string
   local env_override = os.getenv("AH_" .. name:upper())
@@ -73,6 +96,12 @@ return {
 
     local stdout_str = (stdout as string) or ""
     local exit_code = tonumber(exit_str) as integer or 0
+
+    -- Replace binary output with an error message to prevent invalid
+    -- UTF-8 from being stored in the session DB and sent to the API.
+    if stdout_str ~= "" and is_binary(stdout_str) then
+      stdout_str = string.format("error: command produced binary output (%d bytes), which cannot be displayed", #stdout_str)
+    end
 
     local result_parts: {string} = {}
     if stdout_str ~= "" then


### PR DESCRIPTION
## Summary

The bash tool captures raw binary output (e.g. gzip data) from commands and stores it in the session DB. When this binary content reaches the API as JSON, it produces invalid UTF-8 that the API rejects with a 400 error. The session becomes permanently broken since the invalid content is persisted.

## Fix

Two-layer defense:

1. **bash tool**: detect binary output using the same `is_binary` heuristic as the read tool. Replace binary stdout with an error message describing the byte count.

2. **truncate module**: add `sanitize_utf8` as a safety net. After truncation, replace any non-UTF-8 bytes with U+FFFD (replacement character) before the content reaches `json.encode`. This catches binary that slips past tool-level checks.

## Testing

- 9 new tests for `sanitize_utf8` covering: ASCII passthrough, valid multibyte, invalid bytes, null bytes, gzip headers, truncated sequences, overlong encodings, and integration with `truncate_output`.
- All 27 tests pass, all 59 type checks pass.

Closes #495