### PR TITLE
enable 1M context by default for opus and sonnet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Makefile               build system
   ah embed myconfig
   ```
 - **models**: aliases `sonnet`, `opus`, `haiku` resolve to full model names
-  in `api.tl`. default model is `claude-opus-4-6`.
+  in `api.tl`. default model is `claude-opus-4-6-1m`.
 - **accessibility**: terminal colors must be colorblind-friendly. avoid
   red/green distinctions — use blue/yellow or bold/dim instead. all visual
   indicators should be distinguishable without color (e.g. via shape, symbol,

--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -45,7 +45,7 @@ local function get_api_url(): string
     return "https://api.anthropic.com/v1/messages"
   end
 end
-local DEFAULT_MODEL = "claude-opus-4-6"
+local DEFAULT_MODEL = "claude-opus-4-6-1m"
 local DEFAULT_MAX_TOKENS = 16384
 
 local MODELS: {string} = {
@@ -58,9 +58,9 @@ local MODELS: {string} = {
 }
 
 local MODEL_ALIASES: {string: string} = {
-  ["sonnet"] = "claude-sonnet-4-6",
+  ["sonnet"] = "claude-sonnet-4-6-1m",
   ["sonnet-1m"] = "claude-sonnet-4-6-1m",
-  ["opus"] = "claude-opus-4-6",
+  ["opus"] = "claude-opus-4-6-1m",
   ["opus-1m"] = "claude-opus-4-6-1m",
   ["haiku"] = "claude-haiku-4-5-20251001",
 }

--- a/lib/ah/compact.tl
+++ b/lib/ah/compact.tl
@@ -11,7 +11,7 @@ local api = require("ah.api")
 -- Model context window limits (tokens) — sourced from api.MODEL_CONTEXT_LIMITS
 local MODEL_CONTEXT_LIMITS = api.MODEL_CONTEXT_LIMITS
 
-local DEFAULT_CONTEXT_LIMIT = 200000
+local DEFAULT_CONTEXT_LIMIT = 1000000
 
 -- Compaction triggers when input_tokens / context_limit exceeds this ratio
 local DEFAULT_THRESHOLD = 0.8

--- a/lib/ah/test_api.tl
+++ b/lib/ah/test_api.tl
@@ -61,7 +61,7 @@ test_extract_tool_calls_mixed()
 local function test_build_request_default_model()
   local req = api.build_request({}, {}, false)
   assert(req.model == api.DEFAULT_MODEL, "should use default model")
-  assert(req.model == "claude-opus-4-6", "default model should be opus")
+  assert(req.model == "claude-opus-4-6-1m", "default model should be opus 1m")
 end
 test_build_request_default_model()
 
@@ -251,9 +251,9 @@ test_extract_retry_delay()
 
 local function test_resolve_model()
   -- Aliases should resolve to full names
-  assert(api.resolve_model("sonnet") == "claude-sonnet-4-6", "sonnet alias")
+  assert(api.resolve_model("sonnet") == "claude-sonnet-4-6-1m", "sonnet alias")
   assert(api.resolve_model("sonnet-1m") == "claude-sonnet-4-6-1m", "sonnet-1m alias")
-  assert(api.resolve_model("opus") == "claude-opus-4-6", "opus alias")
+  assert(api.resolve_model("opus") == "claude-opus-4-6-1m", "opus alias")
   assert(api.resolve_model("opus-1m") == "claude-opus-4-6-1m", "opus-1m alias")
   assert(api.resolve_model("haiku") == "claude-haiku-4-5-20251001", "haiku alias")
   -- Full names should pass through

--- a/lib/ah/test_cli.tl
+++ b/lib/ah/test_cli.tl
@@ -129,7 +129,7 @@ local function test_make_cli_handler_agent_end_nil_model_uses_default()
           total_cache_read_tokens = 0,
         } as events.EventData)
     end)
-  assert(output:match("200%.0k"), "nil model should fall back to 200.0k budget, got: " .. output)
+  assert(output:match("1%.0m"), "nil model should fall back to 1.0m budget, got: " .. output)
   assert(output:match("%%"), "output should contain '%', got: " .. output)
 end
 test_make_cli_handler_agent_end_nil_model_uses_default()

--- a/lib/ah/test_compact.tl
+++ b/lib/ah/test_compact.tl
@@ -119,8 +119,9 @@ end
 test_needs_compaction_custom_threshold_tight()
 
 local function test_needs_compaction_unknown_model()
-  -- Unknown model uses default limit (200000)
-  assert(compact.needs_compaction(170000, "some-future-model"), "unknown model should use default limit")
+  -- Unknown model uses default limit (1000000), threshold 0.8 = 800000
+  assert(compact.needs_compaction(850000, "some-future-model"), "unknown model should use default limit")
+  assert(not compact.needs_compaction(170000, "some-future-model"), "170k should not trigger with 1M default limit")
   print("✓ needs_compaction with unknown model")
 end
 test_needs_compaction_unknown_model()
@@ -134,8 +135,8 @@ end
 test_default_threshold()
 
 local function test_default_context_limit()
-  assert(compact.DEFAULT_CONTEXT_LIMIT == 200000, "default context limit should be 200000: " .. tostring(compact.DEFAULT_CONTEXT_LIMIT))
-  print("✓ DEFAULT_CONTEXT_LIMIT is 200000")
+  assert(compact.DEFAULT_CONTEXT_LIMIT == 1000000, "default context limit should be 1000000: " .. tostring(compact.DEFAULT_CONTEXT_LIMIT))
+  print("✓ DEFAULT_CONTEXT_LIMIT is 1000000")
 end
 test_default_context_limit()
 


### PR DESCRIPTION
changes the default model aliases to use the 1M context variants. there is no downside — same model, same pricing for input tokens under 200K, and it avoids context window errors on long sessions.

## changes

- `DEFAULT_MODEL` → `claude-opus-4-6-1m`
- `sonnet` alias → `claude-sonnet-4-6-1m`
- `opus` alias → `claude-opus-4-6-1m`
- `DEFAULT_CONTEXT_LIMIT` → 1000000 in compact.tl (matches new default model)
- updated AGENTS.md model reference
- updated tests for new defaults

closes #507