### PR TITLE
work: preserve work document updates across discarded iterations

### DIFF
--- a/lib/ah/test_work.tl
+++ b/lib/ah/test_work.tl
@@ -2,6 +2,8 @@
 local db = require("ah.db")
 local work = require("ah.work")
 local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local child = require("cosmic.child")
 local cenv = require("cosmic.env")
 
 local TEST_TMPDIR = cenv.get("TEST_TMPDIR") or "/tmp"
@@ -59,3 +61,69 @@ local function test_work_db()
   print("PASS test_work_db")
 end
 test_work_db()
+
+-- helper: run a shell command in a directory, return stdout
+local function sh(dir: string, cmd: string): string
+  local handle = child.spawn({"sh", "-c", "cd " .. dir .. " && " .. cmd})
+  if not handle then return "" end
+  handle.stderr:read()
+  local ok, out = handle:read()
+  if not ok then return "" end
+  local s = ((out as string) or ""):gsub("%s+$", "")
+  return s
+end
+
+-- test: commit_work_doc + git_revert preserves work doc, reverts code
+local function test_work_doc_survives_revert()
+  local repo = fs.join(TEST_TMPDIR, "test_revert_md")
+  -- clean up any prior run
+  sh(TEST_TMPDIR, "rm -rf " .. repo)
+  fs.mkdir(repo)
+
+  -- init a git repo with initial files
+  sh(repo, "git init")
+  sh(repo, "git config user.email test@test.com")
+  sh(repo, "git config user.name test")
+  cio.barf(fs.join(repo, "code.tl"), "original code")
+  cio.barf(fs.join(repo, "work.md"), "# ideas\n- idea 1\n")
+  cio.barf(fs.join(repo, "docs.md"), "original docs")
+  sh(repo, "git add -A && git commit -m init")
+
+  -- simulate an agent iteration: modify code, work doc, another .md,
+  -- and write the result file
+  cio.barf(fs.join(repo, "code.tl"), "modified code")
+  cio.barf(fs.join(repo, "work.md"), "# ideas\n- idea 1 ✗ discarded\n- idea 2 (new)\n")
+  cio.barf(fs.join(repo, "docs.md"), "modified docs")
+  fs.mkdir(fs.join(repo, ".ah"))
+  cio.barf(fs.join(repo, ".ah", "work-result.json"), '{"work_doc": "work.md"}')
+
+  local prev_cwd = fs.getcwd()
+  fs.chdir(repo)
+
+  -- read result and commit work doc (as run_work would)
+  local doc = work.read_work_result()
+  assert(doc == "work.md", "should read work_doc from result json, got: " .. (doc or "nil"))
+  work.commit_work_doc(doc)
+
+  -- revert remaining changes
+  work.git_revert()
+  fs.chdir(prev_cwd)
+
+  -- code.tl should be reverted
+  local code = cio.slurp(fs.join(repo, "code.tl"))
+  assert(code == "original code", "code.tl should be reverted, got: " .. (code or "nil"))
+
+  -- docs.md should be reverted
+  local docs = cio.slurp(fs.join(repo, "docs.md"))
+  assert(docs == "original docs", "docs.md should be reverted, got: " .. (docs or "nil"))
+
+  -- work.md should be preserved (committed separately)
+  local md = cio.slurp(fs.join(repo, "work.md"))
+  assert(md and md:match("idea 2"), "work.md should preserve updates, got: " .. (md or "nil"))
+  assert(md and md:match("discarded"), "work.md should preserve annotations, got: " .. (md or "nil"))
+
+  -- clean up
+  sh(TEST_TMPDIR, "rm -rf " .. repo)
+  print("PASS test_work_doc_survives_revert")
+end
+test_work_doc_survives_revert()

--- a/lib/ah/work.tl
+++ b/lib/ah/work.tl
@@ -2,6 +2,7 @@
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local child = require("cosmic.child")
+local json = require("cosmic.json")
 local db = require("ah.db")
 local ulid = require("ulid")
 local api = require("ah.api")
@@ -12,6 +13,8 @@ local queue = require("ah.queue")
 local prompt_mod = require("ah.prompt")
 local cli_mod = require("ah.cli")
 local ctime = require("cosmic.time")
