### PR TITLE
Remove command truncation from display_command function

### DIFF
--- a/lib/ah/loop/test_loop.tl
+++ b/lib/ah/loop/test_loop.tl
@@ -422,14 +422,14 @@ test_display_command_single_line()
 local function test_display_command_multi_line()
   local cmd = "git log --oneline -1 origin/work/241-c4\ngit diff HEAD~1"
   local result = loop.display_command(cmd)
-  assert(result == "git log --oneline -1 origin/work/241-c4 ...", "multi-line should show first line + ' ...': " .. result)
+  assert(result == cmd, "multi-line command should be unchanged: " .. result)
 end
 test_display_command_multi_line()
 
 local function test_display_command_three_lines()
   local cmd = "line one\nline two\nline three"
   local result = loop.display_command(cmd)
-  assert(result == "line one ...", "should collapse to first line + ' ...': " .. result)
+  assert(result == cmd, "three-line command should be unchanged: " .. result)
 end
 test_display_command_three_lines()
 
@@ -442,40 +442,27 @@ test_display_command_empty()
 local function test_display_command_trailing_newline()
   local cmd = "echo hello\n"
   local result = loop.display_command(cmd)
-  -- Single content line with trailing newline counts as multi-line
-  assert(result == "echo hello ...", "trailing newline should trigger suffix: " .. result)
+  assert(result == cmd, "trailing newline should be preserved: " .. result)
 end
 test_display_command_trailing_newline()
 
 -- Tests for wrap_command with multi-line input
-local function test_wrap_command_multiline_no_garbling()
+local function test_wrap_command_multiline_preserves_content()
   local cmd = "git log --oneline -1 origin/work/241-c4abc\ngit diff HEAD~1 --stat"
   local result = loop.wrap_command(cmd, 80, "    ")
-  -- Should not contain raw newlines from the original (i.e. multi-line garbling)
-  -- The result may contain backslash-continuation newlines but not bare content newlines
-  local lines_with_content: {string} = {}
-  for line in result:gmatch("[^\n]+") do
-    table.insert(lines_with_content, line)
-  end
-  -- Each line should either end with " \" (continuation) or be the last line
-  for i, line in ipairs(lines_with_content) do
-    if i < #lines_with_content then
-      assert(line:sub(-2) == " \\", "continuation line should end with ' \\': " .. line)
-    end
-  end
-  -- Should not contain "git diff HEAD~1" from the second original line
-  assert(not result:find("git diff HEAD", 1, true), "second line content should not appear: " .. result)
+  -- Both commands should appear in the output
+  assert(result:find("git log", 1, true), "first command should appear: " .. result)
+  assert(result:find("git diff HEAD", 1, true), "second command should appear: " .. result)
 end
-test_wrap_command_multiline_no_garbling()
+test_wrap_command_multiline_preserves_content()
 
-local function test_wrap_command_multiline_shows_first_line()
+local function test_wrap_command_multiline_shows_all_lines()
   local cmd = "gh issue list --repo whilp/ah\n--label todo --state open"
   local result = loop.wrap_command(cmd, 80, "    ")
-  -- First line content should appear
+  -- All content should appear
   assert(result:find("gh issue list", 1, true), "first line tokens should appear: " .. result)
-  -- Second original line should not appear
-  assert(not result:find("--label todo", 1, true), "second line content should not appear: " .. result)
+  assert(result:find("--label todo", 1, true), "second line content should appear: " .. result)
 end
-test_wrap_command_multiline_shows_first_line()
+test_wrap_command_multiline_shows_all_lines()
 
 print("all display_command tests passed")

--- a/lib/ah/loop/test_looputil.tl
+++ b/lib/ah/loop/test_looputil.tl
@@ -56,8 +56,8 @@ test_display_command_single_line()
 local function test_display_command_multi_line()
   local cmd = "git log --oneline\ngit diff HEAD~1"
   local result = looputil.display_command(cmd)
-  assert(result == "git log --oneline ...", "should collapse to first line + ' ...': " .. result)
-  print("PASS: display_command multi-line collapses")
+  assert(result == cmd, "multi-line command should be unchanged: " .. result)
+  print("PASS: display_command multi-line unchanged")
 end
 test_display_command_multi_line()
 
@@ -80,8 +80,8 @@ test_display_command_ampersand()
 local function test_display_command_backslash_continuation()
   local cmd = "gh pr create \\\n  --title 'fix' \\\n  --body 'desc'"
   local result = looputil.display_command(cmd)
-  assert(result == "gh pr create ...", "should truncate at \\ continuation: " .. result)
-  print("PASS: display_command truncates at \\ continuation")
+  assert(result == cmd, "backslash continuation should be unchanged: " .. result)
+  print("PASS: display_command preserves backslash continuation")
 end
 test_display_command_backslash_continuation()
 

--- a/lib/ah/loop/util.tl
+++ b/lib/ah/loop/util.tl
@@ -80,21 +80,8 @@ local function tool_key_param(tool_name: string, tool_input: string, details_jso
 end
 
 -- Normalize a potentially multi-line command for display.
--- If the command has multiple lines, returns the first line with " ..." appended.
--- Also truncates at " \<newline>" continuations.
--- Single-line commands are returned unchanged.
+-- Returns the command unchanged (no truncation).
 local function display_command(cmd: string): string
-  if not cmd or cmd == "" then return cmd end
-  -- Handle \ continuations: " \<newline>" or " \<newline><whitespace>"
-  local first_cont = cmd:match("^(.-) \\%s*\n")
-  if first_cont then
-    return first_cont .. " ..."
-  end
-  -- Handle newlines
-  local first_nl = cmd:match("^([^\n]+)\n")
-  if first_nl then
-    return first_nl .. " ..."
-  end
   return cmd
 end
 


### PR DESCRIPTION
## Summary
This PR removes the multi-line command truncation logic from the `display_command` function, changing it to return commands unchanged instead of appending " ..." to the first line of multi-line commands.

## Key Changes
- **lib/ah/loop/util.tl**: Simplified `display_command()` to return the command as-is without any truncation or line-breaking logic. Removed handling for:
  - Backslash continuation sequences (`\<newline>`)
  - Newline-separated commands
  - The " ..." suffix appending

- **lib/ah/loop/test_loop.tl**: Updated all `display_command` tests to expect the full command unchanged:
  - `test_display_command_multi_line()`: Now expects full multi-line command
  - `test_display_command_three_lines()`: Now expects full three-line command
  - `test_display_command_trailing_newline()`: Now expects trailing newline preserved

- **lib/ah/loop/test_loop.tl**: Updated `wrap_command` tests to reflect new behavior:
  - `test_wrap_command_multiline_preserves_content()`: Changed to verify both commands appear in output (previously checked that second line was excluded)
  - `test_wrap_command_multiline_shows_all_lines()`: Changed to verify all content appears (previously checked that second line was excluded)

- **lib/ah/loop/test_looputil.tl**: Updated corresponding tests in the util test file to expect unchanged commands

## Implementation Details
The `display_command` function now has a single responsibility: return the input command unchanged. All truncation and formatting logic has been removed, simplifying the function to a single return statement. This change suggests that command wrapping/formatting is now handled elsewhere (likely in `wrap_command`), allowing `display_command` to preserve the full command for display purposes.

https://claude.ai/code/session_01A8eugvMmoLo3V9NoBfDeqs