### PR TITLE
looputil: add type safety to tool_key_param

### DIFF
--- a/lib/ah/looputil.tl
+++ b/lib/ah/looputil.tl
@@ -24,12 +24,12 @@ local function tool_key_param(tool_name: string, tool_input: string, details_jso
     if details then
       -- skill tool: show "source → name, N lines"
       if details.skill_name and details.line_count then
-        local src = details.path and shorten_path(details.path as string) or "?"
-        return string.format("%s → %s, %d lines", src, details.skill_name as string, details.line_count as integer)
+        local src = details.path and shorten_path(tostring(details.path)) or "?"
+        return string.format("%s → %s, %d lines", src, tostring(details.skill_name), tonumber(details.line_count) as integer)
       elseif details.path then
-        return shorten_path(details.path as string)
+        return shorten_path(tostring(details.path))
       elseif details.command then
-        return details.command as string
+        return tostring(details.command)
       end
     end
   end
@@ -40,21 +40,21 @@ local function tool_key_param(tool_name: string, tool_input: string, details_jso
   if not input then return "" end
 
   if tool_name == "read" then
-    local key = shorten_path((input.path or "") as string)
-    local offset = input.offset as integer
-    local limit = input.limit as integer
-    if offset and offset as integer > 0 and limit and limit as integer > 0 then
+    local key = shorten_path(tostring(input.path or ""))
+    local offset = tonumber(input.offset) as integer
+    local limit = tonumber(input.limit) as integer
+    if offset and offset > 0 and limit and limit > 0 then
       key = key .. ":" .. tostring(offset) .. "+" .. tostring(limit)
-    elseif offset and offset as integer > 0 then
+    elseif offset and offset > 0 then
       key = key .. ":" .. tostring(offset)
-    elseif limit and limit as integer > 0 then
+    elseif limit and limit > 0 then
       key = key .. " +" .. tostring(limit)
     end
     return key
   elseif tool_name == "write" or tool_name == "edit" then
-    return shorten_path((input.path or "") as string)
+    return shorten_path(tostring(input.path or ""))
   elseif tool_name == "bash" then
-    return (input.command or "") as string
+    return tostring(input.command or "")
   end
   return ""
 end

--- a/lib/ah/test_looputil.tl
+++ b/lib/ah/test_looputil.tl
@@ -227,4 +227,71 @@ local function test_tool_key_param_read_offset_and_limit()
 end
 test_tool_key_param_read_offset_and_limit()
 
+-- Tests for tool_key_param type safety: numeric values from JSON decode
+-- Reproduces: looputil.lua:46: attempt to compare number with string
+-- When offset/limit come from JSON as strings instead of numbers,
+-- the > 0 comparison crashes in Lua 5.4.
+
+local function test_tool_key_param_read_string_offset()
+  -- API might send offset as a string
+  local key = looputil.tool_key_param("read", '{"path":"/tmp/foo.txt","offset":"100"}', nil)
+  assert(key:find("foo%.txt"), "should still return path: " .. key)
+  assert(key:find(":100"), "should handle string offset: " .. key)
+  print("PASS: tool_key_param handles string offset without crash")
+end
+test_tool_key_param_read_string_offset()
+
+local function test_tool_key_param_read_string_limit()
+  -- API might send limit as a string
+  local key = looputil.tool_key_param("read", '{"path":"/tmp/foo.txt","limit":"50"}', nil)
+  assert(key:find("foo%.txt"), "should still return path: " .. key)
+  assert(key:find("%+50"), "should handle string limit: " .. key)
+  print("PASS: tool_key_param handles string limit without crash")
+end
+test_tool_key_param_read_string_limit()
+
+local function test_tool_key_param_read_string_offset_and_limit()
+  local key = looputil.tool_key_param("read", '{"path":"/tmp/foo.txt","offset":"100","limit":"50"}', nil)
+  assert(key:find("foo%.txt"), "should still return path: " .. key)
+  assert(key:find(":100%+50"), "should handle string offset+limit: " .. key)
+  print("PASS: tool_key_param handles string offset and limit without crash")
+end
+test_tool_key_param_read_string_offset_and_limit()
+
+local function test_tool_key_param_bash_numeric_command()
+  -- edge case: command is a number
+  local key = looputil.tool_key_param("bash", '{"command":42}', nil)
+  assert(type(key) == "string", "should return string, got: " .. type(key))
+  assert(key == "42", "should convert numeric command to string: " .. key)
+  print("PASS: tool_key_param converts numeric command to string")
+end
+test_tool_key_param_bash_numeric_command()
+
+local function test_tool_key_param_read_numeric_path()
+  -- edge case: path is a number
+  local key = looputil.tool_key_param("read", '{"path":123}', nil)
+  assert(type(key) == "string", "should return string, got: " .. type(key))
+  assert(key == "123", "should convert numeric path to string: " .. key)
+  print("PASS: tool_key_param converts numeric path to string")
+end
+test_tool_key_param_read_numeric_path()
+
+local function test_tool_key_param_details_numeric_command()
+  -- details.command might be a number
+  local key = looputil.tool_key_param("bash", '{"command":"ls"}', '{"command":42}')
+  assert(type(key) == "string", "should return string from details, got: " .. type(key))
+  assert(key == "42", "should convert numeric details.command: " .. key)
+  print("PASS: tool_key_param converts numeric details.command to string")
+end
+test_tool_key_param_details_numeric_command()
+
+local function test_tool_key_param_details_numeric_path()
+  -- details.path might be a number
+  local key = looputil.tool_key_param("read", '{}', '{"path":123}')
+  assert(type(key) == "string", "should return string from details, got: " .. type(key))
+  assert(key == "123", "should convert numeric details.path: " .. key)
+  print("PASS: tool_key_param converts numeric details.path to string")
+end
+test_tool_key_param_details_numeric_path()
+
 print("all looputil tests passed")


### PR DESCRIPTION
Fixes #531

## Problem

`tool_key_param` crashes with `attempt to compare number with string` in
Lua 5.4 when JSON-decoded values have unexpected types. Specifically, the
`offset > 0` and `limit > 0` comparisons at line 46 crash when the API
sends these as strings (e.g. `"offset": "100"`) instead of numbers.

```
/zip/.lua/ah/looputil.lua:46: attempt to compare number with string
stack traceback:
        /zip/.lua/ah/looputil.lua:46: in function 'ah.looputil.tool_key_param'
        /zip/.lua/ah/looptool.lua:61: in function 'ah.looptool.execute_tool_calls'
```

## Fix

- Use `tonumber()` on `offset`/`limit` before numeric comparisons
- Use `tostring()` on all values returned from JSON-decoded tables
  (`details.command`, `details.path`, `input.command`, `input.path`)
- Guard `shorten_path` calls with `tostring()` to prevent indexing
  non-string values

## Tests

Added 7 new test cases for `tool_key_param`:
- String-typed offset, limit, and offset+limit
- Numeric command and path values (from input and details)

All tests reproduce the crash before the fix and pass after.