+
+local RESULT_FILE = ".ah/work-result.json"
 
 local WORK_SCHEMA = [[
 create table if not exists work_iterations (
@@ -120,9 +123,10 @@ end
 
 -- Run an agent in a throwaway session. Returns last assistant text.
 -- If quiet is true, suppress terminal output.
+-- If must_produce is set, the agent must write that file.
 local function run_agent_once(
     cwd: string, system: string, model: string,
-    prompt: string, quiet: boolean
+    prompt: string, quiet: boolean, must_produce: string
   ): string
   local ah_dir = fs.join(cwd, ".ah")
   local id = ulid.generate()
@@ -142,6 +146,7 @@ local function run_agent_once(
   local on_event = quiet and function(_: any) end or cli_mod.make_cli_handler("work", id)
   local now = (ctime.now()) as number
   local opts: loop.AgentOpts = {deadline = now + 300}
+  if must_produce then opts.must_produce = must_produce end
   loop.run_agent(d, qdb, system, model, prompt, nil, on_event, opts)
   local last_text: string = nil
   local last = db.get_last_message(d)
@@ -170,9 +175,33 @@ local function git_diff(): string
   return git("diff", "HEAD", "--", ".", ":(exclude).ah") or ""
 end
 
--- Revert working tree.
+-- Revert working tree to HEAD.
 local function git_revert()
   git("checkout", "--", ".")
+end
+
+-- Read the work result JSON. Returns work_doc path or nil.
+local function read_work_result(): string
+  local raw = cio.slurp(RESULT_FILE)
+  if not raw then return nil end
+  local ok, data = pcall(json.decode, raw)
+  if not ok or not data then return nil end
+  local t = data as {string: any}
+  local doc = t["work_doc"]
+  if doc and doc is string and doc ~= "" then
+    return doc
+  end
+  return nil
+end
+
+-- Commit the work document separately so it survives code reverts.
+local function commit_work_doc(path: string)
+  git("add", "--", path)
+  -- Only commit if there are staged changes for this file.
+  local status = git("diff", "--cached", "--quiet", "--", path)
+  if status == nil then
+    git("commit", "--quiet", "-m", "work: update " .. path)
+  end
 end
 
 -- Commit all changes using a file for the commit message.
@@ -202,6 +231,7 @@ local function build_system(cwd: string): string
     end
     if content ~= "" then system = system .. "\n\n" .. content end
   end
+  system = system .. "\n\nIMPORTANT: You must write the file `" .. RESULT_FILE .. "` before finishing."
   return system
 end
 
@@ -245,7 +275,10 @@ local function run_work(
     "%s\n\ncurrent metric: %.4g (lower is better)\n\n## iteration history\n%s",
     prompt, best, history)
 
-  local impl_result = run_agent_once(cwd, system, effective_model, implement_prompt, false)
+  -- Clean up stale result file from prior iteration.
+  fs.unlink(RESULT_FILE)
+
+  local impl_result = run_agent_once(cwd, system, effective_model, implement_prompt, false, RESULT_FILE)
   if not impl_result then return 1 end
 
   if not git_has_changes() then
@@ -256,6 +289,16 @@ local function run_work(
       } as Iteration)
     return 1
   end
+
+  -- Commit work document separately so it survives code reverts.
+  -- The agent writes RESULT_FILE with {"work_doc": "<path>"}.
+  local work_doc = read_work_result()
+  if work_doc then
+    commit_work_doc(work_doc)
+  end
+  -- Clean up the result file — it should not be part of code changes.
+  fs.unlink(RESULT_FILE)
+  git("checkout", "--", RESULT_FILE)
 
   -- Phase 2: benchmark the change
   io.write("work: benchmarking...\n")
@@ -291,7 +334,7 @@ local function run_work(
       "write a one-line git commit message for this change.\nmetric: %.4g → %.4g (%s)\n\n```\n%s\n```\n\nrespond with only the commit message, nothing else.",
       best, new_value, pct, diff)
     local msg_system = "write a one-line git commit message. respond with only the message."
-    local msg = run_agent_once(cwd, msg_system, effective_model, msg_prompt, true)
+    local msg = run_agent_once(cwd, msg_system, effective_model, msg_prompt, true, nil)
     if not msg or msg == "" then msg = string.format("%.4g → %.4g (%s)", best, new_value, pct) end
     -- Clean up: take first non-empty line
     msg = msg:match("^%s*(.-)%s*$") or msg
@@ -324,4 +367,7 @@ return {
   fmt_pct = fmt_pct,
   init_work_db = init_work_db,
   format_history = format_history,
+  git_revert = git_revert,
+  read_work_result = read_work_result,
+  commit_work_doc = commit_work_doc,
 }

--- a/skills/autowork/SKILL.md
+++ b/skills/autowork/SKILL.md
@@ -40,6 +40,21 @@ if the work document exists, **read it from disk** — it contains the
 latest state from prior iterations. trust its contents over the prompt's
 copy (the prompt is the original, the file has been updated).
 
+## result file
+
+after making all changes, write `.ah/work-result.json` with the path to
+the work document you used:
+
+```json
+{"work_doc": "work.md"}
+```
+
+the outer loop uses this to commit the work document separately from code
+changes. if a code change is discarded, the work document update is
+preserved (idea annotations, new ideas discovered, etc.).
+
+**you must write this file every iteration.** the outer loop requires it.
+
 ## instructions
 
 1. read the work document from disk (see above)
@@ -56,8 +71,9 @@ copy (the prompt is the original, the file has been updated).
    - update `## ideas`:
      - mark tried ideas with their outcome (✓ kept, ✗ discarded)
      - add any new ideas you discover while reading the code
-   - the outer loop commits all changes together, so the work document
-     stays in sync with the code changes
+   - the work document is committed separately from code changes, so
+     its updates survive even if the code change is discarded
+7. write `.ah/work-result.json` (see above)
 
 ## rules
 


### PR DESCRIPTION
when a work iteration is discarded, `git_revert()` reverts **all** changes including the work document. this loses idea annotations and new ideas discovered during the iteration.

## approach

the agent now must-produce `.ah/work-result.json` containing the work document path:

```json
{"work_doc": "work.md"}
```

after the agent runs, the work loop:
1. reads `.ah/work-result.json` to get the work doc path
2. commits the work document in a separate commit
3. cleans up the result file
4. benchmarks the code change
5. on keep: commits the code change normally
6. on discard: `git checkout -- .` only reverts code — the work doc commit is already safe

this is a two-phase commit: the work document is always preserved, while code changes are kept or reverted based on the benchmark.

## changes

- **`lib/ah/work.tl`**: `read_work_result()` parses the json, `commit_work_doc()` commits the work doc separately, `run_agent_once()` accepts `must_produce` param, `build_system()` adds must-produce instruction
- **`skills/autowork/SKILL.md`**: documents the result file contract and adds step 7 to instructions
- **`lib/ah/test_work.tl`**: `test_work_doc_survives_revert` — sets up a repo, writes the result json, commits work doc, reverts the rest, asserts work doc is preserved while code and other .md files are reverted

fixes #534