### PR TITLE
Update cosmic-lua dependency to 2026-03-24-f2f562b

### DIFF
--- a/deps/cosmic.mk
+++ b/deps/cosmic.mk
@@ -1,4 +1,4 @@
-cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-03-15-6fd4272/cosmic-lua
-cosmic_sha := c5cce7df2c79632664d3438005b765d49d01ffc7570ebf099b563b9e2fdcd3a1
-cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/2026-03-15-6fd4272/cosmic-lua-debug
-cosmic_debug_sha := a5d448a06ffc4088ca9b3215b701bfd534de5883e41d80f8808f57558ed90109
+cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-03-24-f2f562b/cosmic-lua
+cosmic_sha := 93c72ac14400962659e29ff384d81e9696e4c532de69cc72cd8846e7172b9d06
+cosmic_debug_url := https://github.com/whilp/cosmic/releases/download/2026-03-24-f2f562b/cosmic-lua-debug
+cosmic_debug_sha := fbde546a1674df563fcfef70d67ba858c59dcd5f701d65a8aed94adf2ab8f4d7


### PR DESCRIPTION
## Summary
Updates the cosmic-lua dependency to a newer release version.

## Changes
- Updated cosmic-lua release from `2026-03-15-6fd4272` to `2026-03-24-f2f562b`
- Updated cosmic-lua binary SHA256 checksum
- Updated cosmic-lua-debug binary SHA256 checksum

## Details
This updates both the standard and debug variants of the cosmic-lua binary to the latest available release, ensuring the project uses the most recent version of this dependency.

https://claude.ai/code/session_014GsaugFq3ak8jRN7s9QZAs