### PR TITLE
work loop: deadline support, stub helper, shebang-aware runner

### DIFF
--- a/lib/ah/loop.tl
+++ b/lib/ah/loop.tl
@@ -1,5 +1,6 @@
 -- ah/loop.tl: agent loop (API call → tool dispatch → repeat)
 local json = require("cosmic.json")
+local time = require("cosmic.time")
 local db = require("ah.db")
 local api = require("ah.api")
 local tools = require("ah.tools")
@@ -40,6 +41,7 @@ local record AgentOpts
   max_tokens: integer
   max_turn_tokens: integer
   must_produce: string
+  deadline: number -- unix timestamp; stop after this time
 end
 
 -- Build API messages from ancestry. Cuts off at the last [COMPACTION SUMMARY].
@@ -356,18 +358,15 @@ local function run_agent(d: db.DB, qdb: queue.QueueDB, system_prompt: string, mo
     if max_tokens and (last_effective_input_tokens + cumulative_output_tokens) > max_tokens then
       emit(on_event, events.budget_exceeded(last_effective_input_tokens, cumulative_output_tokens, max_tokens))
       db.log_event(d, "budget_exceeded", assistant_msg.id, events.to_json(events.budget_exceeded(last_effective_input_tokens, cumulative_output_tokens, max_tokens)))
-      local pending_tool_ids: {string} = {}
-      for _, blk in ipairs(assistant_blocks) do
-        if blk.block_type == "tool_use" then table.insert(pending_tool_ids, blk.tool_id as string) end
-      end
-      if #pending_tool_ids > 0 then
-        db.begin_transaction(d)
-        local stub_msg = db.create_message(d, "user", assistant_msg.id)
-        for _, tid in ipairs(pending_tool_ids) do
-          db.add_content_block(d, stub_msg.id, "tool_result", {tool_id = tid, tool_output = "error: tool execution skipped (token budget exceeded)", is_error = true, duration_ms = 0})
-        end
-        db.commit(d)
-      end
+      looptool.stub_pending_tools(d, assistant_msg.id, assistant_blocks, "token budget exceeded")
+      final_stop_reason = "budget_exceeded"
+      break
+    end
+
+    if opts.deadline and time.now() >= opts.deadline then
+      local dl_budget = max_tokens or (last_effective_input_tokens + cumulative_output_tokens)
+      emit(on_event, events.budget_exceeded(last_effective_input_tokens, cumulative_output_tokens, dl_budget))
+      looptool.stub_pending_tools(d, assistant_msg.id, assistant_blocks, "deadline exceeded")
       final_stop_reason = "budget_exceeded"
       break
     end

--- a/lib/ah/looptool.tl
+++ b/lib/ah/looptool.tl
@@ -181,8 +181,24 @@ local function persist_tool_results(
   return tool_result_msg
 end
 
+-- Stub out pending tool_use blocks with an error message.
+local function stub_pending_tools(d: db.DB, parent_id: string, blocks: {{string: any}}, reason: string)
+  local ids: {string} = {}
+  for _, blk in ipairs(blocks) do
+    if blk.block_type == "tool_use" then table.insert(ids, blk.tool_id as string) end
+  end
+  if #ids == 0 then return end
+  db.begin_transaction(d)
+  local msg = db.create_message(d, "user", parent_id)
+  for _, tid in ipairs(ids) do
+    db.add_content_block(d, msg.id, "tool_result", {tool_id = tid, tool_output = "error: " .. reason, is_error = true, duration_ms = 0})
+  end
+  db.commit(d)
+end
+
 return {
   execute_tool_calls = execute_tool_calls,
   persist_tool_results = persist_tool_results,
+  stub_pending_tools = stub_pending_tools,
   ToolExecResult = ToolExecResult,
 }

--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -39,7 +39,7 @@ end
 
 -- Run a shell script via cosmic.child. Returns stdout, stderr, exit_code.
 local function run_script(path: string): string, string, integer
-  local handle, err = child.spawn({"bash", path})
+  local handle, err = child.spawn({path})
   if not handle then
     return "", err or "spawn failed", 1
   end
@@ -139,7 +139,7 @@ local function run_agent_once(
     return nil
   end
   local on_event = quiet and function(_: any) end or cli_mod.make_cli_handler("work", id)
-  local opts: loop.AgentOpts = {max_tokens = 16384}
+  local opts: loop.AgentOpts = {deadline = os.time() as number + 300}
   loop.run_agent(d, qdb, system, model, prompt, nil, on_event, opts)
   local last_text: string = nil
   local last = db.get_last_message(d)


### PR DESCRIPTION
three improvements to the `--work` loop:

**deadline support**: adds a `deadline` field to `AgentOpts`. the inner agent now runs for up to 5 minutes (wall clock) instead of using a fixed 16k token budget. the old budget was too small — the agent would spend all tokens reading files and never make edits.

**stub_pending_tools helper**: extracts the duplicated logic for stubbing out pending `tool_use` blocks when the loop terminates early into `looptool.stub_pending_tools()`. used by both the budget_exceeded and deadline checks. net reduction of 2 lines in loop.tl.

**shebang-aware script runner**: `run_script` now uses `{path}` instead of `{"bash", path}`, so work scripts can use any interpreter via shebang (e.g. `#!/usr/bin/env cosmic` for teal scripts).