### PR TITLE
replace lua markdown renderer with glow

### DIFF
--- a/lib/ah/cli.tl
+++ b/lib/ah/cli.tl
@@ -13,10 +13,7 @@ local record ToolFinder
   reset: function()
 end
 
--- make_tool_finder returns a ToolFinder that checks env_var first, then walks
--- candidates via io.open, then falls back to unix.commandv for PATH lookup.
--- tool_names is a list of command names to try via commandv, in priority order.
--- Each finder maintains its own independent cache.
+-- make_tool_finder returns a ToolFinder that checks env_var, then candidates, then PATH.
 local function make_tool_finder(env_var: string, candidates: {string}, tool_names: {string}): ToolFinder
   local cache: string | boolean = nil
 
@@ -63,13 +60,12 @@ local function make_tool_finder(env_var: string, candidates: {string}, tool_name
 end
 
 -- run_piped passes content via stdin to tool with extra_args.
--- Returns rendered output string, or nil on failure.
 local function run_piped(tool: string, content: string, extra_args: {string}): string
   if not tool or content == "" then
     return nil
   end
 
-  -- Build argv: tool is always a bare path, append extra_args elements
+  -- Build argv
   local argv: {string} = {tool}
   if extra_args then
     for _, arg in ipairs(extra_args) do
@@ -81,8 +77,7 @@ local function run_piped(tool: string, content: string, extra_args: {string}): s
   if not h then
     return nil
   end
-  -- Ignore ok and exit code: tools like delta exit 1 when showing diffs,
-  -- but their stdout is still valid output. Empty stdout means no output.
+  -- Ignore exit code: tools like delta exit 1 on diffs but stdout is valid.
   local _, stdout, _ = h:read()
   local output = (stdout as string) or ""
   if output == "" then
@@ -91,25 +86,18 @@ local function run_piped(tool: string, content: string, extra_args: {string}): s
   return output
 end
 
--- difftool_finder: find/reset for delta
-local _difftool_finder = make_tool_finder("AH_DIFFTOOL",
-  {"/usr/bin/delta", "/usr/local/bin/delta", "/opt/homebrew/bin/delta"},
-  {"delta"})
+-- difftool: delta
+local _difftool = make_tool_finder("AH_DIFFTOOL",
+  {"/usr/bin/delta", "/usr/local/bin/delta", "/opt/homebrew/bin/delta"}, {"delta"})
 
--- Find a difftool. Checks AH_DIFFTOOL env var first, then autodetects delta.
-local function find_difftool(): string
-  return _difftool_finder.find()
-end
+local function find_difftool(): string return _difftool.find() end
+local function reset_difftool_cache() _difftool.reset() end
 
--- Run diff text through a difftool subprocess with optional extra_args.
--- Returns rendered output string, or nil on failure.
 local function run_difftool(difftool: string, diff_text: string, extra_args?: {string}): string
   return run_piped(difftool, diff_text, extra_args or {})
 end
 
--- Convert the edit tool's pseudo-diff ("- "/"+ " prefixed lines) to unified diff format
--- so tools like delta can parse and syntax-highlight the output.
--- Returns nil if the input doesn't look like edit tool output.
+-- Convert edit tool pseudo-diff to unified diff for delta.
 local function to_unified_diff(pseudo_diff: string, file_path: string): string
   if not pseudo_diff or pseudo_diff == "" or not file_path or file_path == "" then
     return nil
@@ -143,25 +131,25 @@ local function to_unified_diff(pseudo_diff: string, file_path: string): string
   return header .. table.concat(unified_lines, "\n") .. "\n"
 end
 
--- Reset the difftool cache (for testing).
-local function reset_difftool_cache()
-  _difftool_finder.reset()
+-- glow: markdown renderer
+local _glow = make_tool_finder("AH_GLOW",
+  {"/usr/bin/glow", "/usr/local/bin/glow", "/opt/homebrew/bin/glow"}, {"glow"})
+
+local function find_glow(): string return _glow.find() end
+local function reset_glow_cache() _glow.reset() end
+
+local function run_glow(glow: string, text: string): string
+  return run_piped(glow, text, {"-"})
 end
 
--- pager_finder: find/reset for bat
-local _pager_finder = make_tool_finder("AH_PAGER",
-  {"/usr/bin/bat", "/usr/local/bin/bat", "/opt/homebrew/bin/bat"},
-  {"bat"})
+-- pager: bat
+local _pager = make_tool_finder("AH_PAGER",
+  {"/usr/bin/bat", "/usr/local/bin/bat", "/opt/homebrew/bin/bat"}, {"bat"})
 
--- Find a pager. Checks AH_PAGER env var first, then autodetects bat.
-local function find_pager(): string
-  return _pager_finder.find()
-end
+local function find_pager(): string return _pager.find() end
+local function reset_pager_cache() _pager.reset() end
 
--- Run content through a pager subprocess with syntax highlighting.
--- Strips N\t line number prefixes before piping (for better highlighting),
--- then re-adds them to the highlighted output.
--- Returns rendered output string, or nil on failure.
+-- Run content through bat with syntax highlighting, preserving line number prefixes.
 local function run_pager(pager: string, content: string, file_name: string): string
   if not file_name or file_name == "" then
     return nil
@@ -194,11 +182,6 @@ local function run_pager(pager: string, content: string, file_name: string): str
   return result
 end
 
--- Reset the pager cache (for testing).
-local function reset_pager_cache()
-  _pager_finder.reset()
-end
-
 -- Format token count as human-friendly string (e.g., 1234 -> "1.2k", 12345 -> "12.3k")
 local function format_tokens(n: integer): string
   if n >= 1000000 then
@@ -210,10 +193,7 @@ local function format_tokens(n: integer): string
   end
 end
 
--- Colorize a single tool output line with ANSI escape codes.
--- Uses blue+bold for success (PASS) and yellow+bold for errors (FAIL, error, exit code).
--- Uses blue/yellow instead of green/red for colorblind accessibility.
--- Returns the line (possibly colored) and a boolean indicating if color was applied.
+-- Colorize tool output lines: blue for PASS, yellow for errors.
 local function colorize_tool_line(line: string): string, boolean
   if line:sub(1, 4) == "PASS" then
     return "\27[1;34m" .. line .. "\27[0m", true
@@ -227,8 +207,7 @@ local function colorize_tool_line(line: string): string, boolean
   return line, false
 end
 
--- CLI display handler: renders structured events to stderr/stdout for terminal use.
--- Other handlers (JSON logging, web UI, etc.) can be substituted.
+-- CLI display handler: renders structured events to stderr/stdout.
 local function make_cli_handler(skill_name: string, session_ulid?: string): events.EventCallback
   local is_tty = tty.isatty(2)
   local is_stdout_tty = tty.isatty(1)
@@ -246,7 +225,13 @@ local function make_cli_handler(skill_name: string, session_ulid?: string): even
     if #text_buffer > 0 then
       local text = table.concat(text_buffer)
       if is_stdout_tty then
-        text = render.render_markdown(text)
+        local glow = find_glow()
+        if glow then
+          local rendered = run_glow(glow, text)
+          if rendered then
+            text = rendered
+          end
+        end
       end
       io.write(text)
       io.flush()
@@ -493,6 +478,9 @@ return {
   run_difftool = run_difftool,
   to_unified_diff = to_unified_diff,
   reset_difftool_cache = reset_difftool_cache,
+  find_glow = find_glow,
+  run_glow = run_glow,
+  reset_glow_cache = reset_glow_cache,
   find_pager = find_pager,
   run_pager = run_pager,
   reset_pager_cache = reset_pager_cache,

--- a/lib/ah/render.tl
+++ b/lib/ah/render.tl
@@ -1,10 +1,6 @@
--- ah/render.tl: line-oriented markdown-to-ANSI renderer for terminal output
--- Converts common markdown constructs to ANSI escape sequences.
--- Handles headings, bold, inline code, code fences (with diff colorization),
--- horizontal rules, and tables with box-drawing borders.
+-- ah/render.tl: ANSI helpers and text utilities for terminal output
 
 local BOLD = "\27[1m"
-local DIM = "\27[2m"
 local RESET = "\27[0m"
 
 -- Colorize a single diff line with ANSI escape codes.
@@ -20,40 +16,6 @@ local function colorize_diff_line(line: string): string
     return "\27[33m" .. line .. RESET
   end
   return line
-end
-
--- Apply inline markdown substitutions to a line.
--- Handles **bold** and `code` spans.
-local function apply_inline(line: string): string
-  -- Apply inline code first (more specific pattern)
-  line = line:gsub("`([^`]+)`", DIM .. "%1" .. RESET)
-  -- Apply bold
-  line = line:gsub("%*%*(.-)%*%*", BOLD .. "%1" .. RESET)
-  return line
-end
-
--- Check if a line looks like a markdown table row (starts and ends with |).
-local function is_table_line(line: string): boolean
-  local trimmed = line:match("^%s*(.-)%s*$")
-  return trimmed:sub(1, 1) == "|" and trimmed:sub(-1) == "|"
-end
-
--- Check if a line is a table separator row (e.g. |---|---|).
-local function is_separator_line(line: string): boolean
-  local trimmed = line:match("^%s*(.-)%s*$")
-  return trimmed:match("^|[%-|:%s]+|%s*$") ~= nil
-end
-
--- Parse a table row into cells (trimmed content between pipes).
-local function parse_row(line: string): {string}
-  local cells: {string} = {}
-  local trimmed = line:match("^%s*(.-)%s*$")
-  -- Strip leading and trailing pipes
-  local inner = trimmed:sub(2, -2)
-  for cell in inner:gmatch("([^|]*)") do
-    table.insert(cells, cell:match("^%s*(.-)%s*$"))
-  end
-  return cells
 end
 
 -- Compute display width of a string, stripping ANSI escape sequences
@@ -76,177 +38,6 @@ local function display_width(s: string): integer
     len = len + 1
   end
   return len
-end
-
--- Render a table block from raw markdown lines into box-drawing output.
--- Returns a list of rendered lines.
-local function render_table(lines: {string}): {string}
-  -- Parse all rows, detecting separator
-  local rows: {{string}} = {}
-  local sep_index = 0
-  for i, line in ipairs(lines) do
-    if is_separator_line(line) and i == 2 then
-      sep_index = i
-    else
-      table.insert(rows, parse_row(line))
-    end
-  end
-
-  if #rows == 0 then
-    return lines
-  end
-
-  -- Determine column count (max across all rows)
-  local num_cols = 0
-  for _, row in ipairs(rows) do
-    if #row > num_cols then
-      num_cols = #row
-    end
-  end
-
-  -- Compute column widths (max cell display width per column)
-  local widths: {integer} = {}
-  for c = 1, num_cols do
-    widths[c] = 0
-  end
-  for _, row in ipairs(rows) do
-    for c = 1, num_cols do
-      local cell = row[c] or ""
-      local w = display_width(cell)
-      if w > widths[c] then
-        widths[c] = w
-      end
-    end
-  end
-
-  -- Ensure minimum width of 1
-  for c = 1, num_cols do
-    if widths[c] < 1 then
-      widths[c] = 1
-    end
-  end
-
-  -- Build horizontal border line
-  local function hline(left: string, mid: string, right: string, fill: string): string
-    local parts: {string} = {left}
-    for c = 1, num_cols do
-      table.insert(parts, string.rep(fill, widths[c] + 2))
-      if c < num_cols then
-        table.insert(parts, mid)
-      end
-    end
-    table.insert(parts, right)
-    return table.concat(parts)
-  end
-
-  -- Build data row with optional bold and inline formatting
-  local function data_row(cells: {string}, bold: boolean): string
-    local parts: {string} = {"│"}
-    for c = 1, num_cols do
-      local cell = cells[c] or ""
-      local padded = " " .. cell .. string.rep(" ", widths[c] - display_width(cell)) .. " "
-      if bold then
-        padded = BOLD .. padded .. RESET
-      else
-        padded = apply_inline(padded)
-      end
-      table.insert(parts, padded)
-      table.insert(parts, "│")
-    end
-    return table.concat(parts)
-  end
-
-  local out: {string} = {}
-
-  -- Top border
-  table.insert(out, hline("┌", "┬", "┐", "─"))
-
-  -- Header row (if separator was found)
-  if sep_index > 0 and #rows >= 1 then
-    table.insert(out, data_row(rows[1], true))
-    -- Header separator
-    table.insert(out, hline("├", "┼", "┤", "─"))
-    -- Body rows
-    for r = 2, #rows do
-      table.insert(out, data_row(rows[r], false))
-    end
-  else
-    -- No header, all body rows
-    for _, row in ipairs(rows) do
-      table.insert(out, data_row(row, false))
-    end
-  end
-
-  -- Bottom border
-  table.insert(out, hline("└", "┴", "┘", "─"))
-
-  return out
-end
-
--- Render markdown text to ANSI-escaped text for terminal display.
--- Processes text line-by-line, tracking code fence and table state.
-local function render_markdown(text: string): string
-  local result: {string} = {}
-  local in_code_fence = false
-  local fence_lang = ""
-  local table_buf: {string} = {}
-
-  -- Flush accumulated table lines through render_table
-  local function flush_table()
-    if #table_buf > 0 then
-      local rendered = render_table(table_buf)
-      for _, l in ipairs(rendered) do
-        table.insert(result, l)
-      end
-      table_buf = {}
-    end
-  end
-
-  for line in text:gmatch("([^\n]*)\n?") do
-    if not in_code_fence then
-      -- Check for table line (outside code fences)
-      if is_table_line(line) then
-        table.insert(table_buf, line)
-      else
-        -- Flush any buffered table before processing non-table line
-        flush_table()
-
-        -- Check for fence open
-        local lang = line:match("^```(.*)$")
-        if lang then
-          in_code_fence = true
-          fence_lang = lang
-          table.insert(result, line)
-        elseif line:match("^#+ ") then
-          -- Heading: bold the full line
-          table.insert(result, BOLD .. line .. RESET)
-        elseif line:match("^%-%-%-$") or line:match("^___$") or line:match("^%*%*%*$") then
-          -- Horizontal rule: dim dashes
-          table.insert(result, DIM .. string.rep("─", 40) .. RESET)
-        else
-          -- Regular line: apply inline formatting
-          table.insert(result, apply_inline(line))
-        end
-      end
-    else
-      -- Inside code fence
-      if line:match("^```$") or line:match("^```%s") then
-        -- Fence close
-        in_code_fence = false
-        fence_lang = ""
-        table.insert(result, line)
-      elseif fence_lang == "diff" then
-        table.insert(result, colorize_diff_line(line))
-      else
-        table.insert(result, line)
-      end
-    end
-  end
-
-  -- Flush any remaining table at end of input
-  flush_table()
-
-  return table.concat(result, "\n")
 end
 
 -- Truncate a string to at most max_chars UTF-8 characters, appending suffix
@@ -275,10 +66,7 @@ local function utf8_truncate(s: string, max_chars: integer, suffix: string): str
 end
 
 return {
-  render_markdown = render_markdown,
-  apply_inline = apply_inline,
   colorize_diff_line = colorize_diff_line,
-  render_table = render_table,
   display_width = display_width,
   utf8_truncate = utf8_truncate,
 }

--- a/lib/ah/test_render.tl
+++ b/lib/ah/test_render.tl
@@ -1,127 +1,16 @@
 #!/usr/bin/env cosmic
--- test_render.tl: tests for ah.render markdown-to-ANSI renderer
+-- test_render.tl: tests for ah.render ANSI helpers and text utilities
 
 local record Render
-  render_markdown: function(text: string): string
-  apply_inline: function(line: string): string
   colorize_diff_line: function(line: string): string
-  render_table: function(lines: {string}): {string}
+  display_width: function(s: string): integer
+  utf8_truncate: function(s: string, max_chars: integer, suffix: string): string
 end
 
 local render = require("ah.render") as Render
 
 local BOLD = "\27[1m"
-local DIM = "\27[2m"
 local RESET = "\27[0m"
-
--- test: h1 heading renders bold
-local function test_h1_heading()
-  local result = render.render_markdown("# Hello\n")
-  assert(result:find(BOLD .. "# Hello" .. RESET, 1, true),
-    "h1 should be bold, got: " .. result)
-  print("PASS: h1 heading renders bold")
-end
-
--- test: h2 heading renders bold
-local function test_h2_heading()
-  local result = render.render_markdown("## Section\n")
-  assert(result:find(BOLD .. "## Section" .. RESET, 1, true),
-    "h2 should be bold, got: " .. result)
-  print("PASS: h2 heading renders bold")
-end
-
--- test: h3 heading renders bold
-local function test_h3_heading()
-  local result = render.render_markdown("### Sub\n")
-  assert(result:find(BOLD .. "### Sub" .. RESET, 1, true),
-    "h3 should be bold, got: " .. result)
-  print("PASS: h3 heading renders bold")
-end
-
--- test: **bold** renders with bold ANSI
-local function test_bold()
-  local result = render.render_markdown("some **bold** text\n")
-  assert(result:find(BOLD .. "bold" .. RESET, 1, true),
-    "bold should have ANSI bold, got: " .. result)
-  print("PASS: **bold** renders with bold ANSI")
-end
-
--- test: `code` renders with dim ANSI
-local function test_inline_code()
-  local result = render.render_markdown("use `foo` here\n")
-  assert(result:find(DIM .. "foo" .. RESET, 1, true),
-    "inline code should be dim, got: " .. result)
-  print("PASS: `code` renders with dim ANSI")
-end
-
--- test: code fence lines pass through unchanged
-local function test_code_fence()
-  local input = "```lua\nlocal x = 1\n```\n"
-  local result = render.render_markdown(input)
-  assert(result:find("local x = 1", 1, true),
-    "code fence content should pass through, got: " .. result)
-  -- Should NOT apply inline formatting inside fences
-  assert(not result:find(BOLD, 1, true),
-    "code fence content should not have bold")
-  assert(not result:find(DIM, 1, true),
-    "code fence content should not have dim")
-  print("PASS: code fence lines pass through unchanged")
-end
-
--- test: diff fence lines are colorized
-local function test_diff_fence()
-  local input = "```diff\n+added\n-removed\n@@hunk@@\n```\n"
-  local result = render.render_markdown(input)
-  assert(result:find("\27[34m+added\27[0m", 1, true),
-    "diff + line should be blue, got: " .. result)
-  assert(result:find("\27[33m-removed\27[0m", 1, true),
-    "diff - line should be yellow, got: " .. result)
-  assert(result:find("\27[36m@@hunk@@\27[0m", 1, true),
-    "diff @@ line should be cyan, got: " .. result)
-  print("PASS: diff fence lines are colorized")
-end
-
--- test: horizontal rule renders as dim dashes
-local function test_horizontal_rule()
-  local result = render.render_markdown("---\n")
-  assert(result:find(DIM, 1, true), "hr should have dim, got: " .. result)
-  assert(result:find("─", 1, true), "hr should have dash char, got: " .. result)
-  assert(result:find(RESET, 1, true), "hr should have reset, got: " .. result)
-  print("PASS: horizontal rule renders as dim dashes")
-end
-
--- test: plain text passes through unchanged
-local function test_plain_text()
-  local input = "just some plain text\n"
-  local result = render.render_markdown(input)
-  assert(result:find("just some plain text", 1, true),
-    "plain text should pass through, got: " .. result)
-  assert(not result:find(BOLD, 1, true), "plain text should not have bold")
-  assert(not result:find(DIM, 1, true), "plain text should not have dim")
-  print("PASS: plain text passes through unchanged")
-end
-
--- test: heading with inline code
-local function test_heading_with_code()
-  -- Headings are fully bolded, inline code not separately applied
-  local result = render.render_markdown("# Using `foo`\n")
-  assert(result:find(BOLD .. "# Using `foo`" .. RESET, 1, true),
-    "heading with code should be fully bold, got: " .. result)
-  print("PASS: heading with inline code renders correctly")
-end
-
--- test: multiple paragraphs
-local function test_multiple_paragraphs()
-  local input = "# Title\n\nsome **bold** here\n\n## Next\n\nplain text\n"
-  local result = render.render_markdown(input)
-  assert(result:find(BOLD .. "# Title" .. RESET, 1, true),
-    "title should be bold")
-  assert(result:find(BOLD .. "bold" .. RESET, 1, true),
-    "bold should render")
-  assert(result:find(BOLD .. "## Next" .. RESET, 1, true),
-    "second heading should be bold")
-  print("PASS: multiple paragraphs render correctly")
-end
 
 -- test: colorize_diff_line directly
 local function test_colorize_diff_line()
@@ -133,261 +22,35 @@ local function test_colorize_diff_line()
     "@@ line should be cyan")
   assert(render.colorize_diff_line("context") == "context",
     "context line should be unchanged")
-  assert(render.colorize_diff_line("--- a/file") == "\27[1m--- a/file\27[0m",
+  assert(render.colorize_diff_line("--- a/file") == BOLD .. "--- a/file" .. RESET,
     "--- line should be bold")
-  assert(render.colorize_diff_line("+++ b/file") == "\27[1m+++ b/file\27[0m",
+  assert(render.colorize_diff_line("+++ b/file") == BOLD .. "+++ b/file" .. RESET,
     "+++ line should be bold")
   print("PASS: colorize_diff_line works correctly")
 end
 
--- test: apply_inline directly
-local function test_apply_inline()
-  local result = render.apply_inline("hello **world** and `code`")
-  assert(result:find(BOLD .. "world" .. RESET, 1, true),
-    "bold should work in apply_inline")
-  assert(result:find(DIM .. "code" .. RESET, 1, true),
-    "code should work in apply_inline")
-  print("PASS: apply_inline works correctly")
-end
-
--- test: underscore and asterisk horizontal rules
-local function test_hr_variants()
-  local r1 = render.render_markdown("___\n")
-  assert(r1:find(DIM, 1, true), "___ should render as hr")
-  local r2 = render.render_markdown("***\n")
-  assert(r2:find(DIM, 1, true), "*** should render as hr")
-  print("PASS: horizontal rule variants render correctly")
-end
-
--- test: code fence does not apply bold inside
-local function test_no_bold_in_fence()
-  local input = "```\nsome **bold** text\n```\n"
-  local result = render.render_markdown(input)
-  assert(result:find("some **bold** text", 1, true),
-    "bold markers should be preserved inside fence")
-  assert(not result:find(BOLD .. "bold" .. RESET, 1, true),
-    "bold ANSI should not appear inside fence")
-  print("PASS: no bold formatting inside code fence")
-end
-
--- test: basic table renders with box-drawing chars and aligned columns
-local function test_basic_table()
-  local input = "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |\n"
-  local result = render.render_markdown(input)
-  assert(result:find("┌", 1, true), "table should have top-left corner, got: " .. result)
-  assert(result:find("┐", 1, true), "table should have top-right corner, got: " .. result)
-  assert(result:find("└", 1, true), "table should have bottom-left corner, got: " .. result)
-  assert(result:find("┘", 1, true), "table should have bottom-right corner, got: " .. result)
-  assert(result:find("│", 1, true), "table should have vertical borders, got: " .. result)
-  assert(result:find("─", 1, true), "table should have horizontal borders, got: " .. result)
-  -- Header should be bold
-  assert(result:find(BOLD .. " Name", 1, true), "header Name should be bold, got: " .. result)
-  assert(result:find(BOLD .. " Age", 1, true), "header Age should be bold, got: " .. result)
-  -- Body cells present
-  assert(result:find("Alice", 1, true), "body should contain Alice, got: " .. result)
-  assert(result:find("Bob", 1, true), "body should contain Bob, got: " .. result)
-  print("PASS: basic table renders with box-drawing chars and aligned columns")
-end
-
--- test: separator row is consumed (not shown as-is)
-local function test_separator_consumed()
-  local input = "| H1 | H2 |\n|----|----|  \n| a | b |\n"
-  local result = render.render_markdown(input)
-  assert(not result:find("|----", 1, true), "separator row should be consumed, got: " .. result)
-  assert(result:find("├", 1, true), "should have header separator border, got: " .. result)
-  assert(result:find("┼", 1, true), "should have header separator cross, got: " .. result)
-  assert(result:find("┤", 1, true), "should have header separator right, got: " .. result)
-  print("PASS: separator row is consumed")
-end
-
--- test: header cells are bold
-local function test_header_bold()
-  local input = "| X | Y |\n|---|---|\n| 1 | 2 |\n"
-  local result = render.render_markdown(input)
-  assert(result:find(BOLD, 1, true), "header cells should be bold, got: " .. result)
-  print("PASS: header cells are bold")
-end
-
--- test: table with no separator row treats all rows as body
-local function test_no_separator()
-  local input = "| a | b |\n| c | d |\n"
-  local result = render.render_markdown(input)
-  assert(result:find("┌", 1, true), "no-sep table should have borders, got: " .. result)
-  assert(not result:find("├", 1, true), "no-sep table should not have header sep, got: " .. result)
-  assert(not result:find(BOLD, 1, true), "no-sep table should not have bold, got: " .. result)
-  print("PASS: table with no separator row treats all as body")
-end
-
--- test: table with varying cell widths aligns correctly
-local function test_varying_widths()
-  local input = "| Short | Very Long Header |\n|-------|------------------|\n| x | y |\n"
-  local result = render.render_markdown(input)
-  assert(result:find("┌", 1, true), "varying widths should render, got: " .. result)
-  assert(result:find("Short", 1, true), "should contain Short, got: " .. result)
-  assert(result:find("Very Long Header", 1, true), "should contain long header, got: " .. result)
-  print("PASS: table with varying cell widths aligns correctly")
-end
-
--- test: table surrounded by other markdown renders correctly
-local function test_table_with_context()
-  local input = "# Title\n\nSome text.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nMore text.\n"
-  local result = render.render_markdown(input)
-  assert(result:find(BOLD .. "# Title" .. RESET, 1, true), "heading should render")
-  assert(result:find("┌", 1, true), "table should render in context, got: " .. result)
-  assert(result:find("Some text.", 1, true), "text before table should be present")
-  assert(result:find("More text.", 1, true), "text after table should be present")
-  print("PASS: table surrounded by other markdown renders correctly")
-end
-
--- test: table inside code fence is NOT formatted
-local function test_table_in_code_fence()
-  local input = "```\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n"
-  local result = render.render_markdown(input)
-  assert(not result:find("┌", 1, true), "table in fence should not have box chars, got: " .. result)
-  assert(result:find("| A | B |", 1, true), "table in fence should pass through raw, got: " .. result)
-  print("PASS: table inside code fence is NOT formatted")
-end
-
--- test: single-row table
-local function test_single_row_table()
-  local input = "| only | row |\n"
-  local result = render.render_markdown(input)
-  assert(result:find("┌", 1, true), "single-row table should have borders, got: " .. result)
-  assert(result:find("└", 1, true), "single-row table should have bottom border, got: " .. result)
-  assert(result:find("only", 1, true), "single-row should contain 'only', got: " .. result)
-  print("PASS: single-row table")
-end
-
--- test: cells with inline formatting (bold, code)
-local function test_inline_formatting_in_cells()
-  local input = "| **bold** | `code` |\n|----------|--------|\n| normal | text |\n"
-  local result = render.render_markdown(input)
-  assert(result:find("normal", 1, true), "body should contain normal, got: " .. result)
-  print("PASS: cells with inline formatting")
-end
-
--- test: empty cells
-local function test_empty_cells()
-  local input = "| A | B |\n|---|---|\n|  |  |\n"
-  local result = render.render_markdown(input)
-  assert(result:find("┌", 1, true), "empty cell table should render, got: " .. result)
-  assert(result:find("└", 1, true), "empty cell table should have bottom, got: " .. result)
-  print("PASS: empty cells")
-end
-
--- test: render_table directly
-local function test_render_table_direct()
-  local lines = {"| H1 | H2 |", "|----|----|", "| a  | b  |"}
-  local out = render.render_table(lines)
-  assert(#out > 0, "render_table should return lines")
-  local joined = table.concat(out, "\n")
-  assert(joined:find("┌", 1, true), "render_table should produce box chars, got: " .. joined)
-  assert(joined:find("H1", 1, true), "render_table should contain H1, got: " .. joined)
-  print("PASS: render_table direct")
-end
-
--- test: ragged table (rows with different column counts)
-local function test_ragged_table()
-  local input = "| A | B | C |\n|---|---|---|\n| 1 | 2 |\n"
-  local result = render.render_markdown(input)
-  assert(result:find("┌", 1, true), "ragged table should render, got: " .. result)
-  assert(result:find("A", 1, true), "ragged table should contain A, got: " .. result)
-  print("PASS: ragged table")
-end
-
--- test: table with multi-byte UTF-8 characters aligns correctly
-local function test_utf8_table()
-  local input = "| Name | City |\n|------|------|\n| Alice | Zürich |\n| Bob | Paris |\n"
-  local result = render.render_markdown(input)
-  -- All rows should have same visual width between │ delimiters.
-  -- Extract lines with │ (data rows) and check they have consistent segments.
-  local data_lines: {string} = {}
-  for line in result:gmatch("([^\n]+)") do
-    if line:sub(1, 3) == "│" then
-      table.insert(data_lines, line)
-    end
-  end
-  assert(#data_lines >= 2, "should have at least 2 data rows, got: " .. #data_lines)
-  -- Strip ANSI codes and check visual widths match
-  local function strip_ansi(s: string): string
-    return (s:gsub("\27%[[%d;]*m", ""))
-  end
-  local function utf8len(s: string): integer
-    local len = 0
-    local i = 1
-    while i <= #s do
-      local b = s:byte(i)
-      if b < 0x80 then i = i + 1
-      elseif b < 0xE0 then i = i + 2
-      elseif b < 0xF0 then i = i + 3
-      else i = i + 4 end
-      len = len + 1
-    end
-    return len
-  end
-  local widths: {integer} = {}
-  for _, line in ipairs(data_lines) do
-    table.insert(widths, utf8len(strip_ansi(line)))
-  end
-  for i = 2, #widths do
-    assert(widths[i] == widths[1],
-      "data row " .. i .. " width " .. widths[i] .. " != header width " .. widths[1] .. "\n" .. result)
-  end
-  print("PASS: table with multi-byte UTF-8 characters aligns correctly")
-end
-
 -- test: display_width counts UTF-8 characters not bytes
 local function test_display_width()
-  -- re-export display_width
-  local dw = (render as {string: function(string): integer}).display_width
-  assert(dw("hello") == 5, "ASCII should be 5")
-  assert(dw("café") == 4, "café should be 4 chars, not 5 bytes")
-  assert(dw("日本語") == 3, "3 CJK chars")
-  assert(dw("a\27[1mb\27[0mc") == 3, "ANSI codes should be stripped")
-  assert(dw("") == 0, "empty string")
+  assert(render.display_width("hello") == 5, "ASCII should be 5")
+  assert(render.display_width("café") == 4, "café should be 4 chars, not 5 bytes")
+  assert(render.display_width("日本語") == 3, "3 CJK chars")
+  assert(render.display_width("a\27[1mb\27[0mc") == 3, "ANSI codes should be stripped")
+  assert(render.display_width("") == 0, "empty string")
   print("PASS: display_width counts UTF-8 characters not bytes")
 end
 
 -- test: utf8_truncate never splits multi-byte sequences
 local function test_utf8_truncate()
-  local trunc = (render as {string: function(string, integer, string): string}).utf8_truncate
-  assert(trunc("hello", 3, "...") == "hel...", "ASCII truncate")
-  assert(trunc("hi", 10, "...") == "hi", "no truncate when short")
-  assert(trunc("café", 3, "...") == "caf...", "truncate before é")
-  assert(trunc("café", 4, "...") == "café", "exact length no truncate")
+  assert(render.utf8_truncate("hello", 3, "...") == "hel...", "ASCII truncate")
+  assert(render.utf8_truncate("hi", 10, "...") == "hi", "no truncate when short")
+  assert(render.utf8_truncate("café", 3, "...") == "caf...", "truncate before é")
+  assert(render.utf8_truncate("café", 4, "...") == "café", "exact length no truncate")
   -- Verify no broken UTF-8
-  local result = trunc("aübcd", 3, "…")
+  local result = render.utf8_truncate("aübcd", 3, "…")
   assert(result == "aüb…", "should not split ü, got: " .. result)
   print("PASS: utf8_truncate never splits multi-byte sequences")
 end
 
-test_h1_heading()
-test_h2_heading()
-test_h3_heading()
-test_bold()
-test_inline_code()
-test_code_fence()
-test_diff_fence()
-test_horizontal_rule()
-test_plain_text()
-test_heading_with_code()
-test_multiple_paragraphs()
 test_colorize_diff_line()
-test_apply_inline()
-test_hr_variants()
-test_no_bold_in_fence()
-test_basic_table()
-test_separator_consumed()
-test_header_bold()
-test_no_separator()
-test_varying_widths()
-test_table_with_context()
-test_table_in_code_fence()
-test_single_row_table()
-test_inline_formatting_in_cells()
-test_empty_cells()
-test_render_table_direct()
-test_ragged_table()
-test_utf8_table()
 test_display_width()
 test_utf8_truncate()


### PR DESCRIPTION
remove the built-in lua markdown-to-ANSI renderer (render_markdown, render_table, apply_inline, and all table/inline formatting) from render.tl. keep only utility functions: colorize_diff_line, display_width, utf8_truncate.

add a glow finder in cli.tl following the same pattern as delta and bat finders. agent response text is now piped through `glow -` when available on a tty, falling back to raw text if glow is not found or fails. configurable via `AH_GLOW` env var.

- **render.tl**: 278 → 73 lines (−205)
- **cli.tl**: +glow finder, run_glow, reset_glow_cache; flush_text uses glow
- **test_render.tl**: 393 → 57 lines; removed all render_markdown/table tests, kept utility tests

all tests and type checks pass.