### PR TITLE
remove dat pager, use bat only; fix read tool phantom line; add .tl syntax mapping

### DIFF
--- a/lib/ah/cli.tl
+++ b/lib/ah/cli.tl
@@ -148,13 +148,12 @@ local function reset_difftool_cache()
   _difftool_finder.reset()
 end
 
--- pager_finder: find/reset for dat or bat
+-- pager_finder: find/reset for bat
 local _pager_finder = make_tool_finder("AH_PAGER",
-  {"/usr/bin/dat", "/usr/local/bin/dat", "/opt/homebrew/bin/dat",
-    "/usr/bin/bat", "/usr/local/bin/bat", "/opt/homebrew/bin/bat"},
-  {"dat", "bat"})
+  {"/usr/bin/bat", "/usr/local/bin/bat", "/opt/homebrew/bin/bat"},
+  {"bat"})
 
--- Find a pager. Checks AH_PAGER env var first, then autodetects dat or bat.
+-- Find a pager. Checks AH_PAGER env var first, then autodetects bat.
 local function find_pager(): string
   return _pager_finder.find()
 end
@@ -180,7 +179,7 @@ local function run_pager(pager: string, content: string, file_name: string): str
       return line
     end)
 
-  local highlighted = run_piped(pager, stripped, {"--file-name=" .. file_name, "--color=always", "--style=plain"})
+  local highlighted = run_piped(pager, stripped, {"--file-name=" .. file_name, "--color=always", "--style=plain", "--map-syntax=*.tl:Lua"})
   if not highlighted then
     return nil
   end

--- a/lib/ah/test_cli.tl
+++ b/lib/ah/test_cli.tl
@@ -454,17 +454,17 @@ local function test_run_pager_empty_filename()
 end
 test_run_pager_empty_filename()
 
-local function test_find_pager_prefers_dat()
+local function test_find_pager_finds_bat()
   cli.reset_pager_cache()
   local unix = require("cosmo.unix")
-  local has_dat = unix.commandv("dat")
-  if has_dat then
+  local has_bat = unix.commandv("bat")
+  if has_bat then
     local result = cli.find_pager()
-    assert(result ~= nil and result:find("dat") ~= nil, "find_pager should prefer dat, got: " .. tostring(result))
+    assert(result ~= nil and result:find("bat") ~= nil, "find_pager should find bat, got: " .. tostring(result))
   end
   cli.reset_pager_cache()
 end
-test_find_pager_prefers_dat()
+test_find_pager_finds_bat()
 
 local function test_make_cli_handler_agent_end_shows_session_id()
   local fake_ulid = "01ABCDEFGHIJKLMNOPQRSTUVWX"

--- a/sys/tools/read.tl
+++ b/sys/tools/read.tl
@@ -91,31 +91,31 @@ return {
     local offset = (input.offset as integer) or 1
     local limit = (input.limit as integer) or 0
 
-    local total_lines = 0
-    for _ in content:gmatch("[^\n]*") do
-      total_lines = total_lines + 1
+    -- Split content into lines, dropping the phantom empty match after a
+    -- trailing newline so files ending with \n don't get a spurious extra line.
+    local all_lines: {string} = {}
+    for line in content:gmatch("[^\n]*") do
+      table.insert(all_lines, line)
     end
+    if #all_lines > 0 and all_lines[#all_lines] == "" and content:sub(-1) == "\n" then
+      table.remove(all_lines)
+    end
+    local total_lines = #all_lines
 
     if offset > 1 or limit > 0 then
       local lines: {string} = {}
-      local line_num = 0
-      for line in content:gmatch("[^\n]*") do
-        line_num = line_num + 1
-        if line_num >= offset then
-          if limit > 0 and line_num >= offset + limit then
-            break
-          end
-          table.insert(lines, string.format("%d\t%s", line_num, line))
+      for i = offset, #all_lines do
+        if limit > 0 and i >= offset + limit then
+          break
         end
+        table.insert(lines, string.format("%d\t%s", i, all_lines[i]))
       end
       return table.concat(lines, "\n"), false, {path = file_path, line_count = total_lines}
     end
 
     local lines: {string} = {}
-    local line_num = 0
-    for line in content:gmatch("[^\n]*") do
-      line_num = line_num + 1
-      table.insert(lines, string.format("%d\t%s", line_num, line))
+    for i = 1, #all_lines do
+      table.insert(lines, string.format("%d\t%s", i, all_lines[i]))
     end
     return table.concat(lines, "\n"), false, {path = file_path, line_count = total_lines}
   end,


### PR DESCRIPTION
- remove dat from pager candidates, keep bat as the only option
- add --map-syntax=*.tl:Lua to bat invocation for teal highlighting
- fix read tool gmatch producing a spurious numbered empty line for
  files ending with newline (off-by-one in line count and output)
- update test_find_pager_prefers_dat to test_find_pager_finds_bat
