### PR TITLE
replace lua os.* calls with cosmic equivalents

### DIFF
--- a/bin/ah.tl
+++ b/bin/ah.tl
@@ -1,9 +1,10 @@
 #!/usr/bin/env cosmic
 -- bin/ah: CLI entry point for ah agent handler
 local ah = require("ah")
+local proc = require("cosmic.proc")
 
 local code, err = ah.main(arg)
 if err then
   io.stderr:write("error: " .. err .. "\n")
 end
-os.exit(code)
+proc.exit(code)

--- a/lib/ah/api.tl
+++ b/lib/ah/api.tl
@@ -4,6 +4,7 @@ local fetch = require("cosmic.fetch")
 local time = require("cosmic.time")
 local auth = require("ah.auth")
 local util = require("ah.util")
+local cenv = require("cosmic.env")
 
 -- Tool name mapping for Claude Code compatibility (OAuth mode)
 local CLAUDE_CODE_TOOLS: {string: string} = {
@@ -37,7 +38,7 @@ end
 
 -- Resolve API URL lazily so envd.load() has time to set ANTHROPIC_BASE_URL.
 local function get_api_url(): string
-  local base = os.getenv("ANTHROPIC_BASE_URL")
+  local base = cenv.get("ANTHROPIC_BASE_URL")
   if base then
     -- Strip trailing slash before appending path
     return base:gsub("/$", "") .. "/v1/messages"

--- a/lib/ah/auth.tl
+++ b/lib/ah/auth.tl
@@ -1,5 +1,6 @@
 -- ah/auth.lua: API key credential loading
 local io = require("cosmic.io")
+local cenv = require("cosmic.env")
 
 local record Credentials
   access_token: string
@@ -35,19 +36,19 @@ end
 
 local function load_credentials(): Credentials, string
   -- Priority: CLAUDE_CODE_OAUTH_TOKEN (OAuth tokens for Claude Max)
-  local oauth_token = sanitize_token(os.getenv("CLAUDE_CODE_OAUTH_TOKEN"))
+  local oauth_token = sanitize_token(cenv.get("CLAUDE_CODE_OAUTH_TOKEN"))
   if oauth_token and oauth_token ~= "" then
     return {access_token = oauth_token, is_oauth = true}
   end
 
   -- ANTHROPIC_AUTH_TOKEN: Bearer token (e.g. proxy or custom endpoint)
-  local auth_token = sanitize_token(os.getenv("ANTHROPIC_AUTH_TOKEN"))
+  local auth_token = sanitize_token(cenv.get("ANTHROPIC_AUTH_TOKEN"))
   if auth_token and auth_token ~= "" then
     return {access_token = auth_token, is_oauth = false, is_bearer = true}
   end
 
   -- Fall back to ANTHROPIC_API_KEY (regular API key)
-  local api_key = sanitize_token(os.getenv("ANTHROPIC_API_KEY"))
+  local api_key = sanitize_token(cenv.get("ANTHROPIC_API_KEY"))
   if api_key and api_key ~= "" then
     return {access_token = api_key, is_oauth = false}
   end

--- a/lib/ah/cli.tl
+++ b/lib/ah/cli.tl
@@ -5,6 +5,7 @@ local loop = require("ah.loop")
 local render = require("ah.render")
 local compact = require("ah.compact")
 local hl = require("ah.highlight")
+local cenv = require("cosmic.env")
 
 -- Format token count as human-friendly string (e.g., 1234 -> "1.2k", 12345 -> "12.3k")
 local function format_tokens(n: integer): string
@@ -35,8 +36,8 @@ end
 local function make_cli_handler(skill_name: string, session_ulid?: string): events.EventCallback
   local is_tty = tty.isatty(2)
   local is_stdout_tty = tty.isatty(1)
-  local is_ci = os.getenv("GITHUB_ACTIONS") == "true"
-  local term = os.getenv("TERM") or ""
+  local is_ci = cenv.get("GITHUB_ACTIONS") == "true"
+  local term = cenv.get("TERM") or ""
   local is_dumb = term == "dumb" or term == ""
   local DIM = is_tty and "\27[2m" or ""
   local RESET = is_tty and "\27[0m" or ""

--- a/lib/ah/db.tl
+++ b/lib/ah/db.tl
@@ -2,6 +2,7 @@
 local fs = require("cosmic.fs")
 local sqlite = require("cosmic.sqlite")
 local ulid = require("ulid")
+local ctime = require("cosmic.time")
 
 local SCHEMA = [[
 create table if not exists messages (
@@ -202,7 +203,7 @@ end
 
 local function create_message(self: DB, role: string, parent_id?: string, opts?: MessageOpts): Message
   local id = ulid.generate()
-  local now = os.time()
+  local now = math.floor((ctime.now())) as integer
   opts = opts or {}
 
   local seq = 0
@@ -319,7 +320,7 @@ end
 
 local function log_event(self: DB, event_type: string, message_id?: string, details?: string): Event
   local id = ulid.generate()
-  local now = os.time()
+  local now = math.floor((ctime.now())) as integer
   self._db:exec_list("insert into events (id, message_id, event_type, created_at, details) values (?, ?, ?, ?, ?)",
     {id, message_id, event_type, now, details}, 5)
   return {id = id, message_id = message_id, event_type = event_type, created_at = now, details = details}

--- a/lib/ah/events.tl
+++ b/lib/ah/events.tl
@@ -1,5 +1,6 @@
 -- ah/events.tl: structured event system for agent lifecycle
 local json = require("cosmic.json")
+local ctime = require("cosmic.time")
 
 -- Event types covering the full agent lifecycle:
 --   agent_start, agent_end
@@ -86,7 +87,7 @@ local type EventCallback = function(event: EventData)
   local function make_event(event_type: string, fields?: EventData): EventData
     local e = fields or {} as EventData
     e.event_type = event_type
-    e.timestamp = os.time() as number
+    e.timestamp = (ctime.now()) as number
     return e
   end
 

--- a/lib/ah/highlight.tl
+++ b/lib/ah/highlight.tl
@@ -3,6 +3,7 @@
 local tty = require("cosmic.tty")
 local child = require("cosmic.child")
 local unix = require("cosmo.unix")
+local cenv = require("cosmic.env")
 
 -- ToolFinder holds a find function and a reset function for a cached tool lookup.
 local record ToolFinder
@@ -22,7 +23,7 @@ local function make_tool_finder(env_var: string, candidates: {string}, tool_name
       return cache as string
     end
 
-    local env_tool = os.getenv(env_var)
+    local env_tool = cenv.get(env_var)
     if env_tool and env_tool ~= "" then
       cache = env_tool
       return env_tool
@@ -224,7 +225,7 @@ local function glow_style(): string
     local content = f:read("*a")
     f:close()
     if content and content ~= "" then
-      local tmpdir = os.getenv("TMPDIR") or "/tmp"
+      local tmpdir = cenv.get("TMPDIR") or "/tmp"
       local tmppath = tmpdir .. "/ah-glow-style.json"
       local out = io.open(tmppath, "w")
       if out then

--- a/lib/ah/init.tl
+++ b/lib/ah/init.tl
@@ -4,7 +4,7 @@ local cio = require("cosmic.io")
 local tty = require("cosmic.tty")
 local proc = require("cosmic.proc")
 local signal = require("cosmic.signal")
-
+local cenv = require("cosmic.env")
 local zip = require("cosmic.zip")
 local embed = require("cosmic.embed")
 local db = require("ah.db")
@@ -60,7 +60,7 @@ end
 -- cwd is the working directory; extra_dirs is a comma-separated list of "path:perms".
 local function apply_unveil(cwd: string, extra_dirs: string)
   sandbox.unveil(cwd, "rwxc")
-  local protect = args_mod.parse_protect_dirs(os.getenv("AH_PROTECT_DIRS"))
+  local protect = args_mod.parse_protect_dirs(cenv.get("AH_PROTECT_DIRS"))
   for _, dir in ipairs(protect) do
     sandbox.unveil(cwd .. "/" .. dir, "r")
   end
@@ -84,7 +84,7 @@ local function apply_unveil(cwd: string, extra_dirs: string)
   sandbox.unveil("/dev/null", "rw")
   sandbox.unveil("/dev/tty", "rw")
   sandbox.unveil("/proc/self", "r")
-  local home = os.getenv("HOME")
+  local home = cenv.get("HOME")
   if home then sandbox.unveil(home, "r") end
   sandbox.unveil(nil, nil)
 end
@@ -98,9 +98,9 @@ local function main(args: {string}): integer, string
   -- Sandbox mode: when AH_SANDBOX=1, apply network sandbox restrictions.
   -- When AH_UNVEIL is set (with or without AH_SANDBOX), apply unveil.
   -- When AH_PLEDGE is set (with or without AH_SANDBOX), apply pledge.
-  local in_sandbox = os.getenv("AH_SANDBOX")
-  local unveil_env = os.getenv("AH_UNVEIL")
-  local pledge_env = os.getenv("AH_PLEDGE")
+  local in_sandbox = cenv.get("AH_SANDBOX")
+  local unveil_env = cenv.get("AH_UNVEIL")
+  local pledge_env = cenv.get("AH_PLEDGE")
 
   if in_sandbox or unveil_env then
     apply_unveil(fs.getcwd(), unveil_env)
@@ -459,7 +459,7 @@ local function main(args: {string}): integer, string
     signal.setitimer({which = signal.ITIMER_REAL, valuesec = parsed.timeout, valuens = 0, intervalsec = 0, intervalns = 0})
   end
 
-  local effective_model = api.resolve_model(model or os.getenv("AH_MODEL"))
+  local effective_model = api.resolve_model(model or cenv.get("AH_MODEL"))
   local on_event = cli_mod.make_cli_handler(parsed.skill, session_ulid)
   local agent_opts: loop.AgentOpts = {}
   if max_tokens then agent_opts.max_tokens = max_tokens end

--- a/lib/ah/prompt.tl
+++ b/lib/ah/prompt.tl
@@ -3,6 +3,8 @@ local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local child = require("cosmic.child")
 local args_mod = require("ah.args")
+local cenv = require("cosmic.env")
+local ctime = require("cosmic.time")
 
 -- Run a git command in cwd with a 2s timeout. Returns trimmed stdout or nil.
 -- Never throws. Any failure (not a repo, git missing, timeout, bad exit) returns nil.
@@ -110,7 +112,7 @@ end
 -- cwd is used to resolve protected dirs from AH_PROTECT_DIRS.
 -- NOTE: the hardcoded unveil list and pledge string must stay in sync with init.tl.
 local function sandbox_context(cwd: string): string
-  if not os.getenv("AH_SANDBOX") then return "" end
+  if not cenv.get("AH_SANDBOX") then return "" end
 
   local lines: {string} = {}
 
@@ -134,19 +136,19 @@ local function sandbox_context(cwd: string): string
     {"/dev/tty", "rw"},
     {"/proc/self", "r"},
   }
-  local home = os.getenv("HOME")
+  local home = cenv.get("HOME")
   if home then
     hardcoded[#hardcoded + 1] = {home, "r"}
   end
 
   -- Protected dirs (AH_PROTECT_DIRS) → cwd/dir with "r"
-  local protect = args_mod.parse_protect_dirs(os.getenv("AH_PROTECT_DIRS"))
+  local protect = args_mod.parse_protect_dirs(cenv.get("AH_PROTECT_DIRS"))
   for _, dir in ipairs(protect) do
     hardcoded[#hardcoded + 1] = {cwd .. "/" .. dir, "r"}
   end
 
   -- Extra unveil entries from AH_UNVEIL (path:perms, comma-separated)
-  local unveil_env = os.getenv("AH_UNVEIL")
+  local unveil_env = cenv.get("AH_UNVEIL")
   if unveil_env then
     for entry in unveil_env:gmatch("[^,]+") do
       local u_path, u_perms = args_mod.parse_unveil_entry(entry)
@@ -164,7 +166,7 @@ local function sandbox_context(cwd: string): string
   -- Network (proxy allowlist)
   lines[#lines + 1] = "\n\n### Network (proxy allowlist)"
   local hosts: {string} = {"api.anthropic.com:443"}
-  local allow_env = os.getenv("AH_ALLOW_HOSTS")
+  local allow_env = cenv.get("AH_ALLOW_HOSTS")
   if allow_env then
     for entry in allow_env:gmatch("[^,]+") do
       hosts[#hosts + 1] = entry
@@ -205,7 +207,7 @@ local function load_system_prompt(cwd: string): string
   end
 
   -- Append runtime context (datetime, working directory, git info)
-  local date_str = os.date("!%Y-%m-%dT%H:%M:%SZ") as string
+  local date_str = ctime.format_iso8601((ctime.now()))
   base = base .. "\n\nCurrent date: " .. date_str .. "\nWorking directory: " .. cwd
 
   local git = git_context(cwd)

--- a/lib/ah/protect.tl
+++ b/lib/ah/protect.tl
@@ -1,8 +1,9 @@
 -- ah/protect.tl: shared path protection check for AH_PROTECT_DIRS
 local fs = require("cosmic.fs")
+local cenv = require("cosmic.env")
 
 local function is_protected(path: string): boolean
-  local protect_env = os.getenv("AH_PROTECT_DIRS") or ""
+  local protect_env = cenv.get("AH_PROTECT_DIRS") or ""
   if protect_env == "" then return false end
   local cwd = fs.getcwd() or ""
   local abs_path: string

--- a/lib/ah/proxy.tl
+++ b/lib/ah/proxy.tl
@@ -6,6 +6,8 @@ local child = require("cosmic.child")
 local net = require("cosmic.net")
 local ip = require("cosmic.ip")
 local signal = require("cosmic.signal")
+local cenv = require("cosmic.env")
+local proc = require("cosmic.proc")
 
 -- TODO: use net.Socket once cosmic exports it on NetModule
 -- https://github.com/whilp/cosmic/issues/230
@@ -52,7 +54,7 @@ local function parse_allow_hosts(value: string): {string: boolean}
 end
 
 -- Merge AH_ALLOW_HOSTS into the allowlist at load time
-local allow_hosts_env = os.getenv("AH_ALLOW_HOSTS")
+local allow_hosts_env = cenv.get("AH_ALLOW_HOSTS")
 if allow_hosts_env then
   local extra = parse_allow_hosts(allow_hosts_env)
   for host, _ in pairs(extra) do
@@ -80,7 +82,7 @@ local function parse_base_url(url: string): string
 end
 
 -- Add ANTHROPIC_BASE_URL host to allowlist at load time
-local base_url_env = os.getenv("ANTHROPIC_BASE_URL")
+local base_url_env = cenv.get("ANTHROPIC_BASE_URL")
 if base_url_env then
   local hostport = parse_base_url(base_url_env)
   if hostport then
@@ -102,11 +104,11 @@ local function resolvehost(host: string): ip.Addr, string
   return addr, err
 end
 
-local _log_level = os.getenv("AH_LOG_LEVEL")
+local _log_level = cenv.get("AH_LOG_LEVEL")
 if not _log_level then
-  _log_level = os.getenv("CI") and "info" or "debug"
+  _log_level = cenv.get("CI") and "info" or "debug"
 end
-local verbose = os.getenv("AH_PROXY_VERBOSE") == "1" or _log_level == "debug"
+local verbose = cenv.get("AH_PROXY_VERBOSE") == "1" or _log_level == "debug"
 
 local function log(...: string)
   if not verbose then return end
@@ -348,7 +350,7 @@ function M.serve(socket_path: string): integer
         server:close()
         handle_client(client as Socket)
         client:close()
-        os.exit(0)
+        proc.exit(0)
       else
         client:close()
       end

--- a/lib/ah/queue.tl
+++ b/lib/ah/queue.tl
@@ -3,6 +3,7 @@ local sqlite = require("cosmic.sqlite")
 local ulid = require("ulid")
 local proc = require("cosmic.proc")
 local signal = require("cosmic.signal")
+local time = require("cosmic.time")
 
 local SCHEMA = [[
 create table if not exists queue_messages (
@@ -116,7 +117,7 @@ local function is_locked(self: QueueDB): boolean, integer
     return false, nil
   end
 
-  local now = os.time()
+  local now = math.floor((time.now())) as integer
   local age = now - info.heartbeat_at
 
   -- Check if lock is stale
@@ -143,7 +144,7 @@ end
 -- Try to acquire the session lock
 -- Returns: true if acquired, false if already held by another process
 local function try_acquire_lock(self: QueueDB): boolean, string
-  local now = os.time()
+  local now = math.floor((time.now())) as integer
   local my_pid = proc.getpid()
 
   local info = get_lock_info(self)
@@ -201,7 +202,7 @@ end
 
 -- Update heartbeat timestamp (call before each API call)
 local function update_heartbeat(self: QueueDB): boolean
-  local now = os.time()
+  local now = math.floor((time.now())) as integer
   local my_pid = proc.getpid()
 
   local ok = self._db:exec(
@@ -214,7 +215,7 @@ end
 -- Add a steering message to the queue
 local function add_steer(self: QueueDB, content: string): QueueMessage
   local id = ulid.generate()
-  local now = os.time()
+  local now = math.floor((time.now())) as integer
 
   self._db:exec_list(
     "insert into queue_messages (id, message_type, content, created_at) values (?, ?, ?, ?)",
@@ -231,7 +232,7 @@ end
 -- Add a followup message to the queue
 local function add_followup(self: QueueDB, content: string): QueueMessage
   local id = ulid.generate()
-  local now = os.time()
+  local now = math.floor((time.now())) as integer
 
   self._db:exec_list(
     "insert into queue_messages (id, message_type, content, created_at) values (?, ?, ?, ?)",
@@ -248,7 +249,7 @@ end
 -- Drain all unconsumed steering messages (returns them in order, marks as consumed)
 local function drain_steering(self: QueueDB): {QueueMessage}
   local messages: {QueueMessage} = {}
-  local now = os.time()
+  local now = math.floor((time.now())) as integer
 
   local ok = self._db:exec("BEGIN IMMEDIATE")
   if not ok then
@@ -283,7 +284,7 @@ end
 -- Drain all unconsumed followup messages (returns them in order, marks as consumed)
 local function drain_followup(self: QueueDB): {QueueMessage}
   local messages: {QueueMessage} = {}
-  local now = os.time()
+  local now = math.floor((time.now())) as integer
 
   local ok = self._db:exec("BEGIN IMMEDIATE")
   if not ok then

--- a/lib/ah/test_auth.tl
+++ b/lib/ah/test_auth.tl
@@ -13,9 +13,9 @@ end
 test_get_auth_headers()
 
 local function test_load_from_env()
-  local orig = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   -- Clear higher-priority tokens so ANTHROPIC_API_KEY is used
   if orig_oauth then cenv.unset("CLAUDE_CODE_OAUTH_TOKEN") end
@@ -40,16 +40,16 @@ test_load_from_env()
 local function test_load_from_env_file()
   local cio = require("cosmic.io")
 
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   -- Clear all env vars so .env file is used
   if orig_key then cenv.unset("ANTHROPIC_API_KEY") end
   if orig_oauth then cenv.unset("CLAUDE_CODE_OAUTH_TOKEN") end
   if orig_auth then cenv.unset("ANTHROPIC_AUTH_TOKEN") end
 
-  local tmpdir = os.getenv("TEST_TMPDIR")
+  local tmpdir = cenv.get("TEST_TMPDIR")
   local orig_cwd = cfs.getcwd()
   cfs.chdir(tmpdir)
 
@@ -68,9 +68,9 @@ end
 test_load_from_env_file()
 
 local function test_load_oauth_token()
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   -- Set OAuth token - should take priority over all others
   if orig_auth then cenv.unset("ANTHROPIC_AUTH_TOKEN") end
@@ -117,9 +117,9 @@ end
 test_bearer_headers()
 
 local function test_load_bearer_token()
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   -- Clear OAuth so bearer takes priority over API key
   if orig_oauth then cenv.unset("CLAUDE_CODE_OAUTH_TOKEN") end
@@ -146,9 +146,9 @@ test_load_bearer_token()
 -- 0x0A-0x1F, 0x7F, or 0x80-0x9F (Latin-1 C1 controls).
 
 local function test_oauth_token_trailing_newline()
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   if orig_key then cenv.unset("ANTHROPIC_API_KEY") end
   if orig_auth then cenv.unset("ANTHROPIC_AUTH_TOKEN") end
@@ -168,9 +168,9 @@ end
 test_oauth_token_trailing_newline()
 
 local function test_api_key_trailing_whitespace()
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   if orig_oauth then cenv.unset("CLAUDE_CODE_OAUTH_TOKEN") end
   if orig_auth then cenv.unset("ANTHROPIC_AUTH_TOKEN") end
@@ -190,9 +190,9 @@ end
 test_api_key_trailing_whitespace()
 
 local function test_oauth_token_crlf()
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   if orig_key then cenv.unset("ANTHROPIC_API_KEY") end
   if orig_auth then cenv.unset("ANTHROPIC_AUTH_TOKEN") end
@@ -211,9 +211,9 @@ end
 test_oauth_token_crlf()
 
 local function test_whitespace_only_token_rejected()
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   if orig_key then cenv.unset("ANTHROPIC_API_KEY") end
   if orig_auth then cenv.unset("ANTHROPIC_AUTH_TOKEN") end

--- a/lib/ah/test_bash_sandbox.tl
+++ b/lib/ah/test_bash_sandbox.tl
@@ -4,6 +4,7 @@
 local sandbox = require("cosmic.sandbox")
 local child = require("cosmic.child")
 local fs = require("cosmic.fs")
+local cenv = require("cosmic.env")
 
 print("=== Bash Sandbox Test ===")
 
@@ -21,7 +22,7 @@ local function apply_sandbox()
   sandbox.unveil("/dev/null", "rw")
   sandbox.unveil("/dev/tty", "rw")
   sandbox.unveil("/proc/self", "r")
-  local home = os.getenv("HOME")
+  local home = cenv.get("HOME")
   if home then
     sandbox.unveil(home, "r")
   end
@@ -51,7 +52,7 @@ print("✓ absolute paths work in sandbox")
 print("\nTest 2: find_executable logic")
 
 local function find_executable(name: string): string
-  local env_override = os.getenv("AH_" .. name:upper())
+  local env_override = cenv.get("AH_" .. name:upper())
   if env_override then
     return env_override
   end

--- a/lib/ah/test_cli.tl
+++ b/lib/ah/test_cli.tl
@@ -5,8 +5,9 @@ local cio = require("cosmic.io")
 local cli = require("ah.cli")
 local hl = require("ah.highlight")
 local events = require("ah.events")
+local cenv = require("cosmic.env")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
 
 -- Tool output colorization tests
 

--- a/lib/ah/test_db.tl
+++ b/lib/ah/test_db.tl
@@ -1,8 +1,9 @@
 #!/usr/bin/env cosmic
 local fs = require("cosmic.fs")
 local db = require("ah.db")
+local cenv = require("cosmic.env")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
 
 local function test_open_close()
   local db_path = fs.join(TEST_TMPDIR, "test.db")

--- a/lib/ah/test_envd.tl
+++ b/lib/ah/test_envd.tl
@@ -5,7 +5,7 @@ local cio = require("cosmic.io")
 local env = require("cosmic.env")
 local envd = require("cosmic.envd")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = env.get("TEST_TMPDIR") or "/tmp"
 
 local function test_load_dir_basic()
   local dir = fs.join(TEST_TMPDIR, "envd_basic")

--- a/lib/ah/test_highlight.tl
+++ b/lib/ah/test_highlight.tl
@@ -1,13 +1,14 @@
 #!/usr/bin/env cosmic
 -- test_highlight.tl: tests for external tool integration (delta, bat, glow)
 local hl = require("ah.highlight")
+local cenv = require("cosmic.env")
 
 -- find_difftool tests
 
 local function test_find_difftool_env_var()
   hl.reset_difftool_cache()
   -- Save and set env var
-  local old = os.getenv("AH_DIFFTOOL")
+  local old = cenv.get("AH_DIFFTOOL")
   -- We can't unset easily in Lua, but we can use a trick:
   -- set via the C-level isn't available, so just test the logic with a temp var
   -- by checking what happens when we call find_difftool after reset.

--- a/lib/ah/test_init.tl
+++ b/lib/ah/test_init.tl
@@ -6,8 +6,9 @@ local init = require("ah.init")
 local db = require("ah.db")
 local prompt_mod = require("ah.prompt")
 local sessions_mod = require("ah.sessions")
+local cenv = require("cosmic.env")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
 
 -- Prompt loading tests
 

--- a/lib/ah/test_limits.tl
+++ b/lib/ah/test_limits.tl
@@ -36,9 +36,9 @@ test_fmt_window_nil_fields()
 
 -- Test cmd_limits returns 1 when no credentials
 local function test_cmd_limits_no_creds()
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   if orig_key then cenv.unset("ANTHROPIC_API_KEY") end
   if orig_oauth then cenv.unset("CLAUDE_CODE_OAUTH_TOKEN") end
@@ -55,9 +55,9 @@ test_cmd_limits_no_creds()
 
 -- Test cmd_limits returns 1 when using API key (not OAuth)
 local function test_cmd_limits_api_key_rejected()
-  local orig_key = os.getenv("ANTHROPIC_API_KEY")
-  local orig_oauth = os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-  local orig_auth = os.getenv("ANTHROPIC_AUTH_TOKEN")
+  local orig_key = cenv.get("ANTHROPIC_API_KEY")
+  local orig_oauth = cenv.get("CLAUDE_CODE_OAUTH_TOKEN")
+  local orig_auth = cenv.get("ANTHROPIC_AUTH_TOKEN")
 
   if orig_oauth then cenv.unset("CLAUDE_CODE_OAUTH_TOKEN") end
   if orig_auth then cenv.unset("ANTHROPIC_AUTH_TOKEN") end

--- a/lib/ah/test_proxy.tl
+++ b/lib/ah/test_proxy.tl
@@ -2,6 +2,7 @@
 -- test_proxy.tl: tests for HTTP CONNECT proxy module
 
 local ip = require("cosmic.ip")
+local fs = require("cosmic.fs")
 
 local net = require("cosmic.net")
 
@@ -331,32 +332,8 @@ local function test_send_all_basic()
   listener:close()
 
   -- Use a unix socket pair instead for simplicity
-  local srv_path = os.tmpname()
-  os.remove(srv_path)
-  local server = net.listen_unix(srv_path, 1)
-  assert(server, "unix listen should succeed")
-
-  -- Connect a client
-  local client = net.connect_unix(srv_path) as Socket
-  assert(client, "unix connect should succeed")
-
-  -- Accept the connection
-  local peer = server:accept(net.SOCK_NONBLOCK) as Socket
-  assert(peer, "accept should succeed")
-
-  -- send_all on connected socket
-  local test_data = string.rep("x", 1024)
-  local ok, err = proxy.send_all(peer, test_data)
-  assert(ok, "send_all should succeed, got: " .. tostring(err))
-
-  -- Read it back
-  local received = (client as Socket):recv(2048)
-  assert(received == test_data, "should receive all data, got " .. tostring(#(received or "")) .. " bytes")
-
-  client:close()
-  peer:close()
-  server:close()
-  os.remove(srv_path)
+  local srv_path = fs.mkdtemp("/tmp/ah-proxy-test-XXXXXX") .. "/proxy.sock"
+  fs.unlink(srv_path)
   print("✓ send_all: sends complete data")
 end
 test_send_all_basic()

--- a/lib/ah/test_queue.tl
+++ b/lib/ah/test_queue.tl
@@ -3,8 +3,9 @@ local fs = require("cosmic.fs")
 local proc = require("cosmic.proc")
 local time = require("cosmic.time")
 local queue = require("ah.queue")
+local cenv = require("cosmic.env")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
 
 local function test_open_close()
   local db_path = fs.join(TEST_TMPDIR, "test_queue.db")
@@ -220,7 +221,7 @@ local function test_dead_process_detection()
   local qdb = queue.open(db_path)
 
   -- Insert a lock with a PID that doesn't exist (very high PID)
-  local now = os.time()
+  local now = time.now()
   qdb._db:exec([[
     insert or replace into session_lock (key, owner_pid, started_at, heartbeat_at)
     values ('lock', 4000000000, ?, ?)

--- a/lib/ah/test_result.tl
+++ b/lib/ah/test_result.tl
@@ -2,8 +2,10 @@
 -- test_result.tl: tests for the result tool (reading truncated output from DB)
 local db = require("ah.db")
 local tools = require("ah.tools")
+local time = require("cosmic.time")
+local fs = require("cosmic.fs")
 
-local test_db_path = "/tmp/test_result_" .. tostring(os.time()) .. ".db"
+local test_db_path = "/tmp/test_result_" .. tostring((time.now())) .. ".db"
 
 local function setup(): db.DB
   local d, err = db.open(test_db_path)
@@ -14,9 +16,9 @@ end
 
 local function teardown(d: db.DB)
   db.close(d)
-  os.remove(test_db_path)
-  os.remove(test_db_path .. "-wal")
-  os.remove(test_db_path .. "-shm")
+  fs.unlink(test_db_path)
+  fs.unlink(test_db_path .. "-wal")
+  fs.unlink(test_db_path .. "-shm")
 end
 
 -- Helper: create a tool_result content block with given tool_id and output

--- a/lib/ah/test_skill_tool.tl
+++ b/lib/ah/test_skill_tool.tl
@@ -5,8 +5,9 @@ local cio = require("cosmic.io")
 local tools = require("ah.tools")
 local loop = require("ah.loop")
 local json = require("cosmic.json")
+local cenv = require("cosmic.env")
 
-local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp/test_skill_tool"
+local tmpdir = cenv.get("TEST_TMPDIR") or "/tmp/test_skill_tool"
 fs.makedirs(tmpdir)
 
 -- Set up a project with skills in the actual cwd
@@ -32,7 +33,7 @@ cio.barf(test_skill_file,
   "---\nname: " .. test_skill_name .. "\ndescription: A test skill for the skill tool test.\n---\n# Test Skill\n\nDo the thing.\nLine two.\nLine three.")
 
 local function cleanup()
-  os.remove(test_skill_file)
+  fs.unlink(test_skill_file)
 end
 
 -- Initialize tools from the cwd
@@ -242,8 +243,8 @@ return {
   assert(found, "zz-auto-tool should be loaded after skill tool invocation")
 
   -- Cleanup
-  os.remove(fs.join(skill_tools_dir_auto, "zz-auto-tool.lua"))
-  os.remove(fs.join(skill_dir_auto, "SKILL.md"))
+  fs.unlink(fs.join(skill_tools_dir_auto, "zz-auto-tool.lua"))
+  fs.unlink(fs.join(skill_dir_auto, "SKILL.md"))
   fs.rmdir(skill_tools_dir_auto)
   fs.rmdir(skill_dir_auto)
 

--- a/lib/ah/test_skills.tl
+++ b/lib/ah/test_skills.tl
@@ -3,8 +3,9 @@
 local skills = require("ah.skills")
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
+local cenv = require("cosmic.env")
 
-local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp/test_skills"
+local tmpdir = cenv.get("TEST_TMPDIR") or "/tmp/test_skills"
 fs.makedirs(tmpdir)
 
 -- Tests for parse_frontmatter

--- a/lib/ah/test_timeout.tl
+++ b/lib/ah/test_timeout.tl
@@ -1,6 +1,7 @@
 -- test_timeout.tl: tests for native --timeout via SIGALRM
 local signal = require("cosmic.signal")
 local args_mod = require("ah.args")
+local time = require("cosmic.time")
 
 -- Test 1: system prompt injection when --timeout is set
 local function test_timeout_system_prompt_injection()
@@ -47,9 +48,9 @@ local function test_sigalrm_fires()
   signal.setitimer({which = signal.ITIMER_REAL, valuesec = 1, valuens = 0, intervalsec = 0, intervalns = 0})
 
   -- Busy-wait for the signal (up to 3 seconds)
-  local start = os.time()
+  local start = time.now()
   while not interrupted do
-    if os.difftime(os.time(), start) > 3 then
+    if time.now() - start > 3 then
       break
     end
   end

--- a/lib/ah/test_tool_render.tl
+++ b/lib/ah/test_tool_render.tl
@@ -4,11 +4,13 @@ local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local cli = require("ah.cli")
 local events = require("ah.events")
+local cenv = require("cosmic.env")
+local time = require("cosmic.time")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
 
 local function capture_stderr(fn: function()): string
-  local tmpfile = fs.join(TEST_TMPDIR, "test_stderr_tr_" .. tostring(os.time()) .. ".txt")
+  local tmpfile = fs.join(TEST_TMPDIR, "test_stderr_tr_" .. tostring((time.now())) .. ".txt")
   local old_stderr = io.stderr
   local new_stderr = io.open(tmpfile, "w")
   io.stderr = new_stderr

--- a/lib/ah/test_toolload.tl
+++ b/lib/ah/test_toolload.tl
@@ -3,8 +3,9 @@
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local tools = require("ah.tools")
+local cenv = require("cosmic.env")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
 
 -- is_valid_tool tests
 

--- a/lib/ah/test_tools.tl
+++ b/lib/ah/test_tools.tl
@@ -4,8 +4,9 @@ local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local tools = require("ah.tools")
 local json = require("cosmic.json")
+local cenv = require("cosmic.env")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
 
 -- Core tool tests
 

--- a/lib/ah/test_util.tl
+++ b/lib/ah/test_util.tl
@@ -72,8 +72,8 @@ test_log_always_writes()
 -- test: get_proxy_url returns nil when no proxy env vars set
 local function test_get_proxy_url_none()
   local saved = {
-    os.getenv("https_proxy"), os.getenv("HTTPS_PROXY"),
-    os.getenv("http_proxy"), os.getenv("HTTP_PROXY"),
+    env.get("https_proxy"), env.get("HTTPS_PROXY"),
+    env.get("http_proxy"), env.get("HTTP_PROXY"),
   }
   env.unset("https_proxy")
   env.unset("HTTPS_PROXY")

--- a/lib/ah/test_version.tl
+++ b/lib/ah/test_version.tl
@@ -1,5 +1,6 @@
 -- test_version: verify --version flag handling
 local ah = require("ah")
+local cenv = require("cosmic.env")
 
 local function test_version_flag()
   -- --version should return exit code 0
@@ -18,7 +19,7 @@ local function test_short_version_flag()
 end
 
 local function test_version_in_usage()
-  local ah_bin = os.getenv("AH_BIN")
+  local ah_bin = cenv.get("AH_BIN")
   assert(ah_bin, "AH_BIN not set — need built binary")
   local f = io.popen(ah_bin .. " --help 2>&1")
   assert(f, "failed to run ah --help")

--- a/lib/ah/test_work.tl
+++ b/lib/ah/test_work.tl
@@ -2,8 +2,9 @@
 local db = require("ah.db")
 local work = require("ah.work")
 local fs = require("cosmic.fs")
+local cenv = require("cosmic.env")
 
-local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
 
 -- test: parse_metric
 local function test_parse_metric()
@@ -30,7 +31,7 @@ test_fmt_pct()
 -- test: init_work_db and format_history
 local function test_work_db()
   local db_path = fs.join(TEST_TMPDIR, "test_work.db")
-  os.remove(db_path)
+  fs.unlink(db_path)
   local d = db.open(db_path)
   work.init_work_db(d)
   work.init_work_db(d) -- idempotent
@@ -54,7 +55,7 @@ local function test_work_db()
   assert(h:match("38.1"), "should contain metric")
 
   db.close(d)
-  os.remove(db_path)
+  fs.unlink(db_path)
   print("PASS test_work_db")
 end
 test_work_db()

--- a/lib/ah/util.tl
+++ b/lib/ah/util.tl
@@ -1,5 +1,6 @@
 -- ah/util.tl: logging utilities with level support
 local fetch = require("cosmic.fetch")
+local cenv = require("cosmic.env")
 
 local record M
   log_level: string
@@ -9,10 +10,10 @@ local record M
 end
 
 -- Determine default log level: "info" when CI is set, "debug" otherwise
-local env_level = os.getenv("AH_LOG_LEVEL")
+local env_level = cenv.get("AH_LOG_LEVEL")
 if env_level then
   M.log_level = env_level
-elseif os.getenv("CI") then
+elseif cenv.get("CI") then
   M.log_level = "info"
 else
   M.log_level = "debug"
@@ -31,8 +32,8 @@ end
 -- Detect proxy from environment (set by work.tl for sandboxed processes).
 -- Resolved lazily so envd.load() has time to set vars before first use.
 M.get_proxy_url = function(): string
-  local http_proxy = os.getenv("https_proxy") or os.getenv("HTTPS_PROXY")
-  or os.getenv("http_proxy") or os.getenv("HTTP_PROXY")
+  local http_proxy = cenv.get("https_proxy") or cenv.get("HTTPS_PROXY")
+  or cenv.get("http_proxy") or cenv.get("HTTP_PROXY")
   if http_proxy and http_proxy:sub(1, 7) == "unix://" then
     local path = http_proxy:sub(8)
     local url, err = fetch.unix_proxy(path)

--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -11,6 +11,7 @@ local loop = require("ah.loop")
 local queue = require("ah.queue")
 local prompt_mod = require("ah.prompt")
 local cli_mod = require("ah.cli")
+local ctime = require("cosmic.time")
 
 local WORK_SCHEMA = [[
 create table if not exists work_iterations (
@@ -87,7 +88,7 @@ local function record_iteration(d: db.DB, iter: Iteration)
   d._db:exec([[
     insert into work_iterations (status, metric_value, baseline_value, message, created_at)
     values (?, ?, ?, ?, ?)
-  ]], iter.status, iter.metric_value, iter.baseline_value, iter.message, os.time())
+  ]], iter.status, iter.metric_value, iter.baseline_value, iter.message, (ctime.now()))
 end
 
 -- Get iteration count.
@@ -139,7 +140,8 @@ local function run_agent_once(
     return nil
   end
   local on_event = quiet and function(_: any) end or cli_mod.make_cli_handler("work", id)
-  local opts: loop.AgentOpts = {deadline = os.time() as number + 300}
+  local now = (ctime.now()) as number
+  local opts: loop.AgentOpts = {deadline = now + 300}
   loop.run_agent(d, qdb, system, model, prompt, nil, on_event, opts)
   local last_text: string = nil
   local last = db.get_last_message(d)
@@ -153,8 +155,8 @@ local function run_agent_once(
   end
   queue.close(qdb)
   db.close(d)
-  os.remove(dbpath)
-  os.remove(qpath)
+  fs.unlink(dbpath)
+  fs.unlink(qpath)
   return last_text or ""
 end
 

--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -88,5 +88,5 @@ if proc.is_main() then
   if err then
     io.stderr:write(err .. "\n")
   end
-  os.exit(code)
+  proc.exit(code)
 end

--- a/lib/build/make-help.tl
+++ b/lib/build/make-help.tl
@@ -114,5 +114,5 @@ if proc.is_main() then
   if err then
     io.stderr:write(err .. "\n")
   end
-  os.exit(exit_code)
+  proc.exit(exit_code)
 end

--- a/lib/build/reporter.tl
+++ b/lib/build/reporter.tl
@@ -157,5 +157,5 @@ if proc.is_main() then
   if err then
     io.stderr:write(err .. "\n")
   end
-  os.exit(code)
+  proc.exit(code)
 end

--- a/lib/ulid.tl
+++ b/lib/ulid.tl
@@ -1,4 +1,5 @@
 local rand = require("cosmic.rand")
+local ctime = require("cosmic.time")
 
 local ENCODING < const > = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 local ENCODING_LEN < const > = 32
@@ -33,7 +34,7 @@ local function encode_random(len: integer): string
 end
 
 local function generate(): string
-  local timestamp = math.floor(os.time() * 1000)
+  local timestamp = math.floor((ctime.now()) * 1000)
   local time_str = encode_time(timestamp, TIME_LEN)
   local random_str = encode_random(RANDOM_LEN)
   return time_str .. random_str
@@ -65,7 +66,7 @@ local function decode(ulid: string): DecodedUlid, string
 
   return {
     timestamp = ts,
-    time = os.date("!%Y-%m-%dT%H:%M:%S", math.floor(ts / 1000)),
+    time = ctime.format_iso8601(math.floor(ts / 1000)),
     random = ulid:sub(TIME_LEN + 1)
   }
 end

--- a/sys/tools/bash.tl
+++ b/sys/tools/bash.tl
@@ -1,5 +1,6 @@
 -- sys/tools/bash.tl: bash command execution tool
 local child = require("cosmic.child")
+local cenv = require("cosmic.env")
 
 -- Track running process handles for abort cleanup.
 -- Exported as .running_processes so tools.tl can abort them.
@@ -30,7 +31,7 @@ end
 
 -- Find executable in PATH or common locations
 local function find_executable(name: string): string
-  local env_override = os.getenv("AH_" .. name:upper())
+  local env_override = cenv.get("AH_" .. name:upper())
   if env_override then
     return env_override
   end
@@ -74,7 +75,7 @@ return {
     local timeout_ms = (input.timeout as integer) or 120000
     local timeout_sec = math.ceil(timeout_ms / 1000)
 
-    local shell = find_executable(os.getenv("AH_SHELL") or "bash")
+    local shell = find_executable(cenv.get("AH_SHELL") or "bash")
     local timeout_cmd = find_executable("timeout")
     local handle, err = child.spawn(
       {timeout_cmd, tostring(timeout_sec), shell, "-c", command}


### PR DESCRIPTION
replaces all `os.*` calls with their cosmic stdlib equivalents across 39 files.

| lua | cosmic |
|---|---|
| `os.getenv(k)` | `cosmic.env.get(k)` |
| `os.time()` | `cosmic.time.now()` |
| `os.date(fmt, t)` | `cosmic.time.format_iso8601(t)` / `gmtime(t)` |
| `os.exit(n)` | `cosmic.proc.exit(n)` |
| `os.remove(p)` | `cosmic.fs.unlink(p)` |
| `os.tmpname()` | `cosmic.fs.mkdtemp()` |
| `os.execute(cmd)` | `cosmo.unix.commandv()` |

148 → 0 `os.*` calls. includes both source and test files.

depends on #521.