### PR TITLE
deps: update cosmic to 2026-03-15-6fd4272

### DIFF
--- a/deps/cosmic.mk
+++ b/deps/cosmic.mk
@@ -1,4 +1,4 @@
-cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-03-08-ac3a5d5/cosmic-lua
-cosmic_sha := 4aee99daab172af2c662354e519170fa5c5793e5820e8a2bcd02f23f1d99e531
-cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/2026-03-08-ac3a5d5/cosmic-lua-debug
-cosmic_debug_sha := 361546002fbc9568d134a2f28be7466e04c3ab837d1d1a602b13e512dcae1311
+cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-03-15-6fd4272/cosmic-lua
+cosmic_sha := c5cce7df2c79632664d3438005b765d49d01ffc7570ebf099b563b9e2fdcd3a1
+cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/2026-03-15-6fd4272/cosmic-lua-debug
+cosmic_debug_sha := a5d448a06ffc4088ca9b3215b701bfd534de5883e41d80f8808f57558ed90109


### PR DESCRIPTION
Updates cosmic to [2026-03-15-6fd4272](https://github.com/whilp/cosmic/releases/tag/2026-03-15-6fd4272).

Includes:
- fexecve support for executing binaries from /zip/ (cosmic#396)
- deflate compression for embedded files (cosmic#394